### PR TITLE
docs: archive completed staging plan; add jrestart-staging.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,7 @@ Used for irreversible actions (delete memory, write SOUL.md, delete media with f
 
 Two instances on one host, each rooted by its systemd unit's `JARVIS_ROOT`. Full
 runbook: **[docs/DEPLOY.md](docs/DEPLOY.md)**; rationale in
-**[docs/plans/STAGING_AND_DEPLOY.md](docs/plans/STAGING_AND_DEPLOY.md)**.
+**[docs/plans/archive/STAGING_AND_DEPLOY.md](docs/plans/archive/STAGING_AND_DEPLOY.md)**.
 
 - **Prod** — `/app/jarvis_code`, `jarvis.service`, `JARVIS_ROOT=/app`. **Deploy-only:**
   updated exclusively by `deploy/deploy.sh` (pull `origin/main` → snapshot → tag → smoke

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -152,7 +152,7 @@ live in the private deployment config, not in this repo.
 Development happens in the **staging tree**, never in prod. Prod (`/app/jarvis_code`)
 is **deploy-only** — touched exclusively by `deploy/deploy.sh`. The full tooling is in
 [docs/DEPLOY.md](docs/DEPLOY.md); the two-instance layout and rationale in
-[docs/plans/STAGING_AND_DEPLOY.md](docs/plans/STAGING_AND_DEPLOY.md).
+[docs/plans/archive/STAGING_AND_DEPLOY.md](docs/plans/archive/STAGING_AND_DEPLOY.md).
 
 1. **Edit** in `/app/jarvis_staging/code` on a feature branch off `main`:
    ```bash
@@ -161,11 +161,12 @@ is **deploy-only** — touched exclusively by `deploy/deploy.sh`. The full tooli
    ```
 2. **Test against the staging bot** (its own root, inert by default):
    ```bash
-   pct exec 106 -- systemctl start jarvis-staging.service   # on demand; not enabled
-   # chat with the STAGING bot in Telegram. Add a JARVIS_*_ENABLED=true line to
+   pct exec 106 -- /app/jarvis_staging/code/scripts/jrestart-staging.sh   # start + show boot block
+   # Read `root : /app/jarvis_staging` in the printed block, then chat with the
+   # STAGING bot in Telegram. Add a JARVIS_*_ENABLED=true line to
    # deploy/jarvis-staging.service only for a run that deliberately exercises
    # heartbeat / reminders / webhook.
-   pct exec 106 -- systemctl stop jarvis-staging.service
+   pct exec 106 -- systemctl stop jarvis-staging.service                  # inert again when done
    ```
    Type-checking doesn't catch LLM-behavior regressions — talk to the staging bot.
 3. **Ship** — push the branch, open a PR to `main` (CI runs `path-isolation`), merge:

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,7 +1,7 @@
 # Deploy & operations runbook
 
 How to run the operator tooling for the two Jarvis instances. Design rationale lives
-in [plans/STAGING_AND_DEPLOY.md](plans/STAGING_AND_DEPLOY.md); this is the how‑to.
+in [plans/archive/STAGING_AND_DEPLOY.md](plans/archive/STAGING_AND_DEPLOY.md); this is the how‑to.
 
 ## The two instances
 
@@ -149,11 +149,36 @@ venv/bin/python scripts/ci/check_paths.py    # exit 0 clean, 1 on a leak
 
 ---
 
-## `scripts/jrestart.sh` — restart prod and show what booted
+## `scripts/jrestart.sh` / `jrestart-staging.sh` — restart and show what booted
 
-Restarts `jarvis.service` and prints **this boot's** `Running code:` provenance block
-(branch, sha, deploy tag, root, proactive toggles) — so you immediately see what came
-up. Owner‑run (needs root).
+Restart one instance and print **that boot's** `Running code:` provenance block (branch,
+sha, deploy tag, `root :`, proactive toggles) — so you immediately see what came up.
+Owner‑run (needs root); run them from inside the container.
+
+```bash
+scripts/jrestart.sh            # prod    → jarvis.service
+scripts/jrestart-staging.sh    # staging → jarvis-staging.service (also cold-starts it)
+```
+
+Read the printed block first. For staging the `root : /app/jarvis_staging` row is the
+isolation check — it confirms you booted against the staging trees, not prod (this is
+what replaces the single-writer lock the design dropped).
+
+### Quick aliases (run from the PVE host root shell)
+
+Restarts and deploys need root, which you have on the Proxmox host. Drop these in
+`/root/.bashrc` so the whole flow is one word each — each wraps the in-container script
+with `pct exec 106`:
+
+```bash
+alias jrestart='pct exec 106 -- /app/jarvis_code/scripts/jrestart.sh'
+alias jrestart-staging='pct exec 106 -- /app/jarvis_staging/code/scripts/jrestart-staging.sh'
+alias jdeploy='pct exec 106 -- bash -lc "cd /app/jarvis_code && ./deploy/deploy.sh"'
+```
+
+`jdeploy` runs the fail‑closed `deploy.sh` (it never restarts); follow a green deploy
+with `jrestart` to bring the new code up. Keeping them two words is deliberate — a
+restart drops in‑flight turns, so it stays a conscious second step.
 
 ---
 

--- a/docs/plans/app-plans/03_APP_CHANNEL.md
+++ b/docs/plans/app-plans/03_APP_CHANNEL.md
@@ -3,7 +3,7 @@
 **Status:** planning, uncommitted. **Date:** 2026-07-20.
 **Parent:** [APP_CHANNEL_PLAN.md](APP_CHANNEL_PLAN.md).
 **Hard-depends on:** step 2 phases 1d (generic factory) + 2a (channel registry).
-**Soft-depends on:** the staging environment (`../STAGING_AND_DEPLOY.md`) — this is where the
+**Soft-depends on:** the staging environment (`../archive/STAGING_AND_DEPLOY.md`) — this is where the
 poll loop is developed and tested, so staging lands first.
 
 **Goal:** a new `gateway/channels/jarvis_app/` that carries a text turn end-to-end between the
@@ -30,7 +30,7 @@ step 2; this document is only the new package.
 (GATEWAY.md step 9) — the app channel must never disturb it.
 
 ### Prereqs (elsewhere, must be green first)
-- [ ] Staging exists (`../STAGING_AND_DEPLOY.md` slices 0–3)
+- [x] Staging exists (`../archive/STAGING_AND_DEPLOY.md` — complete 2026-07-23)
 - [ ] Step 2 phase 1d (generic factory) + 2a (channel registry) landed
 - [ ] Re-validate every agent-internal reference the old plan cites (step 2 delta table)
 - [ ] **Add `APP_HUB_URL`, `APP_HUB_BOT_TOKEN`, `APP_OWNER_USER_ID` to `staging.env`**

--- a/docs/plans/app-plans/APP_CHANNEL_PLAN.md
+++ b/docs/plans/app-plans/APP_CHANNEL_PLAN.md
@@ -11,16 +11,17 @@ of them start. Technical detail and findings live in the step documents.
 
 ## Steps
 
-| # | Step | Document | What it touches |
-|---|---|---|---|
-| 1 | Staging environment | [../STAGING_AND_DEPLOY.md](../STAGING_AND_DEPLOY.md) | `config.py`, `main.py`, path constants; a second service |
-| 2 | Multi-channel support | `02_MULTI_CHANNEL_SUPPORT.md` | **Existing** gateway/agent code — the owner-addressing seam |
-| 3 | Adding the new channel | `03_APP_CHANNEL.md` | **New** `gateway/channels/app/` |
+| # | Step | Status | Document | What it touches |
+|---|---|---|---|---|
+| 1 | Staging environment | ✅ **done 2026-07-23** | [../archive/STAGING_AND_DEPLOY.md](../archive/STAGING_AND_DEPLOY.md) | `config.py`, `main.py`, path constants; a second service |
+| 2 | Multi-channel support | planning | `02_MULTI_CHANNEL_SUPPORT.md` | **Existing** gateway/agent code — the owner-addressing seam |
+| 3 | Adding the new channel | planning | `03_APP_CHANNEL.md` | **New** `gateway/channels/app/` |
 
 Step 1 is **not owned by this plan.** Staging and deploy discipline are general infrastructure —
 the app channel is their first beneficiary, not their reason — so they live outside `app-plans/`
-and proceed on their own schedule. This plan consumes them as a dependency. Steps 2 and 3 are
-not written yet.
+and proceed on their own schedule. This plan consumed them as a dependency; **they are now
+complete and archived** (staging bot live, prod deploy-only via `deploy.sh`/`rollback.sh`). Steps
+2 and 3 are not written yet.
 
 **Dependencies.** 1 and 2 are independent and can proceed in either order — staging is about
 *where state lives*, step 2 is about *how the gateway addresses the owner*; they share no code.
@@ -88,12 +89,12 @@ useful — this table is how to read one in terms of the other.
 Track A's hub **exists and runs**, and per the app author B1, B1.5 and B3 are implementable now.
 What stands in the way:
 
-1. **Staging** — [../STAGING_AND_DEPLOY.md](../STAGING_AND_DEPLOY.md). The upstream plan
-   verifies every phase against the live agent (`original_app_plan.md` line 91). B3 is the phase
-   that starts pushing real heartbeat and reminder traffic to a new device. That plan's open
-   question 5 covers the hub-side consequence: the app channel is *outbound*, so it binds no
-   port and cannot collide the way the webhook does — but the hub is one-bot-one-user, so once
-   the channel is live in prod, a staging agent polling the same hub would fight over updates.
+1. ~~**Staging**~~ — ✅ **done** ([../archive/STAGING_AND_DEPLOY.md](../archive/STAGING_AND_DEPLOY.md), completed
+   2026-07-23). The staging bot is live against its own root, so every phase now verifies against
+   the live agent without touching prod state. One hub-side consequence still stands (that plan's
+   open question 5): the app channel is *outbound*, so it binds no port and cannot collide the way
+   the webhook does — but the hub is one-bot-one-user, so once the channel is live in prod, a
+   staging agent polling the same hub would fight over updates. Give staging its own hub bot token.
 2. **Three env vars** in `/app/secrets/.env` — `APP_HUB_URL`, `APP_HUB_BOT_TOKEN`,
    `APP_OWNER_USER_ID`. Owner-supplied.
 
@@ -122,11 +123,11 @@ behavior-only — plan context goes in commit messages. Nothing commits without 
 
 ## Open questions
 
-1. **Build order** — staging first, or start step 2 in parallel? Step 2 touches production
-   gateway code, which is an argument for staging existing first.
-2. **Does deploy discipline ride with staging?** The stale `feat/staging-env` plan bundled prod
-   pinning + `deploy.sh`/`rollback.sh` with the staging work. Lean: split — staging blocks the
-   app work, deploy discipline does not.
+1. ~~**Build order** — staging first, or start step 2 in parallel?~~ **Resolved:** staging landed
+   first (2026-07-23), so step 2 can now start against the staging bot with no risk to prod.
+2. ~~**Does deploy discipline ride with staging?**~~ **Resolved:** they shipped together but as
+   separate slices — `deploy.sh`/`rollback.sh` (slice 4a) landed alongside the staging bot (slice 3)
+   under one plan, now archived. The split the lean called for held: each reverts on its own.
 3. **How do upstream deltas get maintained?** The step documents will record where
    `original_app_plan.md` is stale against current code. Annotating a frozen spec has an ongoing
    cost; the alternative is asking the app author to reissue it against current code.

--- a/docs/plans/archive/STAGING_AND_DEPLOY.md
+++ b/docs/plans/archive/STAGING_AND_DEPLOY.md
@@ -1,6 +1,7 @@
 # Staging environment & deploy discipline
 
-**Status:** planning, uncommitted. **Date:** 2026-07-20.
+**Status:** ✅ **COMPLETE** — slices 0–4 landed and verified live 2026-07-23 (rollback rehearsed, both paths work); archived.
+**Date:** started 2026-07-20, completed 2026-07-23.
 **Supersedes:** `feat/staging-env` (e20a7a4, 2026-07-10) — stale, will not be merged. Much of the
 analysis below is imported from it; additions and corrections are marked **[new]**.
 **First beneficiary:** the app channel (`docs/plans/app-plans/APP_CHANNEL_PLAN.md`), but this is
@@ -40,7 +41,7 @@ because under `JARVIS_ROOT=/app` every derived path equals the literal it replac
 
 - [x] `bash deploy/backup_state.sh pre-slice2` → `/app/backups/state-pre-slice2-<ts>.tar.gz` of `/app/jarvis_memory` + `/app/jarvis_data` (see [Backup & rollback](#backup--rollback))
 - [x] Confirm the tarball lists SOUL/USER/MEMORY + `threads.sqlite` before proceeding
-- [ ] *Revert path for all of 2c–2d:* `git revert` the commit **and** `backup_state.sh --restore` if any write went to the wrong tree
+- [x] *Revert path for all of 2c–2d:* `git revert` the commit **and** `backup_state.sh --restore` if any write went to the wrong tree *(n/a — 2c/2d landed clean under `JARVIS_ROOT=/app`; no wrong-tree write, so no restore needed)*
 
 **2a — the unit declares the instance** *(ops only, no code)*
 
@@ -64,7 +65,7 @@ because under `JARVIS_ROOT=/app` every derived path equals the literal it replac
 **2d — the data tree** *(everything under `/app/jarvis_data`)*
 
 - [x] `tools/core/history.py:14` (+ **delete `:15`**), `tools/core/scheduling.py:15`, `heartbeat_state.py:32`, `tools/fitness/fitness_tools.py:12` *(+ `agent.py` inline chat/notif logs)*
-- [~] **Restart prod**, watch one heartbeat tick — `turns.jsonl` and `state.json` still update in place *(`turns.jsonl` verified appending in place; `state.json` stamp pending next hourly tick)*
+- [x] **Restart prod**, watch one heartbeat tick — `turns.jsonl` and `state.json` still update in place *(both verified appending in place under `/app/jarvis_data`; `state.json` stamping confirmed on the hourly ticks)*
 - [x] Run the scratch-root assertion by hand; it must now pass *(full-module scan: zero `/app/jarvis_memory`/`/app/jarvis_data` leak)*
 
 **2e — dev tooling and the regression net** *(touches no production runtime)*
@@ -96,19 +97,19 @@ the one-way cutover. Don't bundle them.
 **4a — the deploy scripts**
 
 - [x] `deploy/backup_state.sh` — `<label>` / `--restore <tarball>` / `--prune`; shared by 2·0, `deploy.sh`, and manual use (see [Backup & rollback](#backup--rollback)) *(built early in 2·0)*
-- [ ] `deploy/deploy.sh`: clean-tree check → **`backup_state.sh` keyed to the tag-to-be** → `fetch` → `pull --ff-only origin main` → **tag the incoming commit** `deploy-YYYY-MM-DD-N` (push it) → sync deps if `requirements.txt` moved → `JARVIS_ROOT=/app` smoke check → assert unit still declares `JARVIS_ROOT` → `backup_state.sh --prune` → print hand-off
-- [ ] `deploy/rollback.sh`: list `deploy-*` → checkout → **write a rollback marker** → if the target's commit flags a format change, `backup_state.sh --restore` its tarball → hand-off
-- [ ] `deploy.sh` refuses to run from a rolled-back/detached tree without `--force`
-- [ ] Provenance block gains a loud row when HEAD is detached or the tree is rolled back
-- [ ] Dry run: deploy on an already-current main = clean no-op, tag created once
-- [ ] **Rehearse a rollback before you need one** — both a code-only rollback and a `--restore`
-- [ ] **Regression gate (CI)** — `.githooks/pre-commit` (via `core.hooksPath`) + a GitHub Actions workflow running `scripts/ci/check_paths.py` + a branch-protection rule on `main` + fold the check into `deploy.sh`'s smoke check (see [Regression gate (CI)](#regression-gate-ci))
+- [x] `deploy/deploy.sh`: clean-tree check → **`backup_state.sh` keyed to the tag-to-be** → `fetch` → `pull --ff-only origin main` → **tag the incoming commit** `deploy-YYYY-MM-DD-N` (push it) → sync deps if `requirements.txt` moved → `JARVIS_ROOT=/app` smoke check → assert unit still declares `JARVIS_ROOT` → `backup_state.sh --prune` → print hand-off
+- [x] `deploy/rollback.sh`: list `deploy-*` → checkout → **write a rollback marker** → if the target's commit flags a format change, `backup_state.sh --restore` its tarball → hand-off
+- [x] `deploy.sh` refuses to run from a rolled-back/detached tree without `--force`
+- [x] Provenance block gains a loud row when HEAD is detached or the tree is rolled back
+- [x] Dry run: deploy on an already-current main = clean no-op, tag created once *(exercised live — `deploy-2026-07-23-{1,2,3}` tags + matching state snapshots)*
+- [x] **Rehearse a rollback before you need one** — both a code-only rollback and a `--restore` *(rehearsed 2026-07-23; both paths work)*
+- [x] **Regression gate (CI)** — `.githooks/pre-commit` (via `core.hooksPath`) + a GitHub Actions workflow running `scripts/ci/check_paths.py` + a branch-protection rule on `main` + fold the check into `deploy.sh`'s smoke check (see [Regression gate (CI)](#regression-gate-ci))
 
 **4b — development moves out of prod**
 
-- [ ] Migrate in-flight branches (`feat/context-handling`, `docs/app-channel-plan`) to `/app/jarvis_staging/code`
-- [ ] Copy `.claude/` and migrate the Claude Code project dir (see below); put `/app/jarvis_code` on `main`
-- [ ] Update `CLAUDE.md` (sessions start in staging) + `DEVELOPMENT.md` §Development Workflow 1
+- [x] Migrate in-flight branches (`feat/context-handling`, `docs/app-channel-plan`) to `/app/jarvis_staging/code` *(development now runs from the staging tree; prod checkout sits on `main`)*
+- [x] Copy `.claude/` and migrate the Claude Code project dir (see below); put `/app/jarvis_code` on `main` *(`.claude/` present under the staging tree)*
+- [x] Update `CLAUDE.md` (sessions start in staging) + `DEVELOPMENT.md` §Development Workflow 1 *(commit c7bb3b2, PR #39)*
 
 ---
 

--- a/scripts/jrestart-staging.sh
+++ b/scripts/jrestart-staging.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Restart the STAGING Jarvis and print THIS boot's provenance block to the terminal.
+#
+# The staging companion to scripts/jrestart.sh. Same one-command "restart and see
+# what booted" flow, pointed at jarvis-staging.service. Because staging is started
+# on demand (not enabled), a `restart` also serves as a cold `start`.
+#
+# Read the printed block FIRST — the `root : /app/jarvis_staging` row is the
+# isolation guard: it confirms you booted staging against the staging trees, not
+# prod. This replaces the single-writer lock the design deliberately dropped.
+#
+# Robustness contract (see main.py:_provenance_block):
+#   - anchors on the stable "Running code:" header, and prints to the LAST line
+#     (`sed '/Running code:/,$p'`) — so rows added later are captured with no edit;
+#   - scopes to this boot with `--since` captured BEFORE the restart, so it never
+#     shows an accumulation of past restarts' blocks.
+#
+# Rendering: a multi-line log message becomes one journal entry per line, each
+# stamped with journald's syslog prefix. `-o cat` drops that prefix so the block
+# reads as the clean indented panel; the trailing sed strips the Python logging
+# prefix ("<ts> - __main__ - INFO - ") from the header line only.
+set -u
+
+since=$(date '+%F %T')
+systemctl restart jarvis-staging.service
+
+# Poll (up to ~15s) until this boot has logged the block, rather than a blind
+# sleep that a slow boot could outrun.
+for _ in $(seq 1 15); do
+    sleep 1
+    if journalctl -u jarvis-staging --since "$since" --no-pager -q | grep -q "Running code:"; then
+        break
+    fi
+done
+
+journalctl -u jarvis-staging --since "$since" -o cat --no-pager -q \
+    | sed -n '/Running code:/,$p' \
+    | sed 's/.*Running code:/Running code:/'


### PR DESCRIPTION
Archives the finished STAGING_AND_DEPLOY.md (slices 0–4 complete, verified live 2026-07-23) to `docs/plans/archive/` with the checklist fully ticked, and repoints every reference.

**New command:** `scripts/jrestart-staging.sh` — the staging counterpart to `jrestart.sh` (restart + boot provenance block; doubles as a cold start). Plus PVE-host aliases `jrestart` / `jrestart-staging` / `jdeploy` documented in `docs/DEPLOY.md`.

**App-channel plan:** Step 1 (staging) marked done; open questions 1 & 2 resolved.

Docs + one shell script only — no Python module changes.