### PR TITLE
Stage B: lock scheduled_events.json read-modify-write (resource-level)

### DIFF
--- a/docs/plans/app-plans/EXECUTION_PLAN.md
+++ b/docs/plans/app-plans/EXECUTION_PLAN.md
@@ -27,8 +27,11 @@ dependency**, not by whether it touches existing or new code.
 - [ ] A2 — extend the CI channel-agnostic gate to cover `agent.py` (currently exempted)
 - [ ] **Restart staging** + Telegram regression (GATEWAY.md step 9)
 
-**Stage B — concurrent-turn safety** (before any second channel is live)
-- [ ] B-lock — keyed lock serializing *user* turns; heartbeat exempt
+**Stage B — shared-state write safety** (resource-level; heartbeat covered, not exempt)
+- [x] Audit: memory (`_WRITE_LOCK`) + confirmation store (`_lock`) already resource-locked; `scheduled_events.json` the lone gap
+- [ ] B-lock — `threading.Lock` around the `scheduled_events.json` read-modify-write (whole load→modify→save), covering user turns + heartbeat + future channels
+- [ ] Follow-up filed: unify the three ad-hoc locks behind one store-writer primitive (issue #48)
+- [ ] **Restart** + verify: concurrent reminder writes lose no events; heartbeat fire-path unchanged
 - [ ] **Restart** + verify: a second user turn waits for the first; a heartbeat tick still runs concurrently
 
 **Stage C — app channel, text round-trip** (the deliverable)
@@ -68,11 +71,12 @@ code 2026-07-23):
    "write against the seam to avoid a second edit at every send site" concern is empty.
    `OutboundReply` / `send_rich` matter only when something *emits blocks* — upstream B4, deferred
    behind the phone renderer regardless.
-2. **The concurrency lock gates the *prod flip*, not building B1.** B1's own poll loop (single
-   consumer, one turn at a time) prevents user↔user overlap *within* the app channel. The lock
-   matters for **cross-channel** overlap — a Telegram turn and an app turn at the same instant —
-   which is unreachable while B1 is built and validated in staging (one channel at a time), and
-   becomes reachable only when both channels serve the owner concurrently in prod.
+2. **Write safety is a small resource-level fix, not a turn lock that gates B1.** The original
+   plan imagined a keyed lock serializing whole user turns (heartbeat exempt). The audit + the
+   Hermes/OpenClaw research (Stage B) overturned that: the hazard is interleaved read-modify-write
+   of shared state, closed by per-resource locks the heartbeat also passes through — not by
+   serializing turns. B1 needs nothing from it; per-conversation ordering is already handled by the
+   channel transports.
 
 So **the app channel (B0/B1) is the next real deliverable**, with one safety item (Stage B)
 deliberately pulled in front of it.
@@ -104,29 +108,47 @@ name still lives in domain code.
 
 ---
 
-## Stage B — concurrent-turn safety (the keyed lock)
+## Stage B — shared-state write safety (resource-level, heartbeat covered)
 
-A keyed lock serializes **user** turns against each other; **heartbeat stays exempt** — not a
-global `ask_jarvis` lock, which would make a chat message wait behind a ~90s tick. User threads
-share one lock; heartbeat holds none.
+The hazard is interleaved **read-modify-write of shared state**, not concurrent turns as such.
+Turns already run in parallel worker threads (`asyncio.to_thread(ask_jarvis, …)`), and a second
+channel widens that — but the thing that actually corrupts is two writers loading the same file,
+each mutating, each saving back (a lost update). An atomic `os.replace` prevents a *torn* file, not
+a lost update. This supersedes the original plan's "keyed user-turn lock, heartbeat exempt."
 
