### PR TITLE
feat: multi-channel support — phase 2 (default channel + origin-scoped confirmations)

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -578,6 +578,7 @@ def ask_jarvis(
     turn_id = turn_id or uuid4().hex
     _tid_token = telemetry.TURN_ID.set(turn_id)
     _scope_token = turn_context.CURRENT_SCOPE.set(scope)
+    _thread_token = turn_context.CURRENT_THREAD_ID.set(thread_id)
     telemetry.record_turn_start(
         thread_id=thread_id,
         scope=scope,
@@ -710,6 +711,7 @@ def ask_jarvis(
         telemetry.record_turn_end(active_skills_end=active_end, no_action=no_action)
         telemetry.TURN_ID.reset(_tid_token)
         turn_context.CURRENT_SCOPE.reset(_scope_token)
+        turn_context.CURRENT_THREAD_ID.reset(_thread_token)
 
 
 def _ack_from_messages(messages) -> dict | None:

--- a/docs/architecture/GATEWAY.md
+++ b/docs/architecture/GATEWAY.md
@@ -325,7 +325,7 @@ class ConfirmationUI(ABC):
     # (e.g. PTB CallbackQueryHandler) that calls store.resolve(callback_id, outcome).
 ```
 
-`InMemoryConfirmationStore.__init__(ui: ConfirmationUI, outbox: Outbox, on_outcome=None)` — the store delegates rendering to `ui` and delivers the final outcome via the injected `on_outcome` domain callback (conversational acknowledgement) or `outbox.notify_owner(...)` verbatim as fallback.
+`InMemoryConfirmationStore.__init__(ui: ConfirmationUI, outbox: Outbox, owner_thread_id: str, on_outcome=None)` — one store **per channel**, carrying that channel's `owner_thread_id` and `outbox` so a resolved confirmation acks on the channel the turn came from. The store delegates rendering to `ui` and delivers the final outcome via the injected `on_outcome(system_text, owner_thread_id, outbox)` domain callback (conversational acknowledgement) or `outbox.notify_owner(...)` verbatim as fallback. Stores register per channel name; `get_confirmation()` resolves the **origin** channel's store from the running turn's `CURRENT_THREAD_ID` (falling back to the default channel for origin-less turns).
 
 ---
 
@@ -405,7 +405,7 @@ Jarvis takes option (2). Each channel's factory reads its owner-config env and p
 
 The factory reads the env value and passes it into the channel constructor; nowhere else in the codebase reads it (`main.py` only calls `load_dotenv` — it never sees channel config).
 
-Domain code reaches the default channel through two factory accessors, never through a channel object: `default_outbox()` for proactive sends, and `default_owner_thread_id()` for addressing the owner's conversation thread (used by the confirmation-outcome callback). Today both resolve to the single configured Telegram channel. When a second channel ships, "which channel does this send/thread target" becomes a routing decision — that decision lives in `factory.py`, not in callers.
+Domain code reaches channels through factory accessors, never through a channel object. **Proactive** sends use `default_outbox()`, which resolves the configured default channel (`JARVIS_DEFAULT_CHANNEL`, default `telegram`) at call time through a name-keyed registry; `default_owner_thread_id()` addresses the owner's thread on that default channel, for origin-less owner-addressed routing. **Reactive** traffic follows its origin channel instead: a resolved confirmation acks on the thread it came from (the store carries its own channel's thread/outbox), and `get_confirmation()` resolves the origin channel's store from the running turn's `CURRENT_THREAD_ID`. Today every accessor resolves to the single Telegram channel; when a second channel ships, "which channel does this target" is a routing decision that lives in `factory.py`, not in callers.
 
 ---
 

--- a/docs/plans/app-plans/02_MULTI_CHANNEL_SUPPORT.md
+++ b/docs/plans/app-plans/02_MULTI_CHANNEL_SUPPORT.md
@@ -22,12 +22,12 @@ hardcoded thread-prefix assume exactly one channel exists.
 - [x] 1d — generalize the factory: `build_stack(name)` + neutral `Stack` Protocol; Telegram builder is private `_build_telegram_stack` behind a name registry (no public wrapper); `main.py` calls `build_stack("telegram", …)`. Factory kept as composition root (concrete imports stay) — considered moving the builder into the channel package, chose not to
 - [ ] **Restart staging + Telegram regression** — *pending*; prod happens later via `deploy.sh`
 
-### Phase 2 — default channel + origin routing
-- [ ] 2a — `JARVIS_DEFAULT_CHANNEL` (default `telegram`); registry keyed by `Channel.name`
-- [ ] 2b — `default_outbox()` resolves through the configured default
-- [ ] 2c — confirmation acks route to the **origin** thread, not the default
-- [ ] Verify: with one channel every path is byte-identical to today
-- [ ] **Restart prod**; Telegram regression + a confirmation round-trip
+### Phase 2 — default channel + origin routing — ✅ implemented 2026-07-23
+- [x] 2a — `JARVIS_DEFAULT_CHANNEL` (default `telegram`); registry keyed by `Channel.name`
+- [x] 2b — `default_outbox()` resolves through the configured default (at call time)
+- [x] 2c — confirmations origin-scoped: per-channel store, origin-resolved in `get_confirmation()` (Design B)
+- [x] Verify: with one channel every path byte-identical (unit-verified: resolution + channel-local ack)
+- [ ] **Restart staging**; Telegram regression + a confirmation round-trip — *pending*
 
 ### Phase 3 — rendering
 - [ ] 3a — `OutboundReply{text, blocks}` + `Channel.send_rich`, default → `send(text)` (upstream B4)
@@ -133,7 +133,7 @@ Three singletons in `gateway/factory.py:51-53` assume one channel. They generali
 | Singleton | Today | After |
 |---|---|---|
 | `_default_outbox` | the one Outbox | resolves through the configured default channel |
-| `_confirmation` | the one UI | broadcast UI (step 3 wires the second) |
+| `_confirmation` | the one store | per-channel store, origin-resolved in `get_confirmation()` (no broadcast) |
 | `_default_channel` → `default_owner_thread_id()` | the one channel's thread | **origin-aware** — see below |
 
 **2a — a channel registry.** Channels register by `Channel.name`; `JARVIS_DEFAULT_CHANNEL`
@@ -143,12 +143,38 @@ returns what it returns today.
 **2b — proactive resolves through the default.** `default_outbox()` keeps its signature;
 heartbeat, reminders and the media notifier need no changes, exactly as upstream B3 promised.
 
-**2c — acks follow the origin.** `main.py:93` currently calls `default_owner_thread_id()` to
-decide where a resolved confirmation is fed back into the agent. That is proactive-shaped
-routing applied to reactive traffic: confirm on your phone and the acknowledgement lands in the
-Telegram thread, so the device you answered on never hears back. The confirmation record already
-knows which channel prompted it — carry the origin thread through the store and ack there.
-`default_owner_thread_id()` remains for genuinely owner-addressed, origin-less cases.
+**2c — confirmations are origin-scoped (Design B: per-channel handlers).** A confirmation
+belongs to the channel of the turn that raised it — prompt *and* ack. Today both are hardwired to
+the single Telegram store + `default_outbox()`, so a request from a second channel would prompt
+and acknowledge on Telegram instead. The fix keeps confirmation **on its own axis** (not fused
+into the proactive `_registry`) and makes each channel own its confirmations:
+
+- **Per-channel store.** Each channel builds its own confirmation store (its own `ConfirmationUI`
+  + outbox + owner thread), registered by name in a `_confirmation_stores` map. Store internals are
+  unchanged — each is just "one channel's confirmations."
+- **Origin resolved once.** `get_confirmation()` (in the factory — it has both the turn context
+  and the registry) reads a new `CURRENT_THREAD_ID` ambient var → origin channel name → returns
+  that channel's store. Falls back to the default channel for origin-less turns (heartbeat).
+  Destructive tools call `get_confirmation()` unchanged.
+- **Tap + ack are naturally channel-local.** The button tap already returns to the origin
+  channel's own store (each channel's host holds its store); the ack runs `ask_jarvis` on the
+  store's own thread and sends via the store's own outbox. No `PendingAction` change, no
+  cross-channel resolution, no resolver injected into the store.
+
+*Why Design B over a central store that resolves per-request:* origin is resolved in one obvious
+place (`get_confirmation`), the store's internals don't change, and it matches how OpenClaw
+(`ChannelApprovalCapability`) and Hermes (per-adapter `send_*` methods) structure interactive UI.
+
+**Scaling to blocks (buttons / forms / cards).** Confirmation is the first instance of a general
+per-channel *interaction* handler. Future block types become `render_<block>` methods on the same
+per-channel handler, each with a **text-fallback default in the base class**: a channel that can
+render richly overrides, one that can't inherits text. The origin seam (`get_confirmation` → a
+general `get_interaction`) is unchanged. Because block richness is **app-only** (Telegram has no
+custom blocks), Telegram overrides only `confirmation` (native buttons) and inherits text
+fallbacks for everything else — future block work is nearly all additive on the app side.
+"Render, don't negotiate" keeps capability checks out of `tools/`/`agent.py`. We build the
+confirmation template now; the block methods + the app's rich overrides arrive with Phase 3 +
+Step 3, not before (no consumer exists yet).
 
 *Verify:* with one channel, every path byte-identical. A confirmation round-trip acknowledges in
 the same thread it was answered from.

--- a/docs/plans/app-plans/02_MULTI_CHANNEL_SUPPORT.md
+++ b/docs/plans/app-plans/02_MULTI_CHANNEL_SUPPORT.md
@@ -27,7 +27,7 @@ hardcoded thread-prefix assume exactly one channel exists.
 - [x] 2b — `default_outbox()` resolves through the configured default (at call time)
 - [x] 2c — confirmations origin-scoped: per-channel store, origin-resolved in `get_confirmation()` (Design B)
 - [x] Verify: with one channel every path byte-identical (unit-verified: resolution + channel-local ack)
-- [ ] **Restart staging**; Telegram regression + a confirmation round-trip — *pending*
+- [x] **Restart staging**; Telegram regression + confirmation round-trip — ✅ verified live 2026-07-23 (confirm + cancel round-trips, SOUL.md protected write, proactive reminder)
 
 ### Phase 3 — rendering
 - [ ] 3a — `OutboundReply{text, blocks}` + `Channel.send_rich`, default → `send(text)` (upstream B4)

--- a/docs/plans/app-plans/02_MULTI_CHANNEL_SUPPORT.md
+++ b/docs/plans/app-plans/02_MULTI_CHANNEL_SUPPORT.md
@@ -265,6 +265,43 @@ concurrently with a user turn (the behavior that must **not** regress).
 
 ---
 
+## Architecture review (2026-07-23)
+
+Before building Phase 2's confirmation routing, the Channel-vs-Outbox split was checked
+from first principles and against two comparable assistants — **OpenClaw**
+(`openclaw/openclaw`) and **Hermes** (`NousResearch/hermes-agent`). Outcome:
+
+- **The split is principled, not an artifact of the pre-existing Outbox.** It is the
+  transport-adapter (port) vs. delivery-policy (application service) seam. OpenClaw splits it
+  *more* aggressively (a channel-agnostic `infra/outbound/deliver.ts` core + thin per-channel
+  outbound adapters); Hermes fuses send into the adapter for replies but adds a separate
+  `DeliveryRouter` for proactive sends. Both put proactive and reactive through **one delivery
+  seam, differing only in destination** — which validates `Outbox` as the single owner-send seam
+  and replies going straight through the channel.
+- **Confirmation stays on its own axis** (this **supersedes** the Decisions section's earlier
+  "confirmations broadcast, first-resolve-wins" line). A confirmation lives entirely on the
+  channel of the turn that raised it — prompt *and* ack. Interactive UI is per-channel,
+  capability-degrading (plain-text fallback), origin-resolved, with a shared callback-id
+  convention — **not** fused into the proactive `{channel, outbox}` registry. Both reference
+  systems model it this way (Hermes's `send_clarify`/`send_exec_approval`/… family; OpenClaw's
+  `ChannelApprovalCapability`), and both treat confirmation as one instance of a general
+  interactive-callback pattern. We build confirmation as that template but do **not** build the
+  general framework yet.
+
+**Deferred cleanups (tracked, not blocking):**
+- Loop-bridge (`bind_loop`/`submit`) is misfiled in `outbox.py` — it is shared sync→loop infra
+  (the confirmation store uses it too), not owner-send policy → issue #43.
+- `notify_owner`/`notify_owner_media` duplicate a `try/except → log` block; refactor to a send
+  middleware seam when a 3rd cross-cutting concern (retry/rate-limit/fallback) lands → issue #44.
+- The "owner" concept is baked into the `Channel` transport port (`send_to_owner`) — app policy
+  leaking into transport. Low value for a single-user box; flag only, do not churn.
+- `Channel` fuses inbound + outbound where OpenClaw splits them — revisit only if a send-only or
+  receive-only channel is ever added.
+
+**Do NOT adopt yet (over-engineering at N=2 channels):** plugin self-registration + lazy loading,
+`DeliveryTarget`-style envelope-string routing, durable delivery queues / commit hooks, and
+multi-account-per-channel. Noted as the growth path if the channel count ever climbs.
+
 ## Deltas — upstream plan vs. this codebase
 
 `original_app_plan.md` predates the Outbox unification (PR #34, merged 2026-07-16). Verified

--- a/gateway/confirmation/store.py
+++ b/gateway/confirmation/store.py
@@ -37,14 +37,19 @@ class InMemoryConfirmationStore(Confirmation):
         self,
         ui: ConfirmationUI,
         outbox: Outbox,
-        on_outcome: Callable[[str], Awaitable[None]] | None = None,
+        owner_thread_id: str,
+        on_outcome: Callable[[str, str, Outbox], Awaitable[None]] | None = None,
     ) -> None:
         self._ui = ui
         self._outbox = outbox
+        # This store belongs to one channel; its owner thread and outbox are
+        # that channel's, so a resolved confirmation acks on the same channel
+        # the turn came from (origin routing) without any cross-channel lookup.
+        self._owner_thread_id = owner_thread_id
         # Domain callback that turns a neutral outcome line into a
-        # conversational acknowledgement (runs the agent + replies). Injected
-        # by the host so the gateway never imports the agent layer. If unset,
-        # the outcome is posted to the owner verbatim instead.
+        # conversational acknowledgement on a given thread/outbox (runs the
+        # agent + replies). Injected by the host so the gateway never imports
+        # the agent layer. If unset, the outcome is posted to the owner verbatim.
         self._on_outcome = on_outcome
         self._pending: dict[str, PendingAction] = {}
         self._lock = threading.Lock()
@@ -167,7 +172,7 @@ class InMemoryConfirmationStore(Confirmation):
         notification-log event."""
         try:
             if self._on_outcome is not None:
-                await self._on_outcome(system_text)
+                await self._on_outcome(system_text, self._owner_thread_id, self._outbox)
             else:
                 await self._outbox.notify_owner(system_text)
         except Exception:

--- a/gateway/factory.py
+++ b/gateway/factory.py
@@ -58,36 +58,60 @@ class TelegramStack:
         await self.host.stop()
 
 
-# Registry for proactive sends / confirmation. Set when a stack is built.
-_default_channel: Channel | None = None
+# Runtime channel registry for proactive routing. Populated when a stack is
+# built; proactive sends resolve through it by name at call time, so the
+# configured default can change without rebinding callers.
+@dataclass
+class _Registered:
+    channel: Channel
+    outbox: Outbox
+
+
+_registry: dict[str, _Registered] = {}
+_default_channel_name: str | None = None
 _confirmation: Confirmation | None = None
-_default_outbox: Outbox | None = None
 
 
-def _set_default_channel(channel: Channel) -> None:
-    global _default_channel
-    _default_channel = channel
+def register_channel(channel: Channel, outbox: Outbox) -> None:
+    """Register a built channel and its outbox under channel.name."""
+    _registry[channel.name] = _Registered(channel, outbox)
+
+
+def set_default_channel(name: str) -> None:
+    """Override the proactive default channel at runtime (otherwise
+    JARVIS_DEFAULT_CHANNEL decides). Lets the default flip without a rebuild."""
+    global _default_channel_name
+    _default_channel_name = name
+
+
+def _default_name() -> str:
+    """The proactive default channel name: runtime override, else
+    JARVIS_DEFAULT_CHANNEL, else 'telegram'. Read at call time — never baked in."""
+    return _default_channel_name or os.getenv("JARVIS_DEFAULT_CHANNEL", "telegram")
+
+
+def _default_entry() -> _Registered:
+    name = _default_name()
+    entry = _registry.get(name)
+    if entry is None:
+        raise RuntimeError(
+            f"No channel registered as the proactive default ({name!r}); "
+            f"registered: {sorted(_registry)}."
+        )
+    return entry
 
 
 def default_owner_thread_id() -> str:
     """The agent thread id of the owner's conversation on the default channel.
-    When a second channel ships, this becomes a routing decision living here,
-    not in callers."""
-    if _default_channel is None:
-        raise RuntimeError("No default user channel configured.")
-    return _default_channel.owner_thread_id
-
-
-def set_default_outbox(outbox: Outbox) -> None:
-    global _default_outbox
-    _default_outbox = outbox
+    Origin-less, owner-addressed proactive code uses this; reactive traffic
+    (chat replies, confirmations) routes to its own origin channel instead."""
+    return _default_entry().channel.owner_thread_id
 
 
 def default_outbox() -> Outbox:
-    """The outbox owner-addressed proactive sends go through."""
-    if _default_outbox is None:
-        raise RuntimeError("No default outbox configured.")
-    return _default_outbox
+    """The outbox owner-addressed proactive sends go through (heartbeat,
+    reminders, media). Resolves the configured default channel at call time."""
+    return _default_entry().outbox
 
 
 def set_confirmation(confirmation: Confirmation) -> None:
@@ -133,9 +157,8 @@ def _build_telegram_stack(
     router = TelegramInboundRouter(channel, on_message)
     host = TelegramHost(token, channel, router, confirmation_ui, store)
 
-    _set_default_channel(channel)
+    register_channel(channel, outbox)
     set_confirmation(store)
-    set_default_outbox(outbox)
     logger.info("Telegram stack built (owner_id=%d)", owner_id)
     return TelegramStack(
         channel=channel, router=router, store=store,

--- a/gateway/factory.py
+++ b/gateway/factory.py
@@ -18,6 +18,8 @@ from dataclasses import dataclass
 
 from typing import Awaitable, Callable, Protocol
 
+import turn_context
+
 from gateway.base import Channel, OnMessage
 from gateway.confirmation.base import Confirmation
 from gateway.confirmation.store import InMemoryConfirmationStore
@@ -69,7 +71,10 @@ class _Registered:
 
 _registry: dict[str, _Registered] = {}
 _default_channel_name: str | None = None
-_confirmation: Confirmation | None = None
+# Confirmation stores keyed by channel name — kept on their own axis (not in
+# _registry): a confirmation resolves by the turn's ORIGIN channel, a different
+# lookup than the proactive default.
+_confirmation_stores: dict[str, Confirmation] = {}
 
 
 def register_channel(channel: Channel, outbox: Outbox) -> None:
@@ -114,21 +119,40 @@ def default_outbox() -> Outbox:
     return _default_entry().outbox
 
 
-def set_confirmation(confirmation: Confirmation) -> None:
-    global _confirmation
-    _confirmation = confirmation
+def register_confirmation(name: str, store: Confirmation) -> None:
+    """Register a channel's confirmation store under its channel name."""
+    _confirmation_stores[name] = store
+
+
+def _channel_name_for_thread(thread_id: str | None) -> str | None:
+    """The channel a thread belongs to, by its '<name>_<id>' prefix, when that
+    channel has a registered confirmation store. None for origin-less threads
+    (e.g. the 'heartbeat' thread)."""
+    if not thread_id:
+        return None
+    name = thread_id.split("_", 1)[0]
+    return name if name in _confirmation_stores else None
 
 
 def get_confirmation() -> Confirmation:
-    """The active confirmation backend destructive tools call."""
-    if _confirmation is None:
-        raise RuntimeError("Confirmation system not configured.")
-    return _confirmation
+    """The confirmation store for the channel of the running turn (its origin),
+    so a destructive tool's prompt and ack both stay on the channel the turn
+    came from. Falls back to the default channel for origin-less turns
+    (heartbeat). Destructive tools call this with no args; the origin is read
+    from ambient turn context."""
+    name = _channel_name_for_thread(turn_context.current_thread_id()) or _default_name()
+    store = _confirmation_stores.get(name)
+    if store is None:
+        raise RuntimeError(
+            f"No confirmation store registered for channel {name!r}; "
+            f"registered: {sorted(_confirmation_stores)}."
+        )
+    return store
 
 
 def _build_telegram_stack(
     on_message: OnMessage,
-    on_confirmation_outcome: Callable[[str], Awaitable[None]] | None = None,
+    on_confirmation_outcome: Callable[[str, str, Outbox], Awaitable[None]] | None = None,
     log_sink: LogSink | None = None,
 ) -> TelegramStack:
     """Construct and wire the Telegram channel, router, confirmation UI + store,
@@ -152,13 +176,15 @@ def _build_telegram_stack(
     channel = TelegramChannel(owner_id)
     outbox = Outbox(channel, log_sink)
     confirmation_ui = TelegramConfirmationUI(channel)
-    store = InMemoryConfirmationStore(confirmation_ui, outbox, on_confirmation_outcome)
+    store = InMemoryConfirmationStore(
+        confirmation_ui, outbox, channel.owner_thread_id, on_confirmation_outcome
+    )
     confirmation_ui.bind_store(store)
     router = TelegramInboundRouter(channel, on_message)
     host = TelegramHost(token, channel, router, confirmation_ui, store)
 
     register_channel(channel, outbox)
-    set_confirmation(store)
+    register_confirmation(channel.name, store)
     logger.info("Telegram stack built (owner_id=%d)", owner_id)
     return TelegramStack(
         channel=channel, router=router, store=store,
@@ -174,7 +200,7 @@ _STACK_BUILDERS: dict[str, Callable[..., Stack]] = {
 def build_stack(
     name: str,
     on_message: OnMessage,
-    on_confirmation_outcome: Callable[[str], Awaitable[None]] | None = None,
+    on_confirmation_outcome: Callable[[str, str, Outbox], Awaitable[None]] | None = None,
     log_sink: LogSink | None = None,
 ) -> Stack:
     """Build the named channel's stack and register its proactive/confirmation

--- a/main.py
+++ b/main.py
@@ -17,7 +17,8 @@ from heartbeat import init_scheduler, run_heartbeat, fire_reminder
 from tools.core import _load_events
 from gateway.base import InboundMessage
 from gateway.commands import try_handle_command
-from gateway.factory import build_stack, default_outbox, default_owner_thread_id
+from gateway.factory import build_stack
+from gateway.outbox import Outbox
 from gateway.webhook.notifier import MediaNotificationManager
 from gateway.webhook.server import create_webhook_app
 from tools.core import (
@@ -167,17 +168,20 @@ async def main() -> None:
         trim_log(log_path)
         logger.info("Log trimmed: %s", log_path)
 
-    async def on_confirmation_outcome(system_text: str) -> None:
-        """Feed a resolved confirmation back through the agent on the owner's
-        thread so Jarvis acknowledges it conversationally, then reply."""
-        thread_id = default_owner_thread_id()
+    async def on_confirmation_outcome(
+        system_text: str, thread_id: str, outbox: Outbox
+    ) -> None:
+        """Feed a resolved confirmation back through the agent on the ORIGIN
+        channel's thread so Jarvis acknowledges it conversationally there, then
+        reply via that channel's outbox. thread_id/outbox are the origin
+        channel's, supplied by its confirmation store."""
         try:
             await asyncio.to_thread(append_chat_log, "user", system_text, thread_id)
             reply = await asyncio.to_thread(ask_jarvis, system_text, thread_id)
             if reply:
                 await asyncio.to_thread(append_chat_log, "assistant", reply, thread_id)
                 # Conversational reply, already chat-logged — no notification event.
-                await default_outbox().notify_owner(reply)
+                await outbox.notify_owner(reply)
         except Exception:
             logger.exception("Failed to deliver confirmation outcome")
 

--- a/turn_context.py
+++ b/turn_context.py
@@ -18,7 +18,18 @@ from contextvars import ContextVar
 # that restrict what background turns may do.
 CURRENT_SCOPE: ContextVar[str | None] = ContextVar("current_scope", default=None)
 
+# The running turn's conversation thread id (e.g. "telegram_42"); None outside a
+# turn. Lets tool bodies discover which channel a turn originated on without the
+# model declaring it — e.g. a destructive tool's confirmation resolves to the
+# origin channel's handler. Set by ask_jarvis alongside CURRENT_SCOPE.
+CURRENT_THREAD_ID: ContextVar[str | None] = ContextVar("current_thread_id", default=None)
+
 
 def current_scope() -> str:
     """The running turn's scope, defaulting to 'user' outside a turn."""
     return CURRENT_SCOPE.get() or "user"
+
+
+def current_thread_id() -> str | None:
+    """The running turn's thread id, or None outside a turn."""
+    return CURRENT_THREAD_ID.get()


### PR DESCRIPTION
Step 2 (multi-channel support), Phase 2. Removes the last "the one channel is Telegram" assumptions from routing. **No behavior change with the single Telegram channel** — every path is byte-identical; the new machinery only diverges when a second channel registers.

## 2a/2b — proactive routing through a name registry
- `_registry: name → {channel, outbox}`, populated when a stack builds.
- `default_outbox()` / `default_owner_thread_id()` keep their signatures but resolve the configured default **at call time** via `JARVIS_DEFAULT_CHANNEL` (default `telegram`), with a `set_default_channel()` runtime override (dynamic-ready).

## 2c — origin-scoped confirmations (Design B: per-channel handlers)
A confirmation belongs to the channel of the turn that raised it — prompt **and** ack.
- Each channel registers its own confirmation store on its **own axis** (`_confirmation_stores`, not `_registry`).
- New `CURRENT_THREAD_ID` ambient var (set in `ask_jarvis`, reset in `finally`); `get_confirmation()` resolves the **origin** channel's store, falling back to the default for origin-less turns (heartbeat).
- The store carries its channel's `owner_thread_id` and hands `(system_text, thread_id, outbox)` to the ack callback, so `main.py` acks on the origin channel. `PendingAction` unchanged; button-tap + TTL sweeper were already channel-local.
- Chosen over a central store that resolves per-request — matches OpenClaw's `ChannelApprovalCapability` and Hermes's per-adapter `send_*` methods. Scales: future blocks (buttons/forms/cards) become `render_<block>` methods with text-fallback defaults, rich overrides app-side only (Telegram has no custom blocks).

## Design provenance
Architecture reviewed from first principles + against OpenClaw and Hermes before building — confirmed the Channel(transport)/Outbox(delivery-policy) split is principled, not an artifact. Findings + deferred cleanups (issues #43, #44) recorded in `docs/plans/app-plans/02_MULTI_CHANNEL_SUPPORT.md`.

## Verification
- **Independently reviewed** (repo `code-review` skill, fresh agent): MERGEABLE, 0 blockers; the one doc-drift warning fixed (`GATEWAY.md` synced in this branch).
- **Staging-verified live** (provenance-confirmed boot on this branch): confirm + cancel confirmation round-trips (both acking on the origin thread), a SOUL.md protected-write confirmation, and a proactive reminder via `default_outbox()`.

https://claude.ai/code/session_01GYvbMe18Fx4X7h5JcAUeL5