### PR TITLE
feat(ci): channel-agnosticism guard

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,21 +1,28 @@
 #!/usr/bin/env bash
-# pre-commit — block a commit that breaks path isolation.
+# pre-commit — block a commit that breaks a repo guardrail.
 #
 # Active only where core.hooksPath points here (one-time per checkout):
 #     git config core.hooksPath .githooks
 #
-# Runs scripts/ci/check_paths.py — no module may hardcode a prod state path. This is
-# fast local feedback; the unbypassable gate is CI + branch protection (see
-# docs/DEPLOY.md). Bypass in a genuine emergency with:  git commit --no-verify
+# Runs the same static guards as CI's "path-isolation" job: no module hardcodes a
+# prod state path (check_paths.py), and the app stays channel-agnostic
+# (check_channel_agnostic.py). Fast local feedback; the unbypassable gate is CI +
+# branch protection (see docs/DEPLOY.md). Bypass in a genuine emergency with:
+#     git commit --no-verify
 set -euo pipefail
 
 REPO="$(git rev-parse --show-toplevel)"
 PY="$REPO/venv/bin/python"
 [[ -x "$PY" ]] || PY="python3"
 
-if ! out="$("$PY" "$REPO/scripts/ci/check_paths.py" 2>&1)"; then
-    echo "$out" >&2
-    echo "pre-commit: path-isolation check FAILED — commit blocked." >&2
-    echo "pre-commit: fix it, or bypass with 'git commit --no-verify' if you truly must." >&2
-    exit 1
-fi
+run_check() {
+    if ! out="$("$PY" "$REPO/scripts/ci/$1" 2>&1)"; then
+        echo "$out" >&2
+        echo "pre-commit: $2 check FAILED — commit blocked." >&2
+        echo "pre-commit: fix it, or bypass with 'git commit --no-verify' if you truly must." >&2
+        exit 1
+    fi
+}
+
+run_check check_paths.py "path-isolation"
+run_check check_channel_agnostic.py "channel-agnostic"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,12 @@
 name: CI
 
 # The unbypassable half of the regression gate: runs on every PR and on pushes to
-# main. Pair with a branch-protection rule on `main` requiring "path-isolation" to
-# pass, so no hardcoded prod path can be merged. (The pre-commit hook is the fast
-# local half; see docs/DEPLOY.md.)
+# main. Two independent static guards, one job each:
+#   - path-isolation    — no module hardcodes a prod state path (check_paths.py)
+#   - channel-agnostic  — the app stays channel-agnostic (check_channel_agnostic.py)
+# Make each a hard gate with a branch-protection rule on `main` (GitHub → Settings →
+# Branches) requiring its check to pass. (The pre-commit hook is the fast local half
+# and runs both; see docs/DEPLOY.md.)
 on:
   push:
     branches: [main]
@@ -24,3 +27,14 @@ jobs:
         # check_paths.py sets its own scratch JARVIS_ROOT + a dummy GOOGLE_API_KEY,
         # so no real secrets are needed and the import makes no network call.
         run: python scripts/ci/check_paths.py