-**Placed before the app channel on purpose.** Landing it while only one channel exists means B1
-arrives into an already-safe world — there is never a window in which two live channels share the
-unlocked write surfaces (`scheduled_events.json`, memory files, the confirmation store) with no
-lock. Cheaper to land the safety property first than to land the channel and the property together.
+**Audit (2026-07-24).** Of the three shared surfaces, two are already protected at the **resource**
+level, both covering the heartbeat:
+- **Memory files** — `tools/core/memory.py` `_WRITE_LOCK` (its comment already names the user turn
+  *and* the heartbeat as the racing writers, and a second channel as "just another thread here").
+- **Confirmation store** — `InMemoryConfirmationStore._lock` guards every `_pending` access.
+- **`scheduled_events.json`** — the lone gap: `_append_event`/`_remove_event` did an unguarded
+  load→mutate→save. And it's a **live** race today, not hypothetical: `heartbeat.py:201,211` removes
+  fired events in a worker thread while a user `manage_reminder` can append/delete concurrently.
 
-**Honest note on present-day exposure** (verified 2026-07-23, so the rationale is not oversold):
-with a single Telegram channel the overlap is *mostly latent*. PTB runs with `concurrent_updates`
-off (`host.py:56`) and serializes its update queue, so two fast text messages do **not** overlap
-despite `ask_jarvis` running in a worker thread (`main.py:64`). The only real single-channel
-overlap paths today are the media-group flush detach (`router.py:91`) and heartbeat↔user — and the
-lock leaves heartbeat exempt by design. So Stage B's real payoff is **cross-channel**; doing it
-first is a safety-ordering choice, not a fix for a bug firing today. The interleaved-write exposure
-is latent, not new — the second channel widens it.
+**The fix.** A module `threading.Lock` in `scheduling.py` held across the whole load→modify→save, so
+each writer reads fresh committed state (locking only the save would keep the lost update). Covers
+user turns, the heartbeat, and a future app channel *by construction* — a resource lock doesn't care
+which thread you are. **No turn-level lock, no heartbeat exemption, no chat waiting behind a tick.**
 
-*Verify:* a second user turn waits for the first to finish; a heartbeat tick still runs
-concurrently with a user turn (the behavior that must **not** regress). **Restart** + two fast
-messages reply in order, tick unaffected.
+**Why resource-level, not a turn lock (research-backed, 2026-07-24).** Both reference assistants —
+**Hermes** (`NousResearch/hermes-agent`) and **OpenClaw** (`openclaw/openclaw`) — do exactly this:
+shared writes are protected by **per-resource** locks held across the full read-modify-write with a
+fresh in-lock read; the background scheduler is **not** turn-serialized and **not** exempt — it
+funnels through the same resource locks. Both reserve turn-level serialization for *per-conversation
+ordering* only, which Jarvis's channels already provide (PTB serializes Telegram; the app router is
+single-consumer). OpenClaw's own review even flagged that *it* lacks a memory-file lock — a gap
+Jarvis's `_WRITE_LOCK` already closes.
+
+**Deferred (documented, not built).** Both references add a cross-process `flock`/DB lock because
+*multiple processes* touch their stores. Jarvis's `scheduled_events.json` is single-process (one
+service unit per instance root), so an in-process lock is correct and sufficient — the same
+reasoning `memory.py` documents. The escalation trigger is identical: only if the heartbeat is ever
+split into its own process. Tracked, together with the broader "one general store-writer primitive
+instead of three ad-hoc locks" cleanup, in **issue #48**.
+
+*Verify:* concurrent appends/removes lose no events (thread-stress test — done: 400 concurrent
+appends → 400, no lost updates); `manage_reminder` and the heartbeat fire-path behave unchanged
+single-threaded. **Restart** + a reminder round-trip.
 
 ---
 

