### PR TITLE
fix(deploy): run deploy.sh/rollback.sh as the checkout owner, not root

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -28,6 +28,21 @@ CHECK_PATHS="$REPO/scripts/ci/check_paths.py"
 CHECK_ENV="$REPO/scripts/check_env.sh"
 MARKER="$REPO/.rollback-marker"
 
+# Run as the checkout's owner, never root. This script needs no privilege — it only
+# does git + pip + a read-only `systemctl cat`; the restart (which does need root) is
+# deliberately left to the owner. Git refuses to operate on a differently-owned tree
+# ("dubious ownership"), and any git/pip write done as root would scatter root-owned
+# files through a jarvis_user tree and break the service later. So when invoked as
+# root — e.g. from `pct enter` / `pct exec 106 -- …` — drop to the tree's owner and
+# re-exec the identical command (args preserved). su-from-root needs no password.
+if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+    owner="$(stat -c %U "$REPO")"
+    if [[ "$owner" != "root" ]]; then
+        echo "deploy: invoked as root — re-exec as checkout owner '$owner' (no privilege needed)" >&2
+        exec su "$owner" -c "exec $(printf '%q ' "$REPO/deploy/deploy.sh" "$@")"
+    fi
+fi
+
 FORCE=0
 case "${1:-}" in
     --force)     FORCE=1 ;;

--- a/deploy/rollback.sh
+++ b/deploy/rollback.sh
@@ -24,6 +24,18 @@ SERVICE="jarvis.service"
 BACKUP_DIR="$ROOT/backups"
 MARKER="$REPO/.rollback-marker"
 
+# Run as the checkout's owner, never root (same rationale as deploy.sh): this does
+# git only and never restarts, git refuses a differently-owned tree, and a root git
+# write would corrupt ownership. If invoked as root (`pct enter`/`pct exec`), drop to
+# the tree's owner and re-exec the identical command. su-from-root needs no password.
+if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+    owner="$(stat -c %U "$REPO")"
+    if [[ "$owner" != "root" ]]; then
+        echo "rollback: invoked as root — re-exec as checkout owner '$owner'" >&2
+        exec su "$owner" -c "exec $(printf '%q ' "$REPO/deploy/rollback.sh" "$@")"
+    fi
+fi
+
 say() { echo "rollback: $*" >&2; }
 die() { echo "rollback: ERROR: $*" >&2; exit 1; }
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -164,21 +164,33 @@ Read the printed block first. For staging the `root : /app/jarvis_staging` row i
 isolation check — it confirms you booted against the staging trees, not prod (this is
 what replaces the single-writer lock the design dropped).
 
-### Quick aliases (run from the PVE host root shell)
+### Quick commands
 
-Restarts and deploys need root, which you have on the Proxmox host. Drop these in
-`/root/.bashrc` so the whole flow is one word each — each wraps the in-container script
-with `pct exec 106`:
+**Privilege.** `deploy.sh` and `rollback.sh` need **no** root — they do git + pip only —
+and they **self-drop to the checkout owner** (`jarvis_user`) if you invoke them as root, so
+running git as root never corrupts the tree's ownership. The **restart** scripts *do* need
+root (they call `systemctl`). So: deploy as anyone, restart as root.
+
+**Inside the container** (`pct enter 106`, root shell):
+
+```bash
+/app/jarvis_code/deploy/deploy.sh                       # deploy prod (drops to jarvis_user itself)
+/app/jarvis_code/scripts/jrestart.sh                    # then restart prod + show the boot block
+/app/jarvis_staging/code/scripts/jrestart-staging.sh    # restart / cold-start staging
+```
+
+**From the PVE host** — drop these in `/root/.bashrc` (each wraps the in-container script
+with `pct exec 106`):
 
 ```bash
 alias jrestart='pct exec 106 -- /app/jarvis_code/scripts/jrestart.sh'
 alias jrestart-staging='pct exec 106 -- /app/jarvis_staging/code/scripts/jrestart-staging.sh'
-alias jdeploy='pct exec 106 -- bash -lc "cd /app/jarvis_code && ./deploy/deploy.sh"'
+alias jdeploy='pct exec 106 -- /app/jarvis_code/deploy/deploy.sh'
 ```
 
-`jdeploy` runs the fail‑closed `deploy.sh` (it never restarts); follow a green deploy
-with `jrestart` to bring the new code up. Keeping them two words is deliberate — a
-restart drops in‑flight turns, so it stays a conscious second step.
+`jdeploy` runs the fail‑closed `deploy.sh` (it never restarts); follow a green deploy with
+`jrestart` to bring the new code up. Keeping deploy and restart as two steps is deliberate —
+a restart drops in‑flight turns, so it stays a conscious second step.
 
 ---
 


### PR DESCRIPTION
Running `deploy.sh` as root (via `pct enter`/`pct exec`) tripped git's dubious-ownership guard on the `jarvis_user`-owned tree — every git command failed, and step 0 misreported it as **"HEAD is detached (rolled back?)"** on a clean checkout.

Fix: both `deploy.sh` and `rollback.sh` now re-exec as the checkout owner via `su` when invoked as root (no privilege needed; no password from root; args preserved; idempotent). Prevents both the false alarm and root-owned files landing in the tree.

Docs: DEPLOY.md quick-commands clarified — deploys self-drop, only restarts need root.