+
+  channel-agnostic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Channel-agnosticism check
+        # Pure static source scan — no app import and no deps, so no pip install.
+        run: python scripts/ci/check_channel_agnostic.py

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -142,10 +142,29 @@ venv/bin/python scripts/ci/check_paths.py    # exit 0 clean, 1 on a leak
   git config core.hooksPath .githooks
   ```
   Fast local feedback; bypassable with `git commit --no-verify`.
-- **Merge** — `.github/workflows/ci.yml` runs it on every PR and push to `main`. Make it
-  unbypassable by enabling a **branch-protection rule** on `main` (GitHub → Settings →
-  Branches) requiring the `path-isolation` check to pass. This is the real gate.
-- **Deploy** — `deploy/deploy.sh` runs it before the restart hand-off.
+- **Merge** — `.github/workflows/ci.yml` runs the guards on every PR and push to `main`, as
+  two independent jobs (`path-isolation`, `channel-agnostic`). Make each unbypassable by
+  enabling a **branch-protection rule** on `main` (GitHub → Settings → Branches) requiring its
+  check to pass. This is the real gate. (`path-isolation` is already required; add
+  `channel-agnostic` to the required set to enforce it too — until then it runs and reports but
+  does not block.)
+- **Deploy** — `deploy/deploy.sh` runs the path check before the restart hand-off.
+
+## `scripts/ci/check_channel_agnostic.py` — channel-agnostic guard
+
+A pure static source scan (no app import) that keeps multi-channel support from regressing:
+domain code (and slash-command handlers) never import a concrete channel, nothing in
+`gateway/` reverse-imports the app (except `gateway/commands/`, the documented bridge), and no
+channel name leaks into `tools/` (tool docstrings are prompt content). Mirrors the Gateway
+G1/G2 items in the `code-review` skill.
+
+```bash
+venv/bin/python scripts/ci/check_channel_agnostic.py   # exit 0 clean, 1 on a leak
+```
+
+Runs at **commit** (pre-commit hook) and **merge** (its own `channel-agnostic` CI job) — the
+same first two layers as the path guard. It is **not** run at deploy: it is architecture
+hygiene, not runtime-state safety, and `main` has already passed it.
 
 ---
 

--- a/scripts/ci/check_channel_agnostic.py
+++ b/scripts/ci/check_channel_agnostic.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""CI guard: the app stays channel-agnostic.
+
+Multi-channel support (Steps 1-2) moved all channel-specific code and config
+behind gateway.factory. This asserts that boundary holds — a regression (a tool
+docstring naming Telegram, a domain module importing a concrete channel, the
+gateway importing back up into the agent) fails here instead of silently
+coupling the whole app to one channel again.
+
+Three static checks (pure source scan — no app import, no deps):
+  1. No domain module (nor a slash-command handler) imports gateway.channels.* —
+     they reach the gateway only through gateway.factory.
+  2. No channel adapter or core-contract module in gateway/ imports the
+     agent/tools/main/heartbeat layers — a channel is a thin adapter; the host
+     injects the coupling. gateway/commands/ is exempt: slash-command handlers
+     are the documented app bridge and legitimately call into agent/tools (they
+     still may not import a concrete channel — check #1 covers that).
+  3. No channel name appears in tools/ — tool docstrings are prompt content, so
+     the model must not be told a capability is "a Telegram thing".
+
+These mirror the Gateway G1/G2 items in the code-review skill. The narrower
+"no channel names in agent.py/main.py" check is deliberately out of scope until
+Phase 4a generalizes agent.py's `telegram_` thread-prefix filter.
+
+Run:  python3 scripts/ci/check_channel_agnostic.py   (exit 0 = clean, 1 = leak)
+"""
+import ast
+import os
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Locations that must never import a concrete channel — they reach the gateway
+# only through gateway.factory. Includes gateway/commands/: handlers may import
+# agent/tools, but not a concrete channel. The factory (composition root) and
+# the channels themselves are deliberately absent.
+_NO_CONCRETE_CHANNEL = ("agent.py", "heartbeat.py", "heartbeat_state.py", "main.py", "tools", "gateway/commands")
+_FORBIDDEN_IMPORT = "gateway.channels"
+
+# gateway/ is thin adapters + core contracts; it must not import back up into the
+# app — EXCEPT gateway/commands/ (the documented slash-command bridge).
+# turn_context is a stdlib-only leaf and is deliberately allowed.
+_REVERSE_ROOTS = {"agent", "tools", "main", "heartbeat", "heartbeat_state"}
+_REVERSE_EXEMPT = os.path.join(REPO_ROOT, "gateway", "commands") + os.sep
+
+# tools/ carries prompt content; no channel may be named there.
+_FORBIDDEN_TOOL_TOKENS = ("telegram", "inlinekeyboard")
+
+_SKIP_DIRS = {"__pycache__", ".git", "venv", ".venv", "node_modules"}
+
+
+def _py_files(*rels):
+    for rel in rels:
+        p = os.path.join(REPO_ROOT, rel)
+        if os.path.isfile(p):
+            yield p
+        elif os.path.isdir(p):
+            for root, dirs, files in os.walk(p):
+                dirs[:] = [d for d in dirs if d not in _SKIP_DIRS]
+                for f in files:
+                    if f.endswith(".py"):
+                        yield os.path.join(root, f)
+
+
+def _imports(path):
+    """(module, lineno) for every absolute import — via AST, so strings and
+    comments are ignored. Relative imports (within a package) can't reach across
+    the boundaries we guard, so they are skipped."""
+    with open(path, encoding="utf-8") as fh:
+        tree = ast.parse(fh.read(), filename=path)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for a in node.names:
+                yield a.name, node.lineno
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            yield node.module, node.lineno
+
+
+def _rel(path):
+    return os.path.relpath(path, REPO_ROOT)
+
+
+def check_domain_imports():
+    """#1 — no domain module (nor a slash-command handler) imports a channel."""
+    leaks = []
+    for path in _py_files(*_NO_CONCRETE_CHANNEL):
+        for mod, line in _imports(path):
+            if mod == _FORBIDDEN_IMPORT or mod.startswith(_FORBIDDEN_IMPORT + "."):
+                leaks.append(f"{_rel(path)}:{line} imports {mod} — reach the gateway via gateway.factory")
+    return leaks
+
+
+def check_reverse_imports():
+    """#2 — no channel adapter / core contract in gateway/ imports the app layers
+    (gateway/commands/ exempt — the documented slash-command bridge)."""
+    leaks = []
+    for path in _py_files("gateway"):
+        if path.startswith(_REVERSE_EXEMPT):
+            continue
+        for mod, line in _imports(path):
+            if mod.split(".")[0] in _REVERSE_ROOTS:
+                leaks.append(f"{_rel(path)}:{line} imports {mod} — gateway must stay a thin adapter")
+    return leaks
+
+
+def check_tool_channel_names():
+    """#3 — no channel name in tools/ (tool docstrings are prompt content)."""
+    leaks = []
+    for path in _py_files("tools"):
+        with open(path, encoding="utf-8") as fh:
+            for i, raw in enumerate(fh, 1):
+                low = raw.lower()
+                for tok in _FORBIDDEN_TOOL_TOKENS:
+                    if tok in low:
+                        leaks.append(f"{_rel(path)}:{i} names a channel ({tok!r}): {raw.strip()[:80]}")
+    return leaks
+
+
+def main():
+    checks = (
+        ("domain code imports a concrete channel (gateway.channels.*)", check_domain_imports),
+        ("gateway/ reverse-imports the app", check_reverse_imports),
+        ("tools/ names a channel", check_tool_channel_names),
+    )
+    failed = False
+    for label, fn in checks:
+        leaks = fn()
+        if leaks:
+            failed = True
+            print(f"FAIL: {label}:")
+            for leak in leaks:
+                print("   ", leak)
+    if failed:
+        print("\nChannel-specific code and config live behind gateway.factory — keep the app channel-agnostic.")
+        return 1
+    print("OK: channel-agnostic — import boundaries clean, no channel names in tools/")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Locks in the channel-agnostic boundary that multi-channel Phases 1–2 established, so it can't silently regress.

## What it checks
`scripts/ci/check_channel_agnostic.py` — a pure static source scan (no app import, no deps), AST-based so it catches lazy indented imports a grep misses. Three invariants:
1. Domain code + slash-command handlers never `import gateway.channels.*` (reach the gateway via `gateway.factory`).
2. Nothing in `gateway/` reverse-imports the app — `gateway/commands/` exempt (the documented slash-command bridge; found + encoded during testing).
3. No channel name in `tools/` (tool docstrings are prompt content — the 1b leak class).

Mirrors the code-review skill's Gateway G1/G2, now automated.

## Wiring
- Its own `channel-agnostic` CI job (alongside `path-isolation`).
- The pre-commit hook (runs both guards locally).
- Documented in `docs/DEPLOY.md`.

Scoped to what's green today; the narrower "no channel names in agent.py/main.py" check waits for Phase 4a (the `telegram_` filter). Verified both ways: green on the tree, and a throwaway probe confirmed it fails on a real leak.

https://claude.ai/code/session_01GYvbMe18Fx4X7h5JcAUeL5