--- a/docs/plans/app-plans/EXECUTION_PLAN.md
+++ b/docs/plans/app-plans/EXECUTION_PLAN.md
@@ -21,18 +21,17 @@ dependency**, not by whether it touches existing or new code.
 - [x] Per-channel origin-scoped confirmations — prompt + ack on origin, no broadcast (PR #45)
 - [x] Channel-agnosticism CI gate — path-isolation + `channel-agnostic`, required on `main` (PR #46)
 
-**Stage A — free cleanups** (no deps; byte-identical / dead-code)
-- [ ] A1 — delete the dead `supports_streaming` flag (`base.py:52`)
-- [ ] A2 — generalize the `telegram_` thread-prefix filter (`agent.py:262`) to a channel-prefix set
-- [ ] A2 — extend the CI channel-agnostic gate to cover `agent.py` (currently exempted)
-- [ ] **Restart staging** + Telegram regression (GATEWAY.md step 9)
+**Stage A — free cleanups** (no deps; byte-identical / dead-code) — ✅ merged PR #47
+- [x] A1 — deleted the dead `supports_streaming` flag (`base.py`)
+- [x] A2 — the heartbeat chat filter (`agent.py`) now excludes the heartbeat thread *by identity* (`HEARTBEAT_THREAD_ID`) instead of a hardcoded `telegram_` prefix — chose the exclude-list over a registry allow-list as it states the real intent
+- [x] A2 — CI gate: added check #4 (no channel name in `agent.py`); also flipped check #1 allow-list → deny-list so a new module can't silently escape
+- [ ] Restart staging + Telegram regression — *not run; changes byte-identical/tooling-only, so this is regression smoke only*
 
-**Stage B — shared-state write safety** (resource-level; heartbeat covered, not exempt)
+**Stage B — shared-state write safety** (resource-level; heartbeat covered, not exempt) — ✅ PR #49
 - [x] Audit: memory (`_WRITE_LOCK`) + confirmation store (`_lock`) already resource-locked; `scheduled_events.json` the lone gap
-- [ ] B-lock — `threading.Lock` around the `scheduled_events.json` read-modify-write (whole load→modify→save), covering user turns + heartbeat + future channels
-- [ ] Follow-up filed: unify the three ad-hoc locks behind one store-writer primitive (issue #48)
-- [ ] **Restart** + verify: concurrent reminder writes lose no events; heartbeat fire-path unchanged
-- [ ] **Restart** + verify: a second user turn waits for the first; a heartbeat tick still runs concurrently
+- [x] B-lock — `threading.Lock` around the `scheduled_events.json` read-modify-write (whole load→modify→save), covering user turns + heartbeat + future channels. Differential test: lock-free loses 280/400 updates, locked 0
+- [x] Follow-up filed: unify the three ad-hoc locks behind one store-writer primitive (issue #48)
+- [ ] Restart staging + a reminder round-trip — *regression smoke only (the lock is a no-op single-threaded); not run*
 
 **Stage C — app channel, text round-trip** (the deliverable)
 - [ ] **Owner:** `APP_HUB_URL`, `APP_HUB_BOT_TOKEN`, `APP_OWNER_USER_ID` in `staging.env` (staging-specific hub bot token)
@@ -57,7 +56,7 @@ dependency**, not by whether it touches existing or new code.
 
 Steps 2 and 3 were split by *what code is touched* — existing gateway/agent code vs. the new
 channel package. That is a good conceptual map and a misleading run order: taken linearly it
-front-loads scaffolding (the render seam, sibling-thread context, the concurrency lock) **ahead of
+front-loads scaffolding (the render seam, sibling-thread context, the write-safety work) **ahead of
 the app channel that would give that scaffolding a consumer to verify against.** Several of those
 slices have no live consumer until the phone grows a capability it does not have yet, so building
 them first means writing code whose "verify" step cannot run.
@@ -82,9 +81,10 @@ So **the app channel (B0/B1) is the next real deliverable**, with one safety ite
 deliberately pulled in front of it.
 
 ```
-A. free cleanups ─► B. concurrency lock ─► C. app channel (B0/B1) ─► D. rich rendering (open)
-   (no deps)           (before any 2nd         (the deliverable)        (design when a real
-                        channel is live)                                 consumer exists)
+A. free cleanups ─► B. write safety ─► C. app channel (B0/B1) ─► D. rich rendering (open)
+   (no deps)           (resource-level     (the deliverable)        (design when a real
+                        lock; heartbeat                              consumer exists)
+                        covered)
 ```
 
 ---
@@ -187,8 +187,9 @@ API onto the `Channel` ABC, the degraded-mode contract, and the pinned
     `_consume_loop` that runs turns one at a time. The re-poll is what acks the previous batch, so
     it must go out *while* a turn is still running — a serial `poll → turn → poll` collapses the
     app's ✓✓ into the reply and hides a class of concurrency bug.
-  - **One consumer, not a task per update** — task-per-update would overlap same-user turns, the
-    exact failure mode Stage B locks against.
+  - **One consumer, not a task per update** — task-per-update would overlap same-user turns within
+    the app channel; a single consumer keeps them ordered, the same per-conversation serialization
+    the other transports provide (distinct from Stage B, which is resource-level write safety).
   - **Fetch errors don't kill the fetcher** — a dropped poll logs, backs off, continues.
   - **Drain on SIGTERM** — cancel the fetcher (anything fetched is already queued — the ack was the
     poll), `queue.join()` to finish in-flight turns, then exit. Same graceful-shutdown work as #33.

--- a/tools/core/scheduling.py
+++ b/tools/core/scheduling.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import tempfile
+import threading
 import uuid
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
@@ -14,6 +15,18 @@ from tools.registry import tool_register
 ISRAEL_TZ = ZoneInfo("Asia/Jerusalem")
 
 EVENTS_PATH = os.path.join(config.DATA_DIR, "scheduling", "scheduled_events.json")
+
+# Serializes read-modify-write of scheduled_events.json. Concurrent writers are a
+# user turn (manage_reminder) and the heartbeat turn (fire path removes fired
+# events, heartbeat.py) — both asyncio.to_thread(...) in the SAME process, plus a
+# second channel would just add another thread here. The lock is held across the
+# whole load->modify->save so each writer reads fresh state (an atomic os.replace
+# alone prevents a torn file, not a lost update). INVARIANT — one writer process
+# per instance root — is held PROCEDURALLY (one service unit per root); a
+# cross-process fcntl.flock is deliberately not used and would only be needed if
+# the heartbeat were split into its own process. Mirrors tools/core/memory.py's
+# _WRITE_LOCK; a general store-writer primitive is tracked as a follow-up.
+_LOCK = threading.Lock()
 
 logger = logging.getLogger(__name__)
 
@@ -40,15 +53,17 @@ def _save_events(data: dict) -> None:
 
 
 def _append_event(event: dict) -> None:
-    data = _load_events()
-    data["events"].append(event)
-    _save_events(data)
+    with _LOCK:
+        data = _load_events()
+        data["events"].append(event)
+        _save_events(data)
 
 
 def _remove_event(event_id: str) -> None:
-    data = _load_events()
-    data["events"] = [e for e in data["events"] if e.get("id") != event_id]
-    _save_events(data)
+    with _LOCK:
+        data = _load_events()
+        data["events"] = [e for e in data["events"] if e.get("id") != event_id]
+        _save_events(data)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Stage B of the app-channel plan — but reframed from the plan's original "keyed user-turn lock, heartbeat exempt" to **resource-level write safety**, after an audit + benchmarking against Hermes and OpenClaw.

## The change
`tools/core/scheduling.py`: hold a module `threading.Lock` across the whole `load→modify→save` of `scheduled_events.json` in `_append_event`/`_remove_event`.

## Why
- `scheduled_events.json` was the one shared write surface with an **unguarded** read-modify-write. Memory (`_WRITE_LOCK`) and the confirmation store (`_lock`) were already resource-locked.
- It's a **live** race, not hypothetical: `heartbeat.py:201,211` removes fired events in a worker thread while a user `manage_reminder` can append/delete concurrently.
- Resource-level (not turn-level) covers the heartbeat **by construction**. Both Hermes and OpenClaw do exactly this — per-resource locks across the full RMW; background scheduler not exempt; turn-level serialization reserved for per-conversation ordering only (which our channel transports already provide).

## Verification
Differential concurrency test (8 threads × 50 appends):
- **lock-free (pre-slice): loses 280/400 updates**
- **locked (this PR): loses 0**

The lock is a no-op single-threaded, so the change is byte-identical on the happy path (regression risk ~nil by inspection).

## Follow-ups
- #48 — unify the three ad-hoc locks (`memory._WRITE_LOCK`, confirmation `_lock`, scheduling `_LOCK`) behind one store-writer primitive; the cross-process `flock` escalation would land there.

Also updates `EXECUTION_PLAN.md` Stage B to this framing.