### PR TITLE
manage_heartbeat_task writes without confirmation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ Full reference: **[docs/architecture/HEARTBEAT.md](docs/architecture/HEARTBEAT.m
 3. The agent works the due tasks (notes in `heartbeat/*.md`), ends the tick with a `heartbeat_respond(acted_tasks, notify, summary, notification_text, ...)` ack, and still replies `[NO_ACTION]`/message text (fallback delivery path only). Delivery keys off the ack and goes through the gateway Outbox (`default_outbox().notify_owner(..., event="heartbeat")` — send + log-on-success); stamping runs **after** delivery settles — only acted tasks advance `state.json`, and a failed send skips stamping so the tasks re-run next tick
 4. Writes a unified daily log: `daily/daily_YYYY-MM-DD.md` covering both heartbeat activity and today's user conversations (via `get_chat_history(since=...)`)
 
-Task authoring goes through `manage_heartbeat_task` (validated, confirmation-gated; heartbeat turns may not `create`). The agent's notes files still carry a transitional `last_run:` line in parallel with `state.json` until the two have agreed in production.
+Task authoring goes through `manage_heartbeat_task` (validated before write, no confirmation; heartbeat turns may not `create`). The agent's notes files still carry a transitional `last_run:` line in parallel with `state.json` until the two have agreed in production.
 
 The heartbeat and user agents share SOUL.md/AGENTS.md/USER.md and the same tool registry, but the prompt **differs by scope**: heartbeat gets the terse framing + `heartbeat.md` + `[NO_ACTION]` contract + today's chat; user gets conversational framing + today's daily log + today's heartbeat notifications. Awareness now flows both ways via live log injection (chat history into heartbeat, notifications into user); the daily log remains as a richer per-day narrative.
 
@@ -204,7 +204,7 @@ fake the service state.
 | Add a slash command | Add an `async def` handler in `gateway/commands/handlers.py` decorated with `@command(name, description)`. The router auto-discovers it; `/help` and each channel's command-menu (e.g. Telegram autocomplete via `register_command_menu()`) pick it up next start. Handlers receive `(InboundMessage, args: list[str])` and return reply text — they may import `agent`/`tools` but **not** any concrete channel. See docs/architecture/GATEWAY.md (Plane 1 — Slash-Command Dispatch). |
 | Change Jarvis's personality | Edit `/app/jarvis_memory/SOUL.md` directly |
 | Change behavioral rules | `/app/jarvis_code/prompts/AGENTS.md` (always-on) or `prompts/heartbeat.md` (heartbeat-scope only); a skill's own rules go in `tools/<ns>/SKILL.md`. Tool usage is driven by tool docstrings, not prompt prose. |
-| Add a heartbeat task | Ask Jarvis (it uses `manage_heartbeat_task`, confirmation-gated), or hand-edit `/app/jarvis_memory/HEARTBEAT.md` following the grammar in docs/architecture/HEARTBEAT.md (a malformed hand edit degrades to always-due, never a silent drop) |
+| Add a heartbeat task | Ask Jarvis (it uses `manage_heartbeat_task`, validated before write), or hand-edit `/app/jarvis_memory/HEARTBEAT.md` following the grammar in docs/architecture/HEARTBEAT.md (a malformed hand edit degrades to always-due, never a silent drop) |
 | Understand the memory layout | `/app/jarvis_memory/MEMORY.md` |
 | Full architecture reference | `docs/architecture/{GATEWAY,MEMORY,RUNTIME,HEARTBEAT,OBSERVABILITY}.md` |
 | Add per-turn telemetry / read usage | `observability/{telemetry,usage}.py` + `scripts/trace.py` (see [docs/architecture/OBSERVABILITY.md](docs/architecture/OBSERVABILITY.md)) |

--- a/docs/architecture/HEARTBEAT.md
+++ b/docs/architecture/HEARTBEAT.md
@@ -124,18 +124,24 @@ picked up). Missing ack → warning, no stamp, task re-fires — safe.
 ## Authoring (`manage_heartbeat_task`)
 
 `create` / `update` / `delete` / `list` in `tools/core/heartbeat.py`, bound in
