### PR TITLE
docs: development moves to the staging tree; prod is deploy-only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,23 +175,30 @@ Used for irreversible actions (delete memory, write SOUL.md, delete media with f
 
 ## Deployment
 
-Service: `jarvis.service`, running on the host.
+Two instances on one host, each rooted by its systemd unit's `JARVIS_ROOT`. Full
+runbook: **[docs/DEPLOY.md](docs/DEPLOY.md)**; rationale in
+**[docs/plans/STAGING_AND_DEPLOY.md](docs/plans/STAGING_AND_DEPLOY.md)**.
 
-**This Claude Code session runs on the same host** as the code and the running
-service, so commands run directly against it.
+- **Prod** — `/app/jarvis_code`, `jarvis.service`, `JARVIS_ROOT=/app`. **Deploy-only:**
+  updated exclusively by `deploy/deploy.sh` (pull `origin/main` → snapshot → tag → smoke
+  check → hand off), never edited in place.
+- **Staging** — `/app/jarvis_staging/code`, `jarvis-staging.service` (on demand, not
+  enabled), `JARVIS_ROOT=/app/jarvis_staging`. Where development and behavior testing
+  happen; inert by default. **New sessions start here** (see DEVELOPMENT.md § Development
+  Workflow).
+
+**This Claude Code session runs on the same host.** Development edits go in the staging
+tree; prod changes only through `deploy/deploy.sh` + a restart.
 
 ```bash
-# View logs
-journalctl -u jarvis -f
-
-# Restart after code changes — the USER runs this, not Claude
-systemctl restart jarvis.service
+journalctl -u jarvis -f            # prod logs
+journalctl -u jarvis-staging -f    # staging logs
 ```
 
-Claude cannot restart `jarvis.service` (no permission, and restarting would kill
-this very session's environment). After any code change, ask the user to run the
-restart, then check logs and send a Telegram message to verify. Never infer or
-fake the service state.
+Claude **cannot restart** either service (no permission) and does not run `deploy.sh`'s
+restart. After a change, ask the user to restart, then verify: read the `Running code:`
+provenance block (`scripts/jrestart.sh` prints it), check logs, and send a Telegram
+message. Never infer or fake service state.
 
 ---
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -149,26 +149,43 @@ live in the private deployment config, not in this repo.
 
 ## Development Workflow
 
-1. **Edit** code at `/app/jarvis_code` inside LXC 106 (directly or synced from the host).
-2. **Test locally without Telegram** — the agent has a built-in REPL:
+Development happens in the **staging tree**, never in prod. Prod (`/app/jarvis_code`)
+is **deploy-only** — touched exclusively by `deploy/deploy.sh`. The full tooling is in
+[docs/DEPLOY.md](docs/DEPLOY.md); the two-instance layout and rationale in
+[docs/plans/STAGING_AND_DEPLOY.md](docs/plans/STAGING_AND_DEPLOY.md).
+
+1. **Edit** in `/app/jarvis_staging/code` on a feature branch off `main`:
    ```bash
-   cd /app/jarvis_code && source venv/bin/activate && python3 agent.py
+   cd /app/jarvis_staging/code
+   git fetch origin && git checkout -b feat/my-change origin/main
    ```
-   Drops into an interactive loop on thread_id `local_dev_test_01` (isolated from
-   the live `telegram_<user_id>` / `heartbeat` threads).
-3. **Deploy** — restart the service, then watch logs:
+2. **Test against the staging bot** (its own root, inert by default):
    ```bash
+   pct exec 106 -- systemctl start jarvis-staging.service   # on demand; not enabled
+   # chat with the STAGING bot in Telegram. Add a JARVIS_*_ENABLED=true line to
+   # deploy/jarvis-staging.service only for a run that deliberately exercises
+   # heartbeat / reminders / webhook.
+   pct exec 106 -- systemctl stop jarvis-staging.service
+   ```
+   Type-checking doesn't catch LLM-behavior regressions — talk to the staging bot.
+3. **Ship** — push the branch, open a PR to `main` (CI runs `path-isolation`), merge:
+   ```bash
+   git push origin feat/my-change
+   gh pr create --base main --fill          # merge once CI is green
+   ```
+4. **Deploy** — in the prod checkout, pull the merge and hand off the restart:
+   ```bash
+   cd /app/jarvis_code && ./deploy/deploy.sh     # never restarts; fails closed
    pct exec 106 -- systemctl restart jarvis.service
    pct exec 106 -- journalctl -u jarvis.service -f
    ```
-   Type-checking and the REPL don't catch LLM-behavior regressions — after any
-   change, send a real Telegram message to verify.
-4. **New Python deps** — install then re-freeze so the env stays reproducible:
+   Roll back a bad deploy with `deploy/rollback.sh <tag>` (see docs/DEPLOY.md).
+5. **New Python deps** — install in the staging venv and re-freeze; `deploy.sh`
+   re-installs in prod automatically when `requirements.txt` changes:
    ```bash
-   pct exec 106 -- bash -c 'source /app/jarvis_code/venv/bin/activate && pip install <pkg>'
-   pct exec 106 -- bash -c 'source /app/jarvis_code/venv/bin/activate && pip freeze > /app/jarvis_code/requirements.txt'
+   /app/jarvis_staging/code/venv/bin/pip install <pkg>
+   /app/jarvis_staging/code/venv/bin/pip freeze > /app/jarvis_staging/code/requirements.txt
    ```
-   Rebuild from scratch: `pip install -r requirements.txt`.
 
 > Adding a tool/skill/channel is an architecture concern, not an ops one — see
 > [CLAUDE.md](CLAUDE.md) "Key Files to Know" and


### PR DESCRIPTION
Updates `CLAUDE.md` § Deployment and `DEVELOPMENT.md` § Development Workflow for the two-instance model established in slices 2–4a:

- Edit in `/app/jarvis_staging/code` on a branch off `main`.
- Test against the staging bot (own root, inert by default).
- PR to `main` (CI runs `path-isolation`), merge, then `deploy/deploy.sh` in prod + restart.
- Roll back with `deploy/rollback.sh`.

Also drops the reference to the local REPL that was deleted in slice 2e. First change shipped through the new dev→deploy loop.