-both scopes. Validates the mutated file end-to-end before proposing it (the
+both scopes. Validates the mutated file end-to-end before writing it (the
 changed task must round-trip through the same parser the gate uses; all other
-tasks must survive byte-identical), then routes through the standard gateway
-confirmation (see [GATEWAY.md](GATEWAY.md) Plane 3) and writes via the memory
-module's atomic, lock-serialized writer. `update` keeps unspecified fields;
-`due="none"` clears a window.
+tasks must survive byte-identical), then writes via the memory module's atomic,
+lock-serialized writer. `update` keeps unspecified fields; `due="none"` clears
+a window.
+
+Changes land immediately — no confirmation step. HEARTBEAT.md is a
+Jarvis-managed file, and validation (not an owner tap) is what protects it: a
+malformed task is rejected before anything touches disk. The tool returns the
+resulting task block so the agent reports what actually landed. This also makes
+the autonomous path work: a tick tightening its own due window would otherwise
+depend on a confirmation nobody is watching for.
 
 Guards:
 - **Heartbeat turns cannot `create`** (update/delete/list only) — a tick must
   not be able to schedule new work for itself; new tasks originate from chat,
-  where the confirmation tap has a human actively watching. The tool learns
-  the running scope from `turn_context.CURRENT_SCOPE` (a ContextVar set by
+  where the owner is in the loop conversationally. The tool learns the
+  running scope from `turn_context.CURRENT_SCOPE` (a ContextVar set by
   `ask_jarvis`; never from model-supplied arguments), defaulting to `user`
   outside a turn.
 - Raw `write_memory("HEARTBEAT.md", …)` is rejected in code — the guard

--- a/docs/architecture/MEMORY.md
+++ b/docs/architecture/MEMORY.md
@@ -99,7 +99,7 @@ Deletion is blocked for files the system needs to exist; `SOUL.md` additionally 
 | `prompts/heartbeat.md` | **jarvis_code/prompts** | heartbeat scope only | **no** | **no** (deploy only) | n/a |
 | `MEMORY.md` | jarvis_memory | **no** — read on demand via tools | yes | yes | no (delete blocked) |
 | `daily/<today>` | jarvis_memory | user scope (heartbeat: yesterday's) | yes | yes (heartbeat writes) | no |
-| `HEARTBEAT.md` | jarvis_memory | heartbeat scope only — **due task blocks only** (non-due collapse to a note; see [HEARTBEAT.md doc](HEARTBEAT.md)) | yes | task edits via `manage_heartbeat_task` (validated + confirmation); raw `write_memory` rejected in code | create/update/delete confirm (delete of file blocked) |
+| `HEARTBEAT.md` | jarvis_memory | heartbeat scope only — **due task blocks only** (non-due collapse to a note; see [HEARTBEAT.md doc](HEARTBEAT.md)) | yes | task edits via `manage_heartbeat_task` (validated before write); raw `write_memory` rejected in code | no (delete of file blocked) |
 | `chat_history.jsonl` | jarvis_data/logs | heartbeat scope — today's slice | via `get_chat_history` tool | append-only (gateway writes per turn) | n/a |
 | `notifications.jsonl` | jarvis_data/logs | user scope — today's `event="heartbeat"` slice | via `get_notification_history` tool | append-only (heartbeat + gateway writers) | n/a |
 

--- a/prompts/AGENTS.md
+++ b/prompts/AGENTS.md
@@ -10,7 +10,7 @@ You run autonomously on a 1-hour heartbeat. Use the reminder tool to create/list
 
 Heartbeat task authoring:
 - Recognize recurring or conditional proactive wishes as heartbeat tasks: "check in after my workouts", "nudge me if I skip a run", "every Sunday summarize my week". Rule of thumb: recurring / conditional / state-dependent → manage_heartbeat_task; a single fixed moment ("remind me at 15:00 to call the dentist") → manage_reminder.
-- Author tasks ONLY through manage_heartbeat_task — never edit HEARTBEAT.md with write_memory. Translate the wish into (name, cadence, due window, instruction); the tool validates and asks Roi to confirm before anything lands. Keep the due window as tight as you can justify — it controls when the system wakes for the task.
+- Author tasks ONLY through manage_heartbeat_task — never edit HEARTBEAT.md with write_memory. Translate the wish into (name, cadence, due window, instruction); the tool validates before anything lands, and changes take effect immediately. Keep the due window as tight as you can justify — it controls when the system wakes for the task.
 - When a task's timing becomes predictable (e.g. you learn the booked class time), tighten its due window with manage_heartbeat_task(action='update').
 
 Memory architecture:

--- a/tools/core/heartbeat.py
+++ b/tools/core/heartbeat.py
@@ -7,28 +7,29 @@ text. Bound only in heartbeat scope — a user turn has no tick to
 acknowledge.
 
 ``manage_heartbeat_task`` is the validated write path for the task list in
-HEARTBEAT.md: it parses, mutates one task block, re-validates the whole
-candidate before anything touches disk, and gates every change behind an
-owner confirmation tap. The read side (heartbeat_state.parse_tasks) stays
-lenient; this write side fails loud — a malformed task must be rejected at
-authoring time, never silently dropped by the gate later.
+HEARTBEAT.md: it parses, mutates one task block, and re-validates the whole
+candidate before anything touches disk. The read side
+(heartbeat_state.parse_tasks) stays lenient; this write side fails loud — a
+malformed task must be rejected at authoring time, never silently dropped by
+the gate later.
 """
 
 from __future__ import annotations
 
-import asyncio
 import re
 
 from langchain_core.tools import tool
 
 import heartbeat_state
 import turn_context
+from tools.core.memory import _exec_write_memory
 from tools.registry import tool_register
 
 _NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 _CADENCE_INPUT_RE = re.compile(
     r"^(?:every\s+)?(?P<n>\d+)\s*(?P<unit>hours?|days?|h|d)$", re.IGNORECASE
 )
+_NOTES_RE = re.compile(r"notes:\s*`([^`]+)`")
 
 
 def _normalize_cadence(cadence: str) -> str | None:
@@ -44,12 +45,31 @@ def _normalize_cadence(cadence: str) -> str | None:
     return f"every {n}{unit}"
 
 
-def _build_block(name: str, cadence: str, due: str, instruction: str) -> list[str]:
-    """A canonical task block: header line + two-space-indented body."""
+def _default_notes(name: str) -> str:
+    """The notes path a brand-new task gets: kebab name → snake filename."""
+    return f"heartbeat/{name.replace('-', '_')}.md"
+
+
+def _notes_of(header: str) -> str | None:
+    """The notes path declared on an existing header line, or None."""
+    m = _NOTES_RE.search(header)
+    return m.group(1) if m else None
+
+
+def _build_block(
+    name: str, cadence: str, due: str, instruction: str, notes: str
+) -> list[str]:
+    """A canonical task block: header line + two-space-indented body.
+
+    ``notes`` is explicit rather than derived from ``name``: an existing
+    task's notes file is frequently named by hand and does not match the
+    derived form, and rebuilding its block must carry the declared path over
+    or the task silently loses the narrative state it has accumulated.
+    """
     fields = [f"- **{name}**", cadence]
     if due:
         fields.append(f"due: {due}")
-    fields.append(f"notes: `heartbeat/{name.replace('-', '_')}.md`")
+    fields.append(f"notes: `{notes}`")
     block = [" | ".join(fields)]
     block += [f"  {line}".rstrip() for line in instruction.strip().splitlines()]
     return block
@@ -100,7 +120,7 @@ def heartbeat_respond(
     return payload
 
 
-@tool_register(namespace="core", destructive=True)
+@tool_register(namespace="core")
 @tool
 def manage_heartbeat_task(
     action: str,
@@ -116,10 +136,11 @@ def manage_heartbeat_task(
     workouts", "every Sunday summarize my week"). For a one-shot ping at a
     fixed moment ("remind me at 15:00 to call") use manage_reminder instead.
 
-    Every create/update/delete shows Roi a confirmation with the exact
-    change and only lands after he approves. Invalid input (bad cadence,
-    bad due window, duplicate/unknown name) is rejected with the reason and
-    the file stays untouched.
+    Changes land immediately. Invalid input (bad cadence, bad due window,
+    duplicate/unknown name) is rejected with the reason and the file stays
+    untouched. On success the resulting task block is returned — report back
+    what actually landed rather than restating what you asked for, since an
+    update keeps the fields you left empty.
 
     Args:
         action: "create" | "update" | "delete" | "list".
@@ -175,12 +196,10 @@ def manage_heartbeat_task(
         removed = next(b for n, b in blocks if n == name)
         new_blocks = [(n, b) for n, b in blocks if n != name]
         new_text = _render(preamble, new_blocks)
-        description = (
-            f"Delete heartbeat task '{name}':\n\n" + "\n".join(removed)
+        ok_text = (
+            f"Heartbeat task '{name}' deleted:\n\n" + "\n".join(removed)
             + "\n\n(Its notes file in heartbeat/ is kept and can be cleaned up separately.)"
         )
-        ok_text = f"Heartbeat task '{name}' deleted."
-        cancel_text = f"Deletion cancelled — '{name}' unchanged."
     else:
         if action == "create":
             if name in existing:
@@ -194,6 +213,7 @@ def manage_heartbeat_task(
                     "Use forms like '1h', '24h', '7d'."
                 )
             new_due = due.strip()
+            notes = _default_notes(name)
         else:  # update
             if name not in existing:
                 return f"Error: no task named '{name}' in HEARTBEAT.md."
@@ -201,6 +221,7 @@ def manage_heartbeat_task(
                 t for t in heartbeat_state.parse_tasks_text(current_text) if t.name == name
             )
             prior_block = next(b for n, b in blocks if n == name)
+            notes = _notes_of(prior_block[0]) or _default_notes(name)
             if cadence.strip():
                 norm_cadence = _normalize_cadence(cadence)
                 if norm_cadence is None:
@@ -238,18 +259,17 @@ def manage_heartbeat_task(
                 "'06:00-22:00', 'Tue,Sat 20:30±3h', '09:00±2h' (or 'none' to clear)."
             )
 
-        new_block = _build_block(name, norm_cadence, new_due, instruction)
+        new_block = _build_block(name, norm_cadence, new_due, instruction, notes)
         if action == "create":
             new_blocks = blocks + [(name, new_block)]
         else:
             new_blocks = [(n, b if n != name else new_block) for n, b in blocks]
         new_text = _render(preamble, new_blocks)
-        description = (
-            f"{'Create' if action == 'create' else 'Update'} heartbeat task "
-            f"'{name}':\n\n" + "\n".join(new_block)
+        ok_text = (
+            f"Heartbeat task '{name}' "
+            f"{'created' if action == 'create' else 'updated'}:\n\n"
+            + "\n".join(new_block)
         )
-        ok_text = f"Heartbeat task '{name}' {'created' if action == 'create' else 'updated'}."
-        cancel_text = f"{action.capitalize()} cancelled — HEARTBEAT.md unchanged."
 
     # Validate the full candidate exactly as the gate will read it: the
     # mutated task must round-trip with a parseable cadence (+ window when
@@ -268,18 +288,9 @@ def manage_heartbeat_task(
     if set(parsed) != expected_names:
         return "Error: internal validation failed — other tasks would be disturbed."
 
-    from gateway.factory import get_confirmation
-    from tools.core.memory import _exec_write_memory
-
-    async def _do_write() -> str:
-        return await asyncio.to_thread(_exec_write_memory, "HEARTBEAT.md", new_text)
-
-    try:
-        return get_confirmation().request_confirmation_sync(
-            description=description,
-            action_fn=_do_write,
-            result_ok_text=ok_text,
-            result_cancel_text=cancel_text,
-        )
-    except Exception as e:
-        return f"Error requesting confirmation: {e}"
+    # _exec_write_memory reports failure in its return string rather than
+    # raising, so a failed write must be caught by inspecting the result.
+    result = _exec_write_memory("HEARTBEAT.md", new_text)
+    if not result.startswith("Successfully"):
+        return f"Error: HEARTBEAT.md was not modified — {result}"
+    return ok_text

--- a/tools/core/memory.py
+++ b/tools/core/memory.py
@@ -162,7 +162,7 @@ def write_memory(filename: str, content: str) -> str:
         return (
             "Error: HEARTBEAT.md is managed through manage_heartbeat_task — "
             "use it to create, update or delete heartbeat tasks (validated "
-            "and owner-confirmed). Direct writes are not allowed."
+            "before write). Direct writes are not allowed."
         )
     if filename == "SOUL.md":
         from gateway.factory import get_confirmation


### PR DESCRIPTION
Closes #30. Partial #28.

## What

`manage_heartbeat_task` no longer routes `create`/`update`/`delete` through the gateway confirmation — changes land immediately once validated. HEARTBEAT.md is a Jarvis-managed file, and the validation (round-trip re-parse of the whole candidate, all other tasks byte-identical) is what protects it, not an owner tap. Confirmation removal is uniform across all three actions, including `delete`.

`destructive=True` is dropped so the metadata stops advertising a gate that no longer exists — and so registry-enforced confirmation (#13) can't silently re-introduce the prompt later. `is_destructive` only feeds telemetry, so the sole effect is that `tool_calls.jsonl` correctly stops labelling this tool destructive.

## The bug this uncovered

`_build_block` *derived* the `notes:` path from the task name (`crossfit-sync-and-remind` → `crossfit_sync_and_remind.md`), but 6 of the 8 live tasks declare hand-chosen paths (`crossfit_check.md`). Any `update` silently repointed the task at a file that never existed, orphaning its accumulated narrative state.

Pre-existing, and it had never fired — but only by luck: every `manage_heartbeat_task` call ever logged was an update to `haircut-reminder`, one of the two tasks whose name happens to derive to its own notes path.

It matters here because **the confirmation card was an accidental guard**: it rendered the rewritten block, so the drift was visible and cancellable. Removing the card without fixing this would have made it silent — and the first thing to trigger it would likely be a heartbeat tick tightening its own due window, exactly the autonomous behaviour the design wants.

`_build_block` now takes `notes` explicitly (required, so no caller can fall back to derivation by accident): `create` derives, `update` carries the declared path over via `HeartbeatTask.raw`, and a header with no `notes:` field falls back to the derived default.

## #28 down-payment

Of the two adjacent function-local imports, `get_confirmation` (genuinely cycle-breaking) is deleted outright with the confirmation call, and `_exec_write_memory` — the "copy-pasted caution" #28 cites by name — is hoisted to module top-level. `tools.core.memory` has no top-level dependency on `gateway`/`agent`, so there was never a cycle. This leaves `tools/core/` a single-call-site consumer of the gateway, which is the shape #28's preferred option wants.

## Verification

Three offline suites, all green, driving the real tool in a scratch memory dir with `get_confirmation` patched to raise:

- **Behaviour (21 checks):** create/update/delete land immediately; validation still rejects (bad cadence, bad window, duplicate, unknown name) with the file untouched; heartbeat scope still can't `create` but now *can* `update` without a tap; write failures surface as errors; raw `write_memory("HEARTBEAT.md")` still rejected.
- **Real-file round-trip:** against a copy of the live HEARTBEAT.md — preamble and `## Active Tasks` heading preserved, untouched tasks byte-identical, non-canonical cadences (`every 1d`, `every 7 days`) not rewritten.
- **Notes fix:** all 8 live tasks preserve their notes path across an update, including the 6 at-risk ones. Negative control (forcing the old derive path) corrupts exactly those 6 and spares the 2 name-matching ones — confirming the test detects the bug.

**Live, post-restart:** clean boot, `[tool-registry] registered 12 core tools, 52 skill tools across 8 namespaces` matching offline parity (proves the hoisted import created no cycle). A create+delete round-trip completed **in a single turn, 1.2ms apart**, both `status: ok`, `destructive: False`, zero confirmation activity in the journal — structurally impossible under the old code, where the create would have blocked on a tap.

**Not live-tested:** the notes fix end-to-end on a real mismatched task — that needs a manufactured setup (create, then hand-edit the notes path). The logic is deterministic and LLM-independent, and the deployed file predates the service start, so the running process has it.

## Docs

Stale confirmation claims cleared from the live prompt surfaces (tool docstring, `prompts/AGENTS.md`), `write_memory`'s rejection text, CLAUDE.md, and the architecture docs. The "heartbeat ticks cannot `create`" guard **stays**, but its stated rationale had leaned on the confirmation tap having a human watching — reworded, since that reason no longer exists while the guard is still wanted.