### PR TITLE
Stage C: jarvis-app channel — text + media

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,3 +48,14 @@ ARBOX_WHITELABEL=your_gym_whitelabel_here   # gym's app brand identifier (reques
 ARBOX_BOX_ID=your_arbox_box_id_here
 ARBOX_LOCATIONS_BOX_ID=your_arbox_locations_box_id_here
 ARBOX_MEMBERSHIP_USER_ID=your_membership_user_id_here
+
+# --- jarvis-app channel (OPTIONAL — commented on purpose) ---
+# The app channel is built only when APP_HUB_URL is set, so these are
+# instance-specific, not universal: staging sets them; prod leaves them unset
+# until it opts into the app channel. They stay commented here so check_env.sh
+# (which requires every uncommented key on every instance) does not flag prod
+# as missing them. Use a STAGING-SPECIFIC bot token — the hub is one-bot-one-user,
+# and a shared token would make staging and prod fight over the update queue.
+# APP_HUB_URL=http://app-hub.local:8100         # base URL only, no trailing path
+# APP_HUB_BOT_TOKEN=your_staging_hub_bot_token_here
+# APP_OWNER_USER_ID=the_user_id_the_hub_knows_you_as

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,8 @@ Jarvis is a stateful, proactive AI assistant running as a systemd service on a h
 
 /app/jarvis_code/gateway/channels/telegram/media_cache/   # Channel-owned media blobs (gitignored;
                                                  #   absolute paths from gateway/channels/telegram/media_cache.py)
+/app/jarvis_code/gateway/channels/jarvis_app/media_cache/ # jarvis-app channel's own media blobs (gitignored;
+                                                 #   same channel-owned pattern, filenames embed the att_ id)
 
 /app/secrets/.env          # API keys and tokens — DO NOT READ THIS FILE
 ```

--- a/agent.py
+++ b/agent.py
@@ -351,10 +351,18 @@ def build_system_prompt(
     All files are read per turn (edits take effect next turn, no restart).
     """
     now = _dt.datetime.now(_dt.timezone.utc).astimezone(_ISRAEL_TZ)
-    envelope = (
-        f"[Current time: {now.strftime('%A, %Y-%m-%d %H:%M Israel time')}]\n"
-        f"[Active scope: {scope}]"
-    )
+    lines = [
+        f"[Current time: {now.strftime('%A, %Y-%m-%d %H:%M Israel time')}]",
+        f"[Active scope: {scope}]",
+    ]
+    # Origin channel, derived from the turn's thread-id prefix (the "<name>_<id>"
+    # convention every channel follows). A runtime value — no channel-name literal
+    # in this module — so it stays inform-only and channel-agnostic. Skipped for
+    # heartbeat, whose thread is not a channel.
+    thread_id = turn_context.current_thread_id()
+    if scope == "user" and thread_id:
+        lines.append(f"[Channel: {thread_id.split('_', 1)[0]}]")
+    envelope = "\n".join(lines)
     parts = [
         envelope,
         load_or_blank(_SOUL_PATH),

--- a/agent.py
+++ b/agent.py
@@ -611,6 +611,18 @@ def ask_jarvis(
                     if not media_type or not media_path:
                         continue
 
+                    # A media kind this build can't feed to the model (e.g. a
+                    # "file" — documents today, video later). Surface it as text so
+                    # the reply is honest rather than silently ignoring the
+                    # attachment, and skip reading bytes we have no way to use.
+                    if media_type not in ("image", "audio", "video"):
+                        label = f"{media_type} ({mime_type})" if mime_type else media_type
+                        content.append({
+                            "type": "text",
+                            "text": f"\n[Received a {label} attachment I can't read yet.]"
+                        })
+                        continue
+
                     abs_path = media_path
 
                     with open(abs_path, "rb") as f:

--- a/docs/architecture/GATEWAY.md
+++ b/docs/architecture/GATEWAY.md
@@ -377,6 +377,7 @@ Each channel owns its media cache module **and** directory. **Filenames encode t
 | Channel | Cache module | Cache directory |
 |---|---|---|
 | Telegram | `gateway/channels/telegram/media_cache.py` (`save`/`trim`) | `gateway/channels/telegram/media_cache/` |
+| jarvis-app | `gateway/channels/jarvis_app/media_cache.py` (`save`/`trim`) | `gateway/channels/jarvis_app/media_cache/` |
 | Email (future) | `gateway/email/media_cache.py` | `gateway/email/media_cache/` |
 
 `save(bytes, kind, file_id) -> absolute path`; the router imports and calls its own channel's `media_cache.save` directly (no injection). Retention: `trim()` deletes blobs older than 90 days (mtime) and runs once at module import (process start) — channel-owned, no cross-layer call. Cache dirs are gitignored (`gateway/channels/*/media_cache/`).

--- a/docs/plans/app-plans/EXECUTION_PLAN.md
+++ b/docs/plans/app-plans/EXECUTION_PLAN.md
@@ -1,6 +1,11 @@
 # App channel — execution plan
 
-**Status:** planning, uncommitted. **Date:** 2026-07-24.
+**Status (2026-07-24):** Stage C in progress on branch `feat/stage-c-app-channel`. **Landed &
+committed:** C1 (text round-trip, verified live), C2 (slash commands), C6 (channel identity in the
+prompt — #50 Phase 1), `/help` list fix — all pending a phone-verify restart. **Remaining:**
+C3/C4 (media — code buildable now against the frozen contract, but on-device verify is gated on the
+hub upgrading from `f1633277132cbedf` to the pinned `3b3a48f330f09a39`); then the closing regression
++ `code-review` + PR to main. **C5 deferred to B2** (see below). Stages A + B merged (#47, #49).
 **Single source of truth.** Absorbs and replaces the former `APP_CHANNEL_PLAN.md` (index),
 `02_MULTI_CHANNEL_SUPPORT.md`, and `03_APP_CHANNEL.md` (now in `archive/`). The only other live
 material is the app author's pinned handover under `jarvis-app/` — **imported verbatim, not ours
@@ -18,7 +23,7 @@ the hub**, so every step verifies as a real device round-trip, not a phone-less 
 media (in *and* out) now has a live consumer on both sides — `notifier.py` posters outbound, phone
 photos → Gemini inbound — so it joins Stage C as **isolated additive steps (C3/C4)** rather than
 deferring to Stage D. Stage C thus grows from "text round-trip" to **B0 (doc) + C1 text · C2 slash
-commands · C3 outbound media · C4 inbound media · C5 unsupported-capability notice**; rich *blocks*
+commands · C3 outbound media · C4 inbound media · C5 (unsupported-confirmation notice — since deferred → B2)**; rich *blocks*
 stay in Stage D (still no phone renderer).
 
 ---
@@ -55,16 +60,16 @@ stay in Stage D (still no phone renderer).
 - [x] C6 — origin channel injected into the system-prompt envelope (`[Channel: <name>]`, user scope, gate-safe) (commit `c5309f3`); Phase 1 of #50 (capability descriptors deferred there)
 - [ ] C3 — outbound media: `send_media`/`send_to_owner_media` upload (`POST /bot/v1/attachments`) then send `attachment_ids`. *Verify:* a media notification's poster shows on the phone. Consumer: `notifier.py`. **Verify gated on the hub upgrading to `3b3a48…`** (see note)
 - [ ] C4 — inbound media: router downloads `Message.attachments` → app `media_cache` → `InboundMessage.attachments` → Gemini. *Verify:* a photo from the phone gets described. **Verify gated on the hub upgrade** (see note)
-- [ ] C5 — confirmation "unsupported" notice (safe floor): app `UnsupportedConfirmation` returns a text signal to the agent → **plain refusal**, no destructive action, **no cross-channel handoff**. If the app ships confirmation support (upstream B2) before we reach C5, build the real prompt instead and skip this. *Verify:* a destructive ask from the app → graceful text refusal. **Verifiable against the current hub now**
+- [ ] C5 — **DEFERRED → B2** (decided 2026-07-24). An interim `UnsupportedConfirmation` is throwaway: the real `AppConfirmationUI` (upstream B2) replaces it, and its registration seam already exists. Interim behavior is **safe** — app-origin destructive tools fall back to the default channel's (Telegram) confirmation; nothing fires silently. Build the real UI when the app ships confirmation; don't build the placeholder.
 - [ ] **Restart staging** + Telegram regression + `code-review` skill, then PR `feat/stage-c-app-channel` → main
 
-> **Hub-skew note (2026-07-24):** the running hub still serves `contract_version = f1633277132cbedf`; the warn-on-mismatch fired as designed. C1/C2/C5 are unaffected (stable endpoints), but **C3/C4 verify waits for the hub to upgrade to the pinned `3b3a48f330f09a39`** (in progress, app-side). The contract is frozen, so C3/C4 are safe to *build* ahead of that; only the on-device verify is gated.
+> **Hub-skew note (2026-07-24):** the running hub still serves `contract_version = f1633277132cbedf`; the warn-on-mismatch fired as designed. C1/C2 are unaffected (stable endpoints), but **C3/C4 verify waits for the hub to upgrade to the pinned `3b3a48f330f09a39`** (in progress, app-side). The contract is frozen, so C3/C4 are safe to *build* ahead of that; only the on-device verify is gated.
 
 **Stage D — rich rendering / blocks** (design deliberately OPEN — decide when a consumer exists)
 - [ ] Design the outbound seam against the real app renderer (`OutboundReply` is *one candidate*, not committed)
 - [ ] 4b — sibling-thread chat injection (needs a second live user thread)
 - [ ] 4c — durable cross-channel context (open question — not app-specific)
-- [ ] Upstream deferrals: B2 app `AppConfirmationUI` (upgrades C5's unsupported notice to a real prompt) · B5 chips · B6 apps
+- [ ] Upstream deferrals: B2 app `AppConfirmationUI` — the app's real confirm/cancel UI (this is the successor to the deferred C5; until it lands, app-origin confirmations fall back to Telegram — safe) · B5 chips · B6 apps
 
 ---
 
@@ -103,8 +108,8 @@ loop's job, not Stage B's.
 ```
 A. free cleanups ─► B. write safety ─► C. app channel ──────────────► D. rich blocks (open)
    (no deps)           (resource-level     C1 text · C2 commands ·       (design when the
-                        lock; heartbeat     C3/C4 media · C5 unsupported   phone renders blocks)
-                        covered)            -capability notice)
+                        lock; heartbeat     C3/C4 media · C5 → B2         phone renders blocks)
+                        covered)
 ```
 
 ---
@@ -172,21 +177,23 @@ single-threaded. **Restart** + a reminder round-trip.
 
 ---
 
-## Stage C — the app channel (B0 doc + C1–C5)
+## Stage C — the app channel (B0 + C1–C4; C5 deferred → B2)
 
 The deliverable. Prereqs (generic factory, channel registry) are merged; the lock (Stage B) is in
 place; the block render seam is **not needed** (blocks stay in Stage D). Build order: **B0** (doc),
-then **C1** (text round-trip — the old "B1"), then the additive steps **C2** (slash commands),
-**C3/C4** (media, unlocked by the `3b3a48f330f09a39` attachments model + the connected phone), and
-**C5** (the unsupported-capability notice). C1 is the foundation; C2–C5 are independent of one
-another and may land in any order (or Stage C may stop after C1 to prove text first).
+then **C1** (text round-trip — the old "B1"), then the additive steps **C2** (slash commands) and
+**C3/C4** (media, unlocked by the `3b3a48f330f09a39` attachments model + the connected phone).
+**C5** (an interim unsupported-confirmation notice) was **deferred to B2** (see below). C1 is the
+foundation; the rest are independent and may land in any order (or Stage C may stop after C1 to
+prove text first).
 
 **Channel identity.** `Channel.name = "jarvis-app"`; thread ids `jarvis-app_<owner>`. The Python
 package is `gateway/channels/jarvis_app/` (packages cannot contain a hyphen — the one place dir and
 name differ). Env vars use the handover names `APP_HUB_URL` / `APP_HUB_BOT_TOKEN` /
 `APP_OWNER_USER_ID` (settled — see Decisions; already in `.env.example`).
 
-**Scope.** Text + media + the unsupported-capability notice. The hub also validates blocks, chips
+**Scope.** Text + media. (The interim unsupported-confirmation notice, C5, was deferred to B2; the
+app-origin confirmation gap is covered by a safe Telegram fallback meanwhile.) The hub also validates blocks, chips
 and apps, but the phone renders none of *those* yet, so their adapters still wait (Stage D) —
 building them now means code unexercisable when written. Attachments graduated *out* of that list:
 the contract now carries them and the phone renders them, so media has a live consumer both ways.
@@ -195,8 +202,8 @@ the contract now carries them and the phone renders them, so media has a live co
 do — in the channel package, not the architecture layer. `client.py` holds the pinned
 `contract_version = 3b3a48f330f09a39` as a constant and **warns** (never hard-fails) on mismatch —
 the hub reports it on `GET /v1/health`, and already 422s a bad payload, so this only gives a
-*silent* skew a voice. The adapter map (bot API → `Channel` ABC), the poll-loop ack semantics,
-degraded mode, and the unsupported-capability pattern (C5) are documented in the package's module
+*silent* skew a voice. The adapter map (bot API → `Channel` ABC), the poll-loop ack semantics, and
+degraded mode are documented in the package's module
 docstrings (`client.py` / `channel.py` / `router.py`), mirroring how `host.py` / `channel.py`
 self-document Telegram and how `fake_agent.py` documents its loop. `GATEWAY.md` stays
 **channel-agnostic** — it is *not* the home for app specifics; its channel-agnostic registry tables
@@ -232,7 +239,8 @@ lands (C4), a byproduct rather than a doc-writing phase.
 Each inbound update becomes an `InboundMessage(thread_id=f"jarvis-app_{owner}")` and flows through
 the existing shared `on_message` — slash commands and history logging work with no app-specific
 code (already channel-agnostic). Confirmations are the one interaction that needs an app-specific
-piece, because the hub has no confirm/cancel widget the phone renders yet — that is C5. The app
+piece, because the hub has no confirm/cancel widget the phone renders yet — deferred to B2 (interim:
+app-origin confirmations fall back to Telegram, safe). The app
 wire carries no per-message user id (the bot token scopes the single owner), so the router stamps
 the configured owner's thread id and passes benign placeholders for the `InboundMessage`
 `user_id`/`chat_id` ints — nothing downstream reads them (verified: only Telegram's own routing does).
@@ -254,7 +262,7 @@ carries on), so it never blocks C1. Isolated step with its own verify (the slash
 **C3 — outbound media.** The attachments model makes `send_media`/`send_to_owner_media` real: a
 two-step **upload-then-reference** — `POST /bot/v1/attachments` returns an `att_…` id, then
 `send_message(attachment_ids=[…], text=caption)`. Kinds are `image|audio|file`; `notifier.py`'s
-posters are `image`, the live consumer. An unrepresentable kind degrades per C5 rather than raising.
+posters are `image`, the live consumer. An unrepresentable kind raises `NotImplementedError`, which the Outbox reports as a failed send (a graceful caption fallback can come with the capability work in #50).
 *Verify:* trigger a media notification → the poster renders on the phone.
 
 **C4 — inbound media.** `Message.attachments[]` on an inbound update → the router downloads each via
@@ -263,20 +271,19 @@ same channel-owns-storage rule as Telegram's) → `InboundMessage.attachments=[{
 source}]`, which the existing `process_inbound_message` already forwards to Gemini. Mirrors
 Telegram's `_download_and_store`. *Verify:* send a photo from the phone → Jarvis describes it.
 
-**C5 — the unsupported-capability notice.** The hub has no confirm/cancel widget the phone renders
-yet (real `AppConfirmationUI` is Stage D / B2), but destructive tools must stay safe on app turns.
-An app-scoped `UnsupportedConfirmation.request_confirmation_sync(...)` **does not** schedule a
-prompt and **does not** run `action_fn` (nothing destructive fires); it returns a status string
-reporting the gap *to the agent*, which then phrases a **plain refusal** in its own voice — that the
-action needs a confirmation the app can't show yet, so it was not taken. **No cross-channel handoff**
-(we deliberately do *not* bounce the prompt to Telegram) and **no silent drop**. Registered
-per-channel on the confirmation axis. This is the first concrete instance of a **general pattern**:
-*a channel that can't render a rich interaction reports the gap back to the agent as a text signal;
-the agent renders the human explanation.* We build only this one case — not a capability-declaration
-framework (over-engineering at N=2 channels, per Decisions). **If the app gains confirmation support
-(upstream B2) before we reach C5, we build the real `AppConfirmationUI` instead and skip the refusal
-— C5 is the safe floor, not a goal.** *Verify:* ask Jarvis a destructive action from the app →
-graceful text refusal, action not taken.
+**C5 — the unsupported-capability notice — DEFERRED to B2 (decided 2026-07-24).** Building an
+app-scoped `UnsupportedConfirmation` now is throwaway: the real `AppConfirmationUI` (upstream B2)
+replaces it the moment the app can render a confirm/cancel widget, and the per-channel registration
+seam it would plug into (`register_confirmation` / `_confirmation_stores` in the factory) already
+exists. So we skip the placeholder and build the real UI when the app ships confirmation.
+
+**Interim behavior (safe, documented).** Until B2, no confirmation store is registered for the app,
+so `get_confirmation()` on an app-origin turn falls back to the **default channel's store
+(Telegram)**: a destructive tool triggered from the app renders its confirm/cancel prompt on
+Telegram, and the action fires **only** if the owner taps Confirm there — nothing destructive
+happens silently. It is a cross-device wrinkle (a dead-end if the owner isn't on Telegram), not a
+hazard. The general principle still stands and is realized by B2: a channel that can't render a rich
+interaction has the gap surfaced to the agent, which phrases the human explanation.
 
 **Owner prereq (done).** `APP_HUB_URL`, `APP_HUB_BOT_TOKEN`, `APP_OWNER_USER_ID` are in staging's
 `secrets/.env` with a **staging-specific hub bot token** — the hub is one-bot-one-user, so a
@@ -309,10 +316,10 @@ defaulting to `send(text)` is **one candidate** — not a committed choice. Deci
 Everything whose only consumer is a phone capability lands here, on the same "has a real consumer
 now" gate:
 
-- **Media kind fallback** — *folded into Stage C.* C3 makes `image` real; an outbound kind the app
-  can't represent degrades via the C5 unsupported-capability pattern (caption or a `[kind]`
-  placeholder, the convention `Outbox._log` uses at `outbox.py:115`) rather than raising. No longer
-  a standalone Stage D item.
+- **Media kind fallback.** C3 makes `image` real; an outbound kind the app can't represent raises
+  `NotImplementedError` (the Outbox reports a failed send). A graceful caption / `[kind]`-placeholder
+  degradation (the convention `Outbox._log` uses at `outbox.py:115`) can land with the capability
+  work (#50).
 - **4b — sibling-thread chat injection.** User-scope prompts additionally inject today's chat from
   the *other* user thread (bounded by the same start-of-Israel-day window and per-entry cap as the
   existing slices). Needs a second *live* user thread to be meaningful — telegram↔app is the same
@@ -321,8 +328,8 @@ now" gate:
   sibling chat; beyond that, continuity depends on the daily log or a memory write. Not
   app-specific — the same time-bound governs heartbeat↔user today — so treat it on its own terms,
   alongside `../CONTEXT_HANDLING_PLAN.md` (a wider window costs tokens).
-- **Upstream honest-boundary deferrals:** B2 app `AppConfirmationUI` (upgrades C5's unsupported
-  notice to a real prompt), B5 streaming chips, B6 apps. Each is real and specified in
+- **Upstream honest-boundary deferrals:** B2 app `AppConfirmationUI` (the confirm/cancel UI; the
+  successor to the deferred C5), B5 streaming chips, B6 apps. Each is real and specified in
   `jarvis-app/original_app_plan.md`; none is end-to-end testable today. (B1.6 media inbound
   graduated to **Stage C4** — the phone sends attachments now.)
 
@@ -397,7 +404,7 @@ channels. **Deferred cleanups** (tracked, not blocking): loop-bridge misfiled in
 renders: `blocks` have no renderer or action path (B2/B4 wait), chips fan out with no consumer (B5
 waits), no apps endpoints yet (B6 waits). **Attachments crossed the boundary on 2026-07-24** — the
 contract added them and the phone renders them, so media is now buildable/verifiable (Stage C3/C4).
-**Buildable and verifiable now: B0, C1–C5** (this plan's Stage C), plus B1.5/B3 which are folded
+**Buildable and verifiable now: B0, C1–C4** (C5 deferred → B2; this plan's Stage C), plus B1.5/B3 which are folded
 into the landed multi-channel work and Stage D.
 
 **Re-validation duty.** The handover cannot see this repo, so it asks that every agent-internal

--- a/docs/plans/app-plans/EXECUTION_PLAN.md
+++ b/docs/plans/app-plans/EXECUTION_PLAN.md
@@ -47,14 +47,18 @@ stay in Stage D (still no phone renderer).
 **Stage C — app channel** (the deliverable; contract `3b3a48f330f09a39`, phone connected for real round-trip)
 - [x] **Owner:** `APP_HUB_URL`, `APP_HUB_BOT_TOKEN`, `APP_OWNER_USER_ID` in staging `secrets/.env` (staging-specific hub bot token); documented (commented) in `.env.example`
 - [x] Hub reachable from staging + contract pin re-validated via `GET /v1/health` (returned `3b3a48f330f09a39`)
-- [ ] Re-validate every agent-internal reference against current code + `jarvis-app/contract.md` before build
-- [ ] B0 — **no new doc.** Record `contract_version = 3b3a48f330f09a39` as a `HubClient` constant (warn-on-mismatch); app specifics (adapter map, poll-loop ack, degraded mode, unsupported-capability pattern) live in `gateway/channels/jarvis_app/` module docstrings, same as Telegram's. `GATEWAY.md` stays channel-agnostic — touched only for channel-agnostic registry rows (e.g. the media-cache table) as the step adding that artifact lands (C4)
-- [ ] C1 — text round-trip: `client.py` (`HubClient`) · `channel.py` (`JarvisAppChannel`, text) · `router.py` (fetch loop + single consumer) · degraded mode (log once, back off 1→60s) · SIGTERM drain (shared with #33) · `build_jarvis_app_stack()` + `main.py` gate on `APP_HUB_URL`. *Verify:* type on the phone → reply on the phone + a `jarvis-app_<owner>` row.
-- [ ] C2 — slash commands declared to the hub (`declare_commands`, non-fatal). *Verify:* slash menu on the phone.
-- [ ] C3 — outbound media: `send_media`/`send_to_owner_media` upload (`POST /bot/v1/attachments`) then send `attachment_ids`. *Verify:* a media notification's poster shows on the phone. Consumer: `notifier.py`.
-- [ ] C4 — inbound media: router downloads `Message.attachments` → app `media_cache` → `InboundMessage.attachments` → Gemini. *Verify:* a photo from the phone gets described.
-- [ ] C5 — confirmation "unsupported" notice (safe floor): app `UnsupportedConfirmation` returns a text signal to the agent → **plain refusal**, no destructive action, **no cross-channel handoff**. If the app ships confirmation support (upstream B2) before we reach C5, build the real prompt instead and skip this. *Verify:* a destructive ask from the app → graceful text refusal.
-- [ ] **Restart staging** + Telegram regression + `code-review` skill
+- [x] Re-validate agent-internal references against current code + `jarvis-app/contract.md` (done during the C1 build — Channel ABC, factory, `main`, Outbox, poll-loop reference all re-checked)
+- [x] B0 — **no new doc.** Pin `3b3a48f330f09a39` recorded as the `HubClient` constant (warn-on-mismatch); app specifics + the Telegram-vs-app differences write-up live in `gateway/channels/jarvis_app/` module docstrings. `GATEWAY.md` untouched (stays channel-agnostic); its media-cache row lands with C4
+- [x] C1 — text round-trip (commit `3f4e7b0`). **Verified live on the phone** — `jarvis-app_<owner>` round-trip in `chat_history.jsonl`, both channels up, no crash, no degraded backoff
+- [x] C2 — slash commands declared to the hub (`declare_commands`, non-fatal) (commit `22b463a`). *Pending phone verify:* the `declared 8 slash commands…` log line + the app slash menu
+- [x] Commands polish — `/help` reformatted as a markdown list so it renders on all channels (bare-newline list collapsed on the app's CommonMark renderer) (commit `899fe67`)
+- [x] C6 — origin channel injected into the system-prompt envelope (`[Channel: <name>]`, user scope, gate-safe) (commit `c5309f3`); Phase 1 of #50 (capability descriptors deferred there)
+- [ ] C3 — outbound media: `send_media`/`send_to_owner_media` upload (`POST /bot/v1/attachments`) then send `attachment_ids`. *Verify:* a media notification's poster shows on the phone. Consumer: `notifier.py`. **Verify gated on the hub upgrading to `3b3a48…`** (see note)
+- [ ] C4 — inbound media: router downloads `Message.attachments` → app `media_cache` → `InboundMessage.attachments` → Gemini. *Verify:* a photo from the phone gets described. **Verify gated on the hub upgrade** (see note)
+- [ ] C5 — confirmation "unsupported" notice (safe floor): app `UnsupportedConfirmation` returns a text signal to the agent → **plain refusal**, no destructive action, **no cross-channel handoff**. If the app ships confirmation support (upstream B2) before we reach C5, build the real prompt instead and skip this. *Verify:* a destructive ask from the app → graceful text refusal. **Verifiable against the current hub now**
+- [ ] **Restart staging** + Telegram regression + `code-review` skill, then PR `feat/stage-c-app-channel` → main
+
+> **Hub-skew note (2026-07-24):** the running hub still serves `contract_version = f1633277132cbedf`; the warn-on-mismatch fired as designed. C1/C2/C5 are unaffected (stable endpoints), but **C3/C4 verify waits for the hub to upgrade to the pinned `3b3a48f330f09a39`** (in progress, app-side). The contract is frozen, so C3/C4 are safe to *build* ahead of that; only the on-device verify is gated.
 
 **Stage D — rich rendering / blocks** (design deliberately OPEN — decide when a consumer exists)
 - [ ] Design the outbound seam against the real app renderer (`OutboundReply` is *one candidate*, not committed)

--- a/docs/plans/app-plans/EXECUTION_PLAN.md
+++ b/docs/plans/app-plans/EXECUTION_PLAN.md
@@ -1,6 +1,6 @@
 # App channel — execution plan
 
-**Status:** planning, uncommitted. **Date:** 2026-07-23.
+**Status:** planning, uncommitted. **Date:** 2026-07-24.
 **Single source of truth.** Absorbs and replaces the former `APP_CHANNEL_PLAN.md` (index),
 `02_MULTI_CHANNEL_SUPPORT.md`, and `03_APP_CHANNEL.md` (now in `archive/`). The only other live
 material is the app author's pinned handover under `jarvis-app/` — **imported verbatim, not ours
@@ -9,6 +9,17 @@ to edit.**
 **Goal:** ship the custom app as a second channel beside Telegram, without the Telegram loop — the
 owner's day-to-day assistant — ever being the test surface. Work is sequenced by **real
 dependency**, not by whether it touches existing or new code.
+
+**Revision 2026-07-24.** Two facts changed Stage C since the first draft. (1) The hub contract
+advanced to `contract_version = 3b3a48f330f09a39` (from `f1633277132cbedf`), adding an
+**attachments** model — upload-then-reference (`POST /bot/v1/attachments` → `attachment_ids`),
+kinds `image|audio|file`, and `Message.attachments[]` inbound. (2) The **phone is now connected to
+the hub**, so every step verifies as a real device round-trip, not a phone-less curl. Consequently
+media (in *and* out) now has a live consumer on both sides — `notifier.py` posters outbound, phone
+photos → Gemini inbound — so it joins Stage C as **isolated additive steps (C3/C4)** rather than
+deferring to Stage D. Stage C thus grows from "text round-trip" to **B0 (doc) + C1 text · C2 slash
+commands · C3 outbound media · C4 inbound media · C5 unsupported-capability notice**; rich *blocks*
+stay in Stage D (still no phone renderer).
 
 ---
 
@@ -25,30 +36,31 @@ dependency**, not by whether it touches existing or new code.
 - [x] A1 — deleted the dead `supports_streaming` flag (`base.py`)
 - [x] A2 — the heartbeat chat filter (`agent.py`) now excludes the heartbeat thread *by identity* (`HEARTBEAT_THREAD_ID`) instead of a hardcoded `telegram_` prefix — chose the exclude-list over a registry allow-list as it states the real intent
 - [x] A2 — CI gate: added check #4 (no channel name in `agent.py`); also flipped check #1 allow-list → deny-list so a new module can't silently escape
-- [ ] Restart staging + Telegram regression — *not run; changes byte-identical/tooling-only, so this is regression smoke only*
+- [x] Restart staging + Telegram regression — verified fine (byte-identical/tooling-only)
 
 **Stage B — shared-state write safety** (resource-level; heartbeat covered, not exempt) — ✅ PR #49
 - [x] Audit: memory (`_WRITE_LOCK`) + confirmation store (`_lock`) already resource-locked; `scheduled_events.json` the lone gap
 - [x] B-lock — `threading.Lock` around the `scheduled_events.json` read-modify-write (whole load→modify→save), covering user turns + heartbeat + future channels. Differential test: lock-free loses 280/400 updates, locked 0
 - [x] Follow-up filed: unify the three ad-hoc locks behind one store-writer primitive (issue #48)
-- [ ] Restart staging + a reminder round-trip — *regression smoke only (the lock is a no-op single-threaded); not run*
+- [x] Restart staging + a reminder round-trip — verified fine (lock is a no-op single-threaded)
 
-**Stage C — app channel, text round-trip** (the deliverable)
-- [ ] **Owner:** `APP_HUB_URL`, `APP_HUB_BOT_TOKEN`, `APP_OWNER_USER_ID` in `staging.env` (staging-specific hub bot token)
-- [ ] Re-validate every agent-internal reference against current code + `jarvis-app/contract.md` before B1
-- [ ] B0 — `docs/architecture/APP_CHANNEL.md` (adapter map, degraded mode, pin `f1633277132cbedf`) + GATEWAY.md channel tables
-- [ ] B1 — `client.py` (`HubClient`) · `channel.py` (`JarvisAppChannel`, text-only sends) · `router.py` (fetch loop + single consumer)
-- [ ] B1 — hub-down: log once, back off 1→60s; SIGTERM drain (shared with #33)
-- [ ] B1 — `build_jarvis_app_stack()` in factory; `main.py` builds it **only if `APP_HUB_URL` is set**
-- [ ] **Start staging with `APP_HUB_URL` set**; curl the hub as "the app", confirm a reply + a `jarvis-app_<owner>` row in `chat_history.jsonl`
-- [ ] **Restart staging** + Telegram regression
+**Stage C — app channel** (the deliverable; contract `3b3a48f330f09a39`, phone connected for real round-trip)
+- [x] **Owner:** `APP_HUB_URL`, `APP_HUB_BOT_TOKEN`, `APP_OWNER_USER_ID` in staging `secrets/.env` (staging-specific hub bot token); documented (commented) in `.env.example`
+- [x] Hub reachable from staging + contract pin re-validated via `GET /v1/health` (returned `3b3a48f330f09a39`)
+- [ ] Re-validate every agent-internal reference against current code + `jarvis-app/contract.md` before build
+- [ ] B0 — **no new doc.** Record `contract_version = 3b3a48f330f09a39` as a `HubClient` constant (warn-on-mismatch); app specifics (adapter map, poll-loop ack, degraded mode, unsupported-capability pattern) live in `gateway/channels/jarvis_app/` module docstrings, same as Telegram's. `GATEWAY.md` stays channel-agnostic — touched only for channel-agnostic registry rows (e.g. the media-cache table) as the step adding that artifact lands (C4)
+- [ ] C1 — text round-trip: `client.py` (`HubClient`) · `channel.py` (`JarvisAppChannel`, text) · `router.py` (fetch loop + single consumer) · degraded mode (log once, back off 1→60s) · SIGTERM drain (shared with #33) · `build_jarvis_app_stack()` + `main.py` gate on `APP_HUB_URL`. *Verify:* type on the phone → reply on the phone + a `jarvis-app_<owner>` row.
+- [ ] C2 — slash commands declared to the hub (`declare_commands`, non-fatal). *Verify:* slash menu on the phone.
+- [ ] C3 — outbound media: `send_media`/`send_to_owner_media` upload (`POST /bot/v1/attachments`) then send `attachment_ids`. *Verify:* a media notification's poster shows on the phone. Consumer: `notifier.py`.
+- [ ] C4 — inbound media: router downloads `Message.attachments` → app `media_cache` → `InboundMessage.attachments` → Gemini. *Verify:* a photo from the phone gets described.
+- [ ] C5 — confirmation "unsupported" notice (safe floor): app `UnsupportedConfirmation` returns a text signal to the agent → **plain refusal**, no destructive action, **no cross-channel handoff**. If the app ships confirmation support (upstream B2) before we reach C5, build the real prompt instead and skip this. *Verify:* a destructive ask from the app → graceful text refusal.
+- [ ] **Restart staging** + Telegram regression + `code-review` skill
 
 **Stage D — rich rendering / blocks** (design deliberately OPEN — decide when a consumer exists)
 - [ ] Design the outbound seam against the real app renderer (`OutboundReply` is *one candidate*, not committed)
-- [ ] 3c — media→caption fallback (fold in with the seam it hardens)
 - [ ] 4b — sibling-thread chat injection (needs a second live user thread)
 - [ ] 4c — durable cross-channel context (open question — not app-specific)
-- [ ] Upstream deferrals: B1.6 media inbound · B2 app `AppConfirmationUI` · B5 chips · B6 apps
+- [ ] Upstream deferrals: B2 app `AppConfirmationUI` (upgrades C5's unsupported notice to a real prompt) · B5 chips · B6 apps
 
 ---
 
@@ -64,27 +76,31 @@ them first means writing code whose "verify" step cannot run.
 Two dependencies the old step docs asserted **do not hold on inspection** (verified against current
 code 2026-07-23):
 
-1. **The render seam does *not* gate B1.** B1 is text-only: `JarvisAppChannel.send(chat_id, text)`
-   implements the *existing* abstract `send(str)`, and the reply rides the existing
-   `on_message → return str → channel.send(str)` path. B1 adds **zero new send call-sites**, so the
+1. **The *block* render seam does *not* gate C1.** C1's text reply rides the existing
+   `on_message → return str → channel.send(str)` path and adds **zero new send call-sites**, so the
    "write against the seam to avoid a second edit at every send site" concern is empty.
    `OutboundReply` / `send_rich` matter only when something *emits blocks* — upstream B4, deferred
-   behind the phone renderer regardless.
-2. **Write safety is a small resource-level fix, not a turn lock that gates B1.** The original
-   plan imagined a keyed lock serializing whole user turns (heartbeat exempt). The audit + the
-   Hermes/OpenClaw research (Stage B) overturned that: the hazard is interleaved read-modify-write
+   behind the phone renderer regardless. Media (C3) does add send work, but it rides the *existing*
+   `send_media(kind, bytes)` primitive and the attachment endpoints — not the block seam — so the
+   point stands for the whole of Stage C.
+2. **Write safety is a small resource-level fix, not a turn lock that gates the channel.** The
+   original plan imagined a keyed lock serializing whole user turns (heartbeat exempt). The audit +
+   the Hermes/OpenClaw research (Stage B) overturned that: the hazard is interleaved read-modify-write
    of shared state, closed by per-resource locks the heartbeat also passes through — not by
-   serializing turns. B1 needs nothing from it; per-conversation ordering is already handled by the
-   channel transports.
+   serializing turns. C1 needs nothing from it; per-conversation ordering is already handled by the
+   channel transports (the single-consumer loop).
 
-So **the app channel (B0/B1) is the next real deliverable**, with one safety item (Stage B)
-deliberately pulled in front of it.
+So **the app channel is the next real deliverable**, with one safety item (Stage B) deliberately
+pulled in front of it. Neither dependency point weakens with the contract update: media (C3/C4)
+rides the *attachment* endpoints and the existing `send_media` primitive, not the block seam, so
+the render seam still does not gate it; and per-conversation ordering is still the single-consumer
+loop's job, not Stage B's.
 
 ```
-A. free cleanups ─► B. write safety ─► C. app channel (B0/B1) ─► D. rich rendering (open)
-   (no deps)           (resource-level     (the deliverable)        (design when a real
-                        lock; heartbeat                              consumer exists)
-                        covered)
+A. free cleanups ─► B. write safety ─► C. app channel ──────────────► D. rich blocks (open)
+   (no deps)           (resource-level     C1 text · C2 commands ·       (design when the
+                        lock; heartbeat     C3/C4 media · C5 unsupported   phone renders blocks)
+                        covered)            -capability notice)
 ```
 
 ---
@@ -152,34 +168,49 @@ single-threaded. **Restart** + a reminder round-trip.
 
 ---
 
-## Stage C — the app channel, text round-trip (B0 + B1)
+## Stage C — the app channel (B0 doc + C1–C5)
 
 The deliverable. Prereqs (generic factory, channel registry) are merged; the lock (Stage B) is in
-place; the render seam is **not needed** (text-only).
+place; the block render seam is **not needed** (blocks stay in Stage D). Build order: **B0** (doc),
+then **C1** (text round-trip — the old "B1"), then the additive steps **C2** (slash commands),
+**C3/C4** (media, unlocked by the `3b3a48f330f09a39` attachments model + the connected phone), and
+**C5** (the unsupported-capability notice). C1 is the foundation; C2–C5 are independent of one
+another and may land in any order (or Stage C may stop after C1 to prove text first).
 
 **Channel identity.** `Channel.name = "jarvis-app"`; thread ids `jarvis-app_<owner>`. The Python
 package is `gateway/channels/jarvis_app/` (packages cannot contain a hyphen — the one place dir and
-name differ). Env vars keep the handover names (`APP_HUB_URL`, `APP_HUB_BOT_TOKEN`,
-`APP_OWNER_USER_ID`) unless we prefix them `JARVIS_APP_*` — small open choice below.
+name differ). Env vars use the handover names `APP_HUB_URL` / `APP_HUB_BOT_TOKEN` /
+`APP_OWNER_USER_ID` (settled — see Decisions; already in `.env.example`).
 
-**Scope is B0 + B1 only.** The hub validates blocks, chips, attachments and apps, but the phone
-renders none of them yet; building those adapters now means code unexercisable when written.
+**Scope.** Text + media + the unsupported-capability notice. The hub also validates blocks, chips
+and apps, but the phone renders none of *those* yet, so their adapters still wait (Stage D) —
+building them now means code unexercisable when written. Attachments graduated *out* of that list:
+the contract now carries them and the phone renders them, so media has a live consumer both ways.
 
-**B0 — contract pin + doc.** New `docs/architecture/APP_CHANNEL.md`: how the adapter maps the bot
-API onto the `Channel` ABC, the degraded-mode contract, and the pinned
-`contract_version = f1633277132cbedf` (the hub reports it on `GET /v1/health`, so `HubClient`
-**warns**, never hard-fails, on mismatch — the hub already 422s a bad payload, so this only gives a
-*silent* skew a voice). Update GATEWAY.md's channel tables to list the app beside Telegram.
+**B0 — contract pin + in-code docs (no new doc file).** The app's specifics live where Telegram's
+do — in the channel package, not the architecture layer. `client.py` holds the pinned
+`contract_version = 3b3a48f330f09a39` as a constant and **warns** (never hard-fails) on mismatch —
+the hub reports it on `GET /v1/health`, and already 422s a bad payload, so this only gives a
+*silent* skew a voice. The adapter map (bot API → `Channel` ABC), the poll-loop ack semantics,
+degraded mode, and the unsupported-capability pattern (C5) are documented in the package's module
+docstrings (`client.py` / `channel.py` / `router.py`), mirroring how `host.py` / `channel.py`
+self-document Telegram and how `fake_agent.py` documents its loop. `GATEWAY.md` stays
+**channel-agnostic** — it is *not* the home for app specifics; its channel-agnostic registry tables
+(e.g. the per-channel media-cache table) pick up an app row when the step that adds that artifact
+lands (C4), a byproduct rather than a doc-writing phase.
 
-**B1 — text round-trip.** New `gateway/channels/jarvis_app/`, three modules:
+**C1 — text round-trip.** New `gateway/channels/jarvis_app/`, three modules:
 
-- **`client.py` — `HubClient` (httpx).** `get_updates(offset, timeout)`, `send_message(body)`,
-  `set_commands(...)`; raises `HubUnavailable` on 5xx so the router can enter degraded mode.
-  Bearer-token auth from `APP_HUB_BOT_TOKEN`. The wider surface (attachments, events, PATCH) waits
-  for the phases that use it.
+- **`client.py` — `HubClient` (httpx).** C1 needs `get_updates(offset, timeout)` and
+  `send_message(body)`; raises `HubUnavailable` on 5xx/network error so the router can enter
+  degraded mode. Bearer-token auth from `APP_HUB_BOT_TOKEN`. Later steps grow it in place:
+  `declare_commands` (C2), `upload_attachment`/`download_attachment` (C3/C4). Events/PATCH (chips,
+  block resolution) wait for Stage D.
 - **`channel.py` — `JarvisAppChannel(Channel)`.** `name = "jarvis-app"`,
-  `owner_thread_id = f"jarvis-app_{owner}"`. Implements the abstract **string/bytes** sends by
-  POSTing to the hub. **No `OutboundReply` here** — its rich-render story is Stage D.
+  `owner_thread_id = f"jarvis-app_{owner}"`. C1 implements the **text** sends by POSTing to the hub;
+  `send_media`/`send_to_owner_media` raise `NotImplementedError` per the ABC (the `Outbox` already
+  reports that as a failed send, no crash) until C3 makes them real uploads. **No `OutboundReply`
+  here** — the rich-block render story is Stage D.
 - **`router.py` — the poll loop.** The load-bearing part; shape is not negotiable —
   `jarvis-app/fake_agent.py:366-417` is the working reference:
   - **Two tasks over a queue.** A `_fetch_loop` that long-polls and, per update, advances the
@@ -195,11 +226,15 @@ API onto the `Channel` ABC, the degraded-mode contract, and the pinned
     poll), `queue.join()` to finish in-flight turns, then exit. Same graceful-shutdown work as #33.
 
 Each inbound update becomes an `InboundMessage(thread_id=f"jarvis-app_{owner}")` and flows through
-the existing shared `on_message` — slash commands, history logging, and confirmations work with no
-app-specific code (already channel-agnostic).
+the existing shared `on_message` — slash commands and history logging work with no app-specific
+code (already channel-agnostic). Confirmations are the one interaction that needs an app-specific
+piece, because the hub has no confirm/cancel widget the phone renders yet — that is C5. The app
+wire carries no per-message user id (the bot token scopes the single owner), so the router stamps
+the configured owner's thread id and passes benign placeholders for the `InboundMessage`
+`user_id`/`chat_id` ints — nothing downstream reads them (verified: only Telegram's own routing does).
 
 **Degraded mode.** Hub unreachable → log **once** (not per failed poll) and back off 1→60s forever.
-Telegram and heartbeat unaffected; the agent never crashes on a missing hub. This is what makes B1
+Telegram and heartbeat unaffected; the agent never crashes on a missing hub. This is what makes C1
 safe to carry in prod behind the `APP_HUB_URL` gate before the channel is "done".
 
 **Wiring.** `build_jarvis_app_stack()` joins the factory beside the Telegram builder (both thin
@@ -207,13 +242,47 @@ wrappers over `build_stack`). `main.py` builds the app stack **only when `APP_HU
 starts its router with `create_task(router.run())` — so prod, with the var unset, constructs
 nothing and is byte-identical to today.
 
-**Owner prereq.** Add `APP_HUB_URL`, `APP_HUB_BOT_TOKEN`, `APP_OWNER_USER_ID` to `staging.env`,
-with a **staging-specific hub bot token** — the hub is one-bot-one-user, so once the channel is
-live in prod a staging agent polling the same hub would fight over updates.
+**C2 — slash commands.** `HubClient.declare_commands` posts the gateway's shared command list
+(`gateway/commands`) to `POST /bot/v1/commands` at router startup, mirroring Telegram's
+`register_command_menu`. Non-fatal: a hub that's down at startup just skips it (the degraded loop
+carries on), so it never blocks C1. Isolated step with its own verify (the slash menu on the phone).
 
-*Verify (staging):* with `APP_HUB_URL` pointed at the hub, curl the hub's client API as "the app";
-confirm the live agent long-polls, replies, and writes a `jarvis-app_<owner>` row to
-`chat_history.jsonl` — a phone-less end-to-end test. Then the Telegram regression, unchanged.
+**C3 — outbound media.** The attachments model makes `send_media`/`send_to_owner_media` real: a
+two-step **upload-then-reference** — `POST /bot/v1/attachments` returns an `att_…` id, then
+`send_message(attachment_ids=[…], text=caption)`. Kinds are `image|audio|file`; `notifier.py`'s
+posters are `image`, the live consumer. An unrepresentable kind degrades per C5 rather than raising.
+*Verify:* trigger a media notification → the poster renders on the phone.
+
+**C4 — inbound media.** `Message.attachments[]` on an inbound update → the router downloads each via
+`GET /bot/v1/attachments/{id}` → saves to an **app-owned `media_cache.py`** (absolute paths, the
+same channel-owns-storage rule as Telegram's) → `InboundMessage.attachments=[{kind, path, mime_type,
+source}]`, which the existing `process_inbound_message` already forwards to Gemini. Mirrors
+Telegram's `_download_and_store`. *Verify:* send a photo from the phone → Jarvis describes it.
+
+**C5 — the unsupported-capability notice.** The hub has no confirm/cancel widget the phone renders
+yet (real `AppConfirmationUI` is Stage D / B2), but destructive tools must stay safe on app turns.
+An app-scoped `UnsupportedConfirmation.request_confirmation_sync(...)` **does not** schedule a
+prompt and **does not** run `action_fn` (nothing destructive fires); it returns a status string
+reporting the gap *to the agent*, which then phrases a **plain refusal** in its own voice — that the
+action needs a confirmation the app can't show yet, so it was not taken. **No cross-channel handoff**
+(we deliberately do *not* bounce the prompt to Telegram) and **no silent drop**. Registered
+per-channel on the confirmation axis. This is the first concrete instance of a **general pattern**:
+*a channel that can't render a rich interaction reports the gap back to the agent as a text signal;
+the agent renders the human explanation.* We build only this one case — not a capability-declaration
+framework (over-engineering at N=2 channels, per Decisions). **If the app gains confirmation support
+(upstream B2) before we reach C5, we build the real `AppConfirmationUI` instead and skip the refusal
+— C5 is the safe floor, not a goal.** *Verify:* ask Jarvis a destructive action from the app →
+graceful text refusal, action not taken.
+
+**Owner prereq (done).** `APP_HUB_URL`, `APP_HUB_BOT_TOKEN`, `APP_OWNER_USER_ID` are in staging's
+`secrets/.env` with a **staging-specific hub bot token** — the hub is one-bot-one-user, so a
+staging agent sharing prod's token would fight over the update queue. Documented (commented) in
+`.env.example`.
+
+*Verify (staging, real device).* The phone is connected to the hub, so each step above verifies as
+a real round-trip on the device (not the phone-less curl the first draft assumed — that remains a
+fallback). C1: type on the phone, get a reply, see a `jarvis-app_<owner>` row in
+`chat_history.jsonl`. Then the Telegram regression, unchanged, plus the `code-review` skill.
 
 ---
 
@@ -236,11 +305,10 @@ defaulting to `send(text)` is **one candidate** — not a committed choice. Deci
 Everything whose only consumer is a phone capability lands here, on the same "has a real consumer
 now" gate:
 
-- **3c — media→caption fallback.** Today no outbound path sends a non-image kind
-  (`notifier.py:292` passes `"image"`), so the `NotImplementedError` in `channel.py:108,118` is
-  unreachable; it becomes real when the app or a media feature first emits another kind. An
-  unsendable kind should render as its caption (or a `[kind]` placeholder — the convention
-  `Outbox._log` already uses at `outbox.py:115`). Fold in with the seam it hardens.
+- **Media kind fallback** — *folded into Stage C.* C3 makes `image` real; an outbound kind the app
+  can't represent degrades via the C5 unsupported-capability pattern (caption or a `[kind]`
+  placeholder, the convention `Outbox._log` uses at `outbox.py:115`) rather than raising. No longer
+  a standalone Stage D item.
 - **4b — sibling-thread chat injection.** User-scope prompts additionally inject today's chat from
   the *other* user thread (bounded by the same start-of-Israel-day window and per-entry cap as the
   existing slices). Needs a second *live* user thread to be meaningful — telegram↔app is the same
@@ -249,9 +317,10 @@ now" gate:
   sibling chat; beyond that, continuity depends on the daily log or a memory write. Not
   app-specific — the same time-bound governs heartbeat↔user today — so treat it on its own terms,
   alongside `../CONTEXT_HANDLING_PLAN.md` (a wider window costs tokens).
-- **Upstream honest-boundary deferrals:** B1.6 media inbound (+ app `media_cache.py`), B2 app
-  `AppConfirmationUI`, B5 streaming chips, B6 apps. Each is real and specified in
-  `jarvis-app/original_app_plan.md`; none is end-to-end testable today.
+- **Upstream honest-boundary deferrals:** B2 app `AppConfirmationUI` (upgrades C5's unsupported
+  notice to a real prompt), B5 streaming chips, B6 apps. Each is real and specified in
+  `jarvis-app/original_app_plan.md`; none is end-to-end testable today. (B1.6 media inbound
+  graduated to **Stage C4** — the phone sends attachments now.)
 
 *Verify:* per slice, when each acquires its consumer.
 
@@ -284,6 +353,11 @@ is everything before the first `_`; neither channel name contains a `_`). Migrat
 separator would rewrite live conversation-state keys in `threads.sqlite` for a hypothetical
 collision — don't.
 
+**Env var names are `APP_*`, settled.** `APP_HUB_URL` / `APP_HUB_BOT_TOKEN` / `APP_OWNER_USER_ID`,
+matching the app author's handover — no `JARVIS_APP_*` prefix. Already written (commented) into
+`.env.example`; the value in staging's `secrets/.env` uses a staging-specific hub bot token so
+staging and prod never fight over the one-bot-one-user update queue.
+
 **Proactive reliability (deferred).** A single default is a single point of failure; once the
 default is `app`, a hub outage stops briefings and reminders reaching the owner, and the heartbeat
 stamping rule (advance `state.json` only on successful delivery) turns a long outage into a growing
@@ -311,14 +385,16 @@ channels. **Deferred cleanups** (tracked, not blocking): loop-bridge misfiled in
 
 | File | What it is |
 |---|---|
-| `contract.md` | The wire contract, **generated from the hub's Pydantic models** — the single source of truth for payload *shape*. Pinned at `contract_version = f1633277132cbedf`, which the live hub reports on `GET /v1/health`. B0 records the pin; `HubClient` warns (not hard-fail) on mismatch |
+| `contract.md` | The wire contract, **generated from the hub's Pydantic models** — the single source of truth for payload *shape*. Pinned at `contract_version = 3b3a48f330f09a39` (bumped 2026-07-24, adds the attachments model), which the live hub reports on `GET /v1/health`. B0 records the pin; `HubClient` warns (not hard-fail) on mismatch |
 | `fake_agent.py` | A fake **agent** (not a fake hub) — it long-polls a *running* hub. Its value is as the reference poll loop B1 must write (`:366-417`) |
 | `original_app_plan.md` | The approved Track B plan (2026-07-12), phases B0–B6. Upstream's *capability* sequencing |
 
 **The honest boundary — don't build ahead of the phone.** The hub validates more than the phone
 renders: `blocks` have no renderer or action path (B2/B4 wait), chips fan out with no consumer (B5
-waits), no attachment/apps endpoints yet (B1.6/B6 wait). **Buildable and verifiable now: B0, B1**
-(this plan's Stage C), plus B1.5/B3 which are folded into the landed multi-channel work and Stage D.
+waits), no apps endpoints yet (B6 waits). **Attachments crossed the boundary on 2026-07-24** — the
+contract added them and the phone renders them, so media is now buildable/verifiable (Stage C3/C4).
+**Buildable and verifiable now: B0, C1–C5** (this plan's Stage C), plus B1.5/B3 which are folded
+into the landed multi-channel work and Stage D.
 
 **Re-validation duty.** The handover cannot see this repo, so it asks that every agent-internal
 reference in `original_app_plan.md` (`store.py:211`, `main.py:102`, the `Channel` ABC, `ask_jarvis`,
@@ -353,6 +429,5 @@ work, tracked nowhere yet.
 
 | Choice | Decide by |
 |---|---|
-| Env prefix `APP_*` vs `JARVIS_APP_*` | Stage C — before the names are written into `staging.env` (avoid renaming twice) |
 | Queue-epoch hub signal | Raise with the app author. Hazard: if the hub's queue is wiped and re-sequenced while the agent holds a higher offset, the next poll acks updates it never fetched → ✓✓ with no reply. Agent-side detection is **provably unreliable** (the ack is implicit in `GET /updates?offset=N`). Needs a hub-side queue epoch. Until then: **restart the agent alongside any hub wipe** |
 | Blocks mechanism (`OutboundReply` or otherwise) | Stage D — kept open by this plan |

--- a/docs/plans/app-plans/EXECUTION_PLAN.md
+++ b/docs/plans/app-plans/EXECUTION_PLAN.md
@@ -1,11 +1,14 @@
 # App channel — execution plan
 
-**Status (2026-07-24):** Stage C in progress on branch `feat/stage-c-app-channel`. **Landed &
-committed:** C1 (text round-trip, verified live), C2 (slash commands), C6 (channel identity in the
-prompt — #50 Phase 1), `/help` list fix — all pending a phone-verify restart. **Remaining:**
-C3/C4 (media — code buildable now against the frozen contract, but on-device verify is gated on the
-hub upgrading from `f1633277132cbedf` to the pinned `3b3a48f330f09a39`); then the closing regression
-+ `code-review` + PR to main. **C5 deferred to B2** (see below). Stages A + B merged (#47, #49).
+**Status (2026-07-29):** Stage C on branch `feat/stage-c-app-channel`. **Landed & committed:** C1
+(text round-trip, verified live), C2 (slash commands), C6 (channel identity — #50 Phase 1), `/help`
+list fix, **C3 (outbound media), C4 (inbound media)** + its review follow-ups, and **§4 (image upload
+metadata — width/height + blur-up placeholder)**. The hub **upgraded to the pinned
+`3b3a48f330f09a39`** (skew resolved), and an independent audit confirmed we are **in sync with
+`roiguri/jarvis-app-v2@main`** (no re-pin). **Remaining:** restart staging → on-device verify pass →
+Telegram regression + `code-review` → PR to main. **Deferred:** C5 → B2; real `file`-kind ingestion
+(PDF/video) → **#51** (interim: an honest "can't read yet" note, never a silent drop). Stages A + B
+merged (#47, #49).
 **Single source of truth.** Absorbs and replaces the former `APP_CHANNEL_PLAN.md` (index),
 `02_MULTI_CHANNEL_SUPPORT.md`, and `03_APP_CHANNEL.md` (now in `archive/`). The only other live
 material is the app author's pinned handover under `jarvis-app/` — **imported verbatim, not ours
@@ -58,12 +61,20 @@ stay in Stage D (still no phone renderer).
 - [x] C2 — slash commands declared to the hub (`declare_commands`, non-fatal) (commit `22b463a`). *Pending phone verify:* the `declared 8 slash commands…` log line + the app slash menu
 - [x] Commands polish — `/help` reformatted as a markdown list so it renders on all channels (bare-newline list collapsed on the app's CommonMark renderer) (commit `899fe67`)
 - [x] C6 — origin channel injected into the system-prompt envelope (`[Channel: <name>]`, user scope, gate-safe) (commit `c5309f3`); Phase 1 of #50 (capability descriptors deferred there)
-- [ ] C3 — outbound media: `send_media`/`send_to_owner_media` upload (`POST /bot/v1/attachments`) then send `attachment_ids`. *Verify:* a media notification's poster shows on the phone. Consumer: `notifier.py`. **Verify gated on the hub upgrading to `3b3a48…`** (see note)
-- [ ] C4 — inbound media: router downloads `Message.attachments` → app `media_cache` → `InboundMessage.attachments` → Gemini. *Verify:* a photo from the phone gets described. **Verify gated on the hub upgrade** (see note)
+- [x] C3 — outbound media: `send_media`/`send_to_owner_media` upload (`POST /bot/v1/attachments`) then send `attachment_ids` (commit `55a987a`). image/audio pass through (image sniffs PNG/JPEG); any other kind raises `NotImplementedError` (Outbox reports a failed send). Consumer: `notifier.py`. *Verified* via the real channel code round-tripping an image to the hub; *pending* on-device render after restart
+- [x] C4 — inbound media: router downloads `Message.attachments` → app `media_cache` → `InboundMessage.attachments` → Gemini (commit `d3e986e`). *Verified* upload→download byte-exact + `_handle` cases; *pending* an on-device photo→describe after restart
+- [x] C4 review follow-ups (commit `bee778c`): reject malformed `att_` ids before a filesystem path + basename guard; `media_cache.save` inside the per-attachment try; retrieval note instead of an empty turn when every download fails
+- [x] §4 — image upload metadata (commit `0783aeb`): `upload_attachment` sends optional `width`/`height`/`blur_preview`; the channel computes them for images via Pillow (`Pillow==12.3.0` added, import guarded). App reserves aspect ratio (no reflow) + shows a blur-up placeholder. `duration_ms` omitted (no outbound-audio producer). *Verified* the hub stored `w/h/blur_preview`
+- [x] `file`-kind honest fallback (commit `23c347d`): the agent surfaces any unreadable kind as text rather than silently dropping it; real PDF/video ingestion tracked in **#51**
 - [ ] C5 — **DEFERRED → B2** (decided 2026-07-24). An interim `UnsupportedConfirmation` is throwaway: the real `AppConfirmationUI` (upstream B2) replaces it, and its registration seam already exists. Interim behavior is **safe** — app-origin destructive tools fall back to the default channel's (Telegram) confirmation; nothing fires silently. Build the real UI when the app ships confirmation; don't build the placeholder.
 - [ ] **Restart staging** + Telegram regression + `code-review` skill, then PR `feat/stage-c-app-channel` → main
 
-> **Hub-skew note (2026-07-24):** the running hub still serves `contract_version = f1633277132cbedf`; the warn-on-mismatch fired as designed. C1/C2 are unaffected (stable endpoints), but **C3/C4 verify waits for the hub to upgrade to the pinned `3b3a48f330f09a39`** (in progress, app-side). The contract is frozen, so C3/C4 are safe to *build* ahead of that; only the on-device verify is gated.
+> **Hub-skew note — RESOLVED (2026-07-29):** the hub now serves `contract_version =
+> 3b3a48f330f09a39`, the pinned version (`GET /v1/health`), so the warn-on-mismatch no longer fires
+> and C3/C4 are unblocked. An independent audit of `roiguri/jarvis-app-v2@main` confirmed the
+> contract has not advanced past the pin (verified against its CI drift test) — **no re-pin needed.**
+> One low-impact upstream note it surfaced, now closed: our upload omitted the optional
+> `width/height/blur_preview` metadata → landed as §4.
 
 **Stage D — rich rendering / blocks** (design deliberately OPEN — decide when a consumer exists)
 - [ ] Design the outbound seam against the real app renderer (`OutboundReply` is *one candidate*, not committed)
@@ -320,6 +331,11 @@ now" gate:
   `NotImplementedError` (the Outbox reports a failed send). A graceful caption / `[kind]`-placeholder
   degradation (the convention `Outbox._log` uses at `outbox.py:115`) can land with the capability
   work (#50).
+- **Inbound `file`-kind ingestion (#51).** C4 downloads `file`-kind attachments (the hub's `file`
+  bundles PDF + video by mime), but the agent can't yet feed them to the model — it emits an honest
+  "can't read yet" note. Real ingestion routes `file` by `mime_type` (`application/pdf` / `video/*` →
+  media block) with an inline-size guard (Gemini ~20 MB vs the hub's 50 MB → Files API or cap-and-note).
+  Gated on the app composer being able to *send* a file/video (video is owner-confirmed future work).
 - **4b — sibling-thread chat injection.** User-scope prompts additionally inject today's chat from
   the *other* user thread (bounded by the same start-of-Israel-day window and per-entry cap as the
   existing slices). Needs a second *live* user thread to be meaningful — telegram↔app is the same

--- a/docs/plans/app-plans/jarvis-app/contract.md
+++ b/docs/plans/app-plans/jarvis-app/contract.md
@@ -6,19 +6,23 @@
 JSON Schema plus the endpoint list, generated from the Pydantic models and
 the mounted routes under `backend/jarvis_app_backend`.
 
-`contract_version`: `f1633277132cbedf`
+`contract_version`: `3b3a48f330f09a39`
 
 ## Endpoints
 
+- `GET /bot/v1/attachments/{attachment_id}` — Bot Download Attachment
 - `GET /bot/v1/updates` — Get Updates
+- `GET /v1/attachments/{attachment_id}` — Download Attachment
 - `GET /v1/commands` — Get Commands
 - `GET /v1/events` — Events
 - `GET /v1/health` — Health
 - `GET /v1/messages` — Get Messages
 - `PATCH /bot/v1/messages/{message_id}` — Bot Patch
+- `POST /bot/v1/attachments` — Bot Upload Attachment
 - `POST /bot/v1/commands` — Declare Commands
 - `POST /bot/v1/events` — Bot Event
 - `POST /bot/v1/messages` — Bot Send
+- `POST /v1/attachments` — Upload Attachment
 - `POST /v1/auth/login` — Login
 - `POST /v1/auth/logout` — Logout
 - `POST /v1/messages` — Send Message
@@ -85,6 +89,107 @@ the mounted routes under `backend/jarvis_app_backend`.
     "error"
   ],
   "title": "ApiError",
+  "type": "object"
+}
+```
+
+### Attachment
+
+```json
+{
+  "additionalProperties": false,
+  "description": "One uploaded blob, as it rides `attachments[]` on a `Message` or the\nresponse of `POST /v1/attachments`.",
+  "properties": {
+    "blur_preview": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Blur Preview"
+    },
+    "duration_ms": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Duration Ms"
+    },
+    "filename": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Filename"
+    },
+    "height": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Height"
+    },
+    "id": {
+      "pattern": "^att_[0-9A-HJKMNP-TV-Z]{26}$",
+      "title": "Id",
+      "type": "string"
+    },
+    "kind": {
+      "enum": [
+        "image",
+        "audio",
+        "file"
+      ],
+      "title": "Kind",
+      "type": "string"
+    },
+    "mime_type": {
+      "title": "Mime Type",
+      "type": "string"
+    },
+    "size": {
+      "title": "Size",
+      "type": "integer"
+    },
+    "width": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Width"
+    }
+  },
+  "required": [
+    "id",
+    "kind",
+    "mime_type",
+    "size"
+  ],
+  "title": "Attachment",
   "type": "object"
 }
 ```
@@ -675,6 +780,14 @@ the mounted routes under `backend/jarvis_app_backend`.
   },
   "additionalProperties": false,
   "properties": {
+    "attachment_ids": {
+      "items": {
+        "pattern": "^att_[0-9A-HJKMNP-TV-Z]{26}$",
+        "type": "string"
+      },
+      "title": "Attachment Ids",
+      "type": "array"
+    },
     "blocks": {
       "anyOf": [
         {
@@ -756,6 +869,102 @@ the mounted routes under `backend/jarvis_app_backend`.
         "label"
       ],
       "title": "Action",
+      "type": "object"
+    },
+    "Attachment": {
+      "additionalProperties": false,
+      "description": "One uploaded blob, as it rides `attachments[]` on a `Message` or the\nresponse of `POST /v1/attachments`.",
+      "properties": {
+        "blur_preview": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Blur Preview"
+        },
+        "duration_ms": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Duration Ms"
+        },
+        "filename": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Filename"
+        },
+        "height": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Height"
+        },
+        "id": {
+          "pattern": "^att_[0-9A-HJKMNP-TV-Z]{26}$",
+          "title": "Id",
+          "type": "string"
+        },
+        "kind": {
+          "enum": [
+            "image",
+            "audio",
+            "file"
+          ],
+          "title": "Kind",
+          "type": "string"
+        },
+        "mime_type": {
+          "title": "Mime Type",
+          "type": "string"
+        },
+        "size": {
+          "title": "Size",
+          "type": "integer"
+        },
+        "width": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Width"
+        }
+      },
+      "required": [
+        "id",
+        "kind",
+        "mime_type",
+        "size"
+      ],
+      "title": "Attachment",
       "type": "object"
     },
     "ButtonsBlock": {
@@ -969,6 +1178,13 @@ the mounted routes under `backend/jarvis_app_backend`.
     "Message": {
       "description": "The persistent unit; `id` is the sync cursor (architecture \u00a75).",
       "properties": {
+        "attachments": {
+          "items": {
+            "$ref": "#/$defs/Attachment"
+          },
+          "title": "Attachments",
+          "type": "array"
+        },
         "blocks": {
           "anyOf": [
             {
@@ -1079,6 +1295,7 @@ the mounted routes under `backend/jarvis_app_backend`.
         "role",
         "text",
         "blocks",
+        "attachments",
         "meta",
         "client_ts",
         "delivered_at",
@@ -1559,6 +1776,102 @@ the mounted routes under `backend/jarvis_app_backend`.
       "title": "Action",
       "type": "object"
     },
+    "Attachment": {
+      "additionalProperties": false,
+      "description": "One uploaded blob, as it rides `attachments[]` on a `Message` or the\nresponse of `POST /v1/attachments`.",
+      "properties": {
+        "blur_preview": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Blur Preview"
+        },
+        "duration_ms": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Duration Ms"
+        },
+        "filename": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Filename"
+        },
+        "height": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Height"
+        },
+        "id": {
+          "pattern": "^att_[0-9A-HJKMNP-TV-Z]{26}$",
+          "title": "Id",
+          "type": "string"
+        },
+        "kind": {
+          "enum": [
+            "image",
+            "audio",
+            "file"
+          ],
+          "title": "Kind",
+          "type": "string"
+        },
+        "mime_type": {
+          "title": "Mime Type",
+          "type": "string"
+        },
+        "size": {
+          "title": "Size",
+          "type": "integer"
+        },
+        "width": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Width"
+        }
+      },
+      "required": [
+        "id",
+        "kind",
+        "mime_type",
+        "size"
+      ],
+      "title": "Attachment",
+      "type": "object"
+    },
     "ButtonsBlock": {
       "additionalProperties": false,
       "description": "No prose field exists here \u2014 see the module docstring. `options`\nabsorbs what a separate `choice` kind would otherwise do; `state` is the\nselected `action_id` once resolved, or `None` while the block is still\nlive.",
@@ -1792,6 +2105,13 @@ the mounted routes under `backend/jarvis_app_backend`.
   },
   "description": "The persistent unit; `id` is the sync cursor (architecture \u00a75).",
   "properties": {
+    "attachments": {
+      "items": {
+        "$ref": "#/$defs/Attachment"
+      },
+      "title": "Attachments",
+      "type": "array"
+    },
     "blocks": {
       "anyOf": [
         {
@@ -1902,6 +2222,7 @@ the mounted routes under `backend/jarvis_app_backend`.
     "role",
     "text",
     "blocks",
+    "attachments",
     "meta",
     "client_ts",
     "delivered_at",
@@ -1963,6 +2284,102 @@ the mounted routes under `backend/jarvis_app_backend`.
         "label"
       ],
       "title": "Action",
+      "type": "object"
+    },
+    "Attachment": {
+      "additionalProperties": false,
+      "description": "One uploaded blob, as it rides `attachments[]` on a `Message` or the\nresponse of `POST /v1/attachments`.",
+      "properties": {
+        "blur_preview": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Blur Preview"
+        },
+        "duration_ms": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Duration Ms"
+        },
+        "filename": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Filename"
+        },
+        "height": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Height"
+        },
+        "id": {
+          "pattern": "^att_[0-9A-HJKMNP-TV-Z]{26}$",
+          "title": "Id",
+          "type": "string"
+        },
+        "kind": {
+          "enum": [
+            "image",
+            "audio",
+            "file"
+          ],
+          "title": "Kind",
+          "type": "string"
+        },
+        "mime_type": {
+          "title": "Mime Type",
+          "type": "string"
+        },
+        "size": {
+          "title": "Size",
+          "type": "integer"
+        },
+        "width": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Width"
+        }
+      },
+      "required": [
+        "id",
+        "kind",
+        "mime_type",
+        "size"
+      ],
+      "title": "Attachment",
       "type": "object"
     },
     "ButtonsBlock": {
@@ -2176,6 +2593,13 @@ the mounted routes under `backend/jarvis_app_backend`.
     "Message": {
       "description": "The persistent unit; `id` is the sync cursor (architecture \u00a75).",
       "properties": {
+        "attachments": {
+          "items": {
+            "$ref": "#/$defs/Attachment"
+          },
+          "title": "Attachments",
+          "type": "array"
+        },
         "blocks": {
           "anyOf": [
             {
@@ -2286,6 +2710,7 @@ the mounted routes under `backend/jarvis_app_backend`.
         "role",
         "text",
         "blocks",
+        "attachments",
         "meta",
         "client_ts",
         "delivered_at",
@@ -2578,6 +3003,14 @@ the mounted routes under `backend/jarvis_app_backend`.
   "additionalProperties": false,
   "description": "`POST /v1/messages`'s body. `client_msg_id` is the idempotency key \u2014\na replay returns the row it already produced rather than a new one.",
   "properties": {
+    "attachment_ids": {
+      "items": {
+        "pattern": "^att_[0-9A-HJKMNP-TV-Z]{26}$",
+        "type": "string"
+      },
+      "title": "Attachment Ids",
+      "type": "array"
+    },
     "blocks": {
       "anyOf": [
         {

--- a/gateway/channels/jarvis_app/__init__.py
+++ b/gateway/channels/jarvis_app/__init__.py
@@ -1,0 +1,32 @@
+"""
+The jarvis-app channel — Jarvis's second channel, beside Telegram.
+
+Same Channel contract, but the two differ in ways worth knowing when reading this
+package next to gateway/channels/telegram/:
+
+- Who drives the connection. Telegram is push: python-telegram-bot owns an inbound
+  Application and Telegram delivers updates to it (host.py wraps the PTB lifecycle).
+  jarvis-app is pull — *we* are the client: router.py long-polls the hub's
+  GET /bot/v1/updates ourselves, with no third-party library owning the loop.
+
+- Identity. Telegram is a multi-user surface: every update carries from_user.id and
+  the channel authorizes against ALLOWED_USER_ID. The hub is one-bot-one-owner: the
+  bot token scopes the single owner, updates carry no per-message user id, and
+  authorization is already done upstream — so there is one conversation and chat_id
+  is not a routing key (every send addresses the owner).
+
+- Availability. Telegram's servers are assumed up and PTB handles reconnection. The
+  hub is a home-grown service that may be down or still in development, so the router
+  has explicit degraded mode (log once, back off 1->60s) and never crashes the agent
+  — and main.py builds this channel only when APP_HUB_URL is set.
+
+- Contract. Telegram is a stable public API; the hub is a home-grown wire contract
+  pinned by contract_version (client.py), against which the client warns on mismatch.
+
+- Rendering. Telegram renders Markdown to HTML and uploads media as multipart photos.
+  jarvis-app sends plain text for now; media (upload-then-reference attachments) and
+  rich blocks are later steps, gated on what the phone renders.
+
+Everything else — slash commands, chat-history logging, the shared on_message path —
+is channel-agnostic and reused unchanged.
+"""

--- a/gateway/channels/jarvis_app/channel.py
+++ b/gateway/channels/jarvis_app/channel.py
@@ -3,8 +3,10 @@ JarvisAppChannel — the jarvis-app implementation of the Channel contract.
 
 A thin adapter over HubClient. The hub is one-bot-one-owner: there is a single
 conversation, so `chat_id` carries no routing and every send addresses the owner.
-Text only for now; media sends raise NotImplementedError (the Outbox reports that
-as a failed send) until the media step lands.
+Media rides the attachment model: upload the bytes, then send a message that
+references the returned id. The hub's kinds are image | audio | file; a kind this
+channel can't represent raises NotImplementedError, which the Outbox reports as a
+failed send (base.Channel.send_media contract) rather than mislabeling the blob.
 """
 
 from __future__ import annotations
@@ -21,6 +23,21 @@ logger = logging.getLogger(__name__)
 # The channel name contains no underscore, so the prefix stays unambiguous.
 def thread_id_for(owner_id: str) -> str:
     return f"jarvis-app_{owner_id}"
+
+
+# The kinds this channel can represent, mapped to the (filename, mime_type) the
+# upload needs. The hub infers its Attachment.kind from the mime type, and its own
+# enum is image | audio | file — Telegram's "video" has no equivalent here, so it
+# (and any other kind) falls through to NotImplementedError rather than being
+# mislabeled. Images sniff PNG vs JPEG since posters arrive as either.
+def _upload_meta(kind: str, payload: bytes) -> tuple[str, str]:
+    if kind == "image":
+        if payload[:8] == b"\x89PNG\r\n\x1a\n":
+            return "image.png", "image/png"
+        return "image.jpg", "image/jpeg"
+    if kind == "audio":
+        return "audio.ogg", "audio/ogg"
+    raise NotImplementedError(f"jarvis-app cannot send media kind={kind!r}")
 
 
 class JarvisAppChannel(Channel):
@@ -41,7 +58,8 @@ class JarvisAppChannel(Channel):
     async def send_media(
         self, chat_id: str, kind: str, payload: bytes, caption: str | None = None
     ) -> None:
-        raise NotImplementedError(f"jarvis-app cannot send media kind={kind!r} yet")
+        # One owner, one conversation — chat_id is not a routing key here.
+        await self._upload_and_send(kind, payload, caption)
 
     async def send_to_owner(self, text: str) -> None:
         await self._client.send_message({"text": text})
@@ -49,7 +67,21 @@ class JarvisAppChannel(Channel):
     async def send_to_owner_media(
         self, kind: str, payload: bytes, caption: str | None = None
     ) -> None:
-        raise NotImplementedError(f"jarvis-app cannot send media kind={kind!r} yet")
+        await self._upload_and_send(kind, payload, caption)
+
+    async def _upload_and_send(
+        self, kind: str, payload: bytes, caption: str | None
+    ) -> None:
+        # Raises NotImplementedError for an unrepresentable kind — before any
+        # upload — so the Outbox reports a failed send with nothing half-sent.
+        filename, mime_type = _upload_meta(kind, payload)
+        att_id = await self._client.upload_attachment(
+            payload, filename=filename, mime_type=mime_type
+        )
+        body: dict = {"attachment_ids": [att_id]}
+        if caption:
+            body["text"] = caption
+        await self._client.send_message(body)
 
     def authorize(self, raw_user_id: str) -> bool:
         # The bot token scopes the hub to the single owner, so inbound updates are

--- a/gateway/channels/jarvis_app/channel.py
+++ b/gateway/channels/jarvis_app/channel.py
@@ -11,12 +11,27 @@ failed send (base.Channel.send_media contract) rather than mislabeling the blob.
 
 from __future__ import annotations
 
+import base64
 import logging
+from io import BytesIO
+
+try:
+    from PIL import Image
+except ImportError:
+    # Pillow only powers optional upload metadata (dimensions + blur-up
+    # placeholder). The factory imports this module unconditionally, so a deploy
+    # without Pillow must still import cleanly — metadata just degrades to none.
+    Image = None
 
 from gateway.base import Channel
 from gateway.channels.jarvis_app.client import HubClient
 
 logger = logging.getLogger(__name__)
+
+# Longest edge of the blur-up placeholder thumbnail, matching the app's own
+# outbound encoder (AttachmentBlurEncoder): ~24px, JPEG quality 60.
+_BLUR_EDGE = 24
+_BLUR_QUALITY = 60
 
 
 # thread_id mirrors telegram's "<channel>_<id>", parsed on the first underscore.
@@ -38,6 +53,33 @@ def _upload_meta(kind: str, payload: bytes) -> tuple[str, str]:
     if kind == "audio":
         return "audio.ogg", "audio/ogg"
     raise NotImplementedError(f"jarvis-app cannot send media kind={kind!r}")
+
+
+# Pixel dimensions + a tiny base64 blur-up thumbnail for an image, so the app
+# reserves the right aspect ratio (no thread reflow) and shows a placeholder
+# while the full image loads. Best-effort: any decode/encode failure returns
+# empty metadata and the upload proceeds without it (the hub treats every field
+# as optional and the app degrades to a plain placeholder). blur_preview is not a
+# perceptual hash — it is base64 of a real ~24px thumbnail the app just decodes.
+def _image_metadata(payload: bytes) -> dict:
+    if Image is None:
+        return {}
+    try:
+        with Image.open(BytesIO(payload)) as im:
+            im.load()
+            width, height = im.size
+            thumb = im.copy()
+            thumb.thumbnail((_BLUR_EDGE, _BLUR_EDGE))
+            # JPEG has no alpha/palette — normalize so the thumbnail always saves.
+            if thumb.mode not in ("RGB", "L"):
+                thumb = thumb.convert("RGB")
+            buf = BytesIO()
+            thumb.save(buf, "JPEG", quality=_BLUR_QUALITY)
+        blur = base64.b64encode(buf.getvalue()).decode("ascii")
+        return {"width": width, "height": height, "blur_preview": blur}
+    except Exception as exc:
+        logger.warning("jarvis-app image metadata skipped: %s", exc)
+        return {}
 
 
 class JarvisAppChannel(Channel):
@@ -75,8 +117,10 @@ class JarvisAppChannel(Channel):
         # Raises NotImplementedError for an unrepresentable kind — before any
         # upload — so the Outbox reports a failed send with nothing half-sent.
         filename, mime_type = _upload_meta(kind, payload)
+        # Images carry dimensions + a blur-up placeholder; other kinds carry none.
+        meta = _image_metadata(payload) if kind == "image" else {}
         att_id = await self._client.upload_attachment(
-            payload, filename=filename, mime_type=mime_type
+            payload, filename=filename, mime_type=mime_type, **meta
         )
         body: dict = {"attachment_ids": [att_id]}
         if caption:

--- a/gateway/channels/jarvis_app/channel.py
+++ b/gateway/channels/jarvis_app/channel.py
@@ -1,0 +1,62 @@
+"""
+JarvisAppChannel — the jarvis-app implementation of the Channel contract.
+
+A thin adapter over HubClient. The hub is one-bot-one-owner: there is a single
+conversation, so `chat_id` carries no routing and every send addresses the owner.
+Text only for now; media sends raise NotImplementedError (the Outbox reports that
+as a failed send) until the media step lands.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from gateway.base import Channel
+from gateway.channels.jarvis_app.client import HubClient
+
+logger = logging.getLogger(__name__)
+
+
+# thread_id mirrors telegram's "<channel>_<id>", parsed on the first underscore.
+# The channel name contains no underscore, so the prefix stays unambiguous.
+def thread_id_for(owner_id: str) -> str:
+    return f"jarvis-app_{owner_id}"
+
+
+class JarvisAppChannel(Channel):
+    name = "jarvis-app"
+
+    def __init__(self, client: HubClient, owner_id: str) -> None:
+        self._client = client
+        self._owner_id = owner_id
+
+    # ------------------------------------------------------------------
+    # Channel ABC
+    # ------------------------------------------------------------------
+
+    async def send(self, chat_id: str, text: str, *, reply_to: str | None = None) -> None:
+        # One owner, one conversation — chat_id is not a routing key here.
+        await self._client.send_message({"text": text})
+
+    async def send_media(
+        self, chat_id: str, kind: str, payload: bytes, caption: str | None = None
+    ) -> None:
+        raise NotImplementedError(f"jarvis-app cannot send media kind={kind!r} yet")
+
+    async def send_to_owner(self, text: str) -> None:
+        await self._client.send_message({"text": text})
+
+    async def send_to_owner_media(
+        self, kind: str, payload: bytes, caption: str | None = None
+    ) -> None:
+        raise NotImplementedError(f"jarvis-app cannot send media kind={kind!r} yet")
+
+    def authorize(self, raw_user_id: str) -> bool:
+        # The bot token scopes the hub to the single owner, so inbound updates are
+        # already authorized upstream; this checks against the configured owner
+        # for completeness.
+        return str(raw_user_id) == self._owner_id
+
+    @property
+    def owner_thread_id(self) -> str:
+        return thread_id_for(self._owner_id)

--- a/gateway/channels/jarvis_app/client.py
+++ b/gateway/channels/jarvis_app/client.py
@@ -77,16 +77,36 @@ class HubClient:
         r.raise_for_status()
 
     async def upload_attachment(
-        self, payload: bytes, *, filename: str, mime_type: str
+        self,
+        payload: bytes,
+        *,
+        filename: str,
+        mime_type: str,
+        width: int | None = None,
+        height: int | None = None,
+        blur_preview: str | None = None,
     ) -> str:
         """Upload one blob and return its `att_…` id, to be referenced by a later
         send_message(attachment_ids=[…]). The hub infers kind from the mime type.
-        Raises HubUnavailable on a server error or transport failure so a proactive
-        media send degrades to a failed send rather than crashing the caller."""
+        Optional metadata lets the app render without reflow (width/height reserve
+        the aspect ratio) and show a blur-up placeholder (blur_preview); all are
+        omitted when absent and the hub does not validate them. Raises
+        HubUnavailable on a server error or transport failure so a proactive media
+        send degrades to a failed send rather than crashing the caller."""
+        # Numeric metadata rides the multipart body as decimal strings (FastAPI
+        # coerces them back to int); blur_preview is passed through verbatim.
+        data: dict[str, str] = {}
+        if width is not None:
+            data["width"] = str(width)
+        if height is not None:
+            data["height"] = str(height)
+        if blur_preview:
+            data["blur_preview"] = blur_preview
         try:
             r = await self._client.post(
                 "/bot/v1/attachments",
                 files={"file": (filename, payload, mime_type)},
+                data=data or None,
             )
             r.raise_for_status()
         except httpx.HTTPStatusError as e:

--- a/gateway/channels/jarvis_app/client.py
+++ b/gateway/channels/jarvis_app/client.py
@@ -97,6 +97,21 @@ class HubClient:
             raise HubUnavailable(str(e)) from e
         return r.json()["id"]
 
+    async def download_attachment(self, attachment_id: str) -> bytes:
+        """Fetch an inbound attachment's bytes by id. Raises HubUnavailable on a
+        server error or transport failure so the router can skip that one
+        attachment without taking the turn down."""
+        try:
+            r = await self._client.get(f"/bot/v1/attachments/{attachment_id}")
+            r.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code >= 500:
+                raise HubUnavailable(f"hub returned {e.response.status_code}") from e
+            raise
+        except httpx.HTTPError as e:
+            raise HubUnavailable(str(e)) from e
+        return r.content
+
     async def declare_commands(self, commands: list[dict]) -> None:
         """Publish the bot's slash-command list to the hub so the app can show a
         command menu. Each entry is {"name", "description"}."""

--- a/gateway/channels/jarvis_app/client.py
+++ b/gateway/channels/jarvis_app/client.py
@@ -1,0 +1,76 @@
+"""
+HubClient — httpx client for the jarvis-app hub's bot API.
+
+Talks to the hub the way python-telegram-bot talks to Telegram's Bot API:
+long-poll for updates, POST replies. Everything hub-specific — endpoints, bearer
+auth, and the contract version this adapter was written against — lives here; the
+channel and router deal in Python objects, never URLs.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# The version the adapter was written against. The hub reports its own
+# contract_version on GET /v1/health; a mismatch is logged, never fatal — the hub
+# already 422s a malformed payload, so this only gives a *silent* skew a voice.
+PINNED_CONTRACT_VERSION = "3b3a48f330f09a39"
+
+# The hanging poll's server-side wait. The client read timeout sits a little above
+# it so a genuinely dead connection eventually errors instead of hanging forever.
+POLL_TIMEOUT_S = 25.0
+
+
+class HubUnavailable(Exception):
+    """The hub could not be reached or returned a server error — raised so the
+    router enters degraded mode instead of the fetch loop dying."""
+
+
+class HubClient:
+    def __init__(
+        self, base_url: str, token: str, *, poll_timeout: float = POLL_TIMEOUT_S
+    ) -> None:
+        self._poll_timeout = poll_timeout
+        self._client = httpx.AsyncClient(
+            base_url=base_url.rstrip("/"),
+            headers={"Authorization": f"Bearer {token}"},
+            # Connect fails fast; the read window covers the long-poll plus slack.
+            timeout=httpx.Timeout(10.0, read=poll_timeout + 5.0),
+        )
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    async def get_health(self) -> dict:
+        """The hub's self-report, including contract_version. Not wrapped in
+        HubUnavailable — its one caller is a startup check that treats any failure
+        as 'skip the check', not 'degrade'."""
+        r = await self._client.get("/v1/health")
+        r.raise_for_status()
+        return r.json()
+
+    async def get_updates(self, offset: int) -> list[dict]:
+        """Long-poll for updates at or after `offset`. Raises HubUnavailable on a
+        server error or transport failure so the fetch loop can back off."""
+        try:
+            r = await self._client.get(
+                "/bot/v1/updates",
+                params={"offset": offset, "timeout": self._poll_timeout},
+            )
+            r.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code >= 500:
+                raise HubUnavailable(f"hub returned {e.response.status_code}") from e
+            raise
+        except httpx.HTTPError as e:
+            raise HubUnavailable(str(e)) from e
+        return r.json()
+
+    async def send_message(self, body: dict) -> None:
+        """POST an assistant message to the hub (text-only body for now)."""
+        r = await self._client.post("/bot/v1/messages", json=body)
+        r.raise_for_status()

--- a/gateway/channels/jarvis_app/client.py
+++ b/gateway/channels/jarvis_app/client.py
@@ -74,3 +74,9 @@ class HubClient:
         """POST an assistant message to the hub (text-only body for now)."""
         r = await self._client.post("/bot/v1/messages", json=body)
         r.raise_for_status()
+
+    async def declare_commands(self, commands: list[dict]) -> None:
+        """Publish the bot's slash-command list to the hub so the app can show a
+        command menu. Each entry is {"name", "description"}."""
+        r = await self._client.post("/bot/v1/commands", json=commands)
+        r.raise_for_status()

--- a/gateway/channels/jarvis_app/client.py
+++ b/gateway/channels/jarvis_app/client.py
@@ -71,9 +71,31 @@ class HubClient:
         return r.json()
 
     async def send_message(self, body: dict) -> None:
-        """POST an assistant message to the hub (text-only body for now)."""
+        """POST an assistant message to the hub. `body` carries any of text /
+        attachment_ids (the hub requires at least one)."""
         r = await self._client.post("/bot/v1/messages", json=body)
         r.raise_for_status()
+
+    async def upload_attachment(
+        self, payload: bytes, *, filename: str, mime_type: str
+    ) -> str:
+        """Upload one blob and return its `att_…` id, to be referenced by a later
+        send_message(attachment_ids=[…]). The hub infers kind from the mime type.
+        Raises HubUnavailable on a server error or transport failure so a proactive
+        media send degrades to a failed send rather than crashing the caller."""
+        try:
+            r = await self._client.post(
+                "/bot/v1/attachments",
+                files={"file": (filename, payload, mime_type)},
+            )
+            r.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code >= 500:
+                raise HubUnavailable(f"hub returned {e.response.status_code}") from e
+            raise
+        except httpx.HTTPError as e:
+            raise HubUnavailable(str(e)) from e
+        return r.json()["id"]
 
     async def declare_commands(self, commands: list[dict]) -> None:
         """Publish the bot's slash-command list to the hub so the app can show a

--- a/gateway/channels/jarvis_app/media_cache.py
+++ b/gateway/channels/jarvis_app/media_cache.py
@@ -26,10 +26,11 @@ _EXT = {"image": ".jpg", "audio": ".ogg", "file": ""}
 def save(data: bytes, kind: str, attachment_id: str) -> str:
     """Persist an inbound blob; return its **absolute** path.
 
-    The filename embeds the hub's `att_…` id (already unique and filename-safe),
-    so the same media re-resolves across turns without re-download.
+    The filename embeds the hub's `att_…` id (unique per blob). `basename`
+    strips any path separators as defense in depth — the caller already
+    validates the id shape, so nothing untrusted should reach here.
     """
-    filename = f"{kind}_{attachment_id}{_EXT.get(kind, '')}"
+    filename = os.path.basename(f"{kind}_{attachment_id}{_EXT.get(kind, '')}")
     abs_path = os.path.join(_CACHE_DIR, filename)
     with open(abs_path, "wb") as f:
         f.write(data)

--- a/gateway/channels/jarvis_app/media_cache.py
+++ b/gateway/channels/jarvis_app/media_cache.py
@@ -1,0 +1,55 @@
+"""jarvis-app-owned media cache.
+
+The jarvis-app channel downloads inbound attachments and stores them here,
+returning an **absolute** path. Nothing in `tools/*` or `agent.py` imports this
+module or knows where app media lives — the channel owns it end to end, the same
+channel-owns-storage rule Telegram's `media_cache.py` follows. The agent receives
+the absolute path via `InboundMessage.attachments[].path` and opens it directly.
+"""
+
+import os
+from datetime import datetime, timedelta, timezone
+
+# Channel-owned cache dir, resolved relative to this file (no hardcoded /app path,
+# no dependency on the memory surface). Gitignored.
+_CACHE_DIR = os.path.join(os.path.dirname(__file__), "media_cache")
+os.makedirs(_CACHE_DIR, exist_ok=True)
+
+_RETENTION_DAYS = 90
+
+# The hub's attachment kinds are image | audio | file. Extensions are cosmetic —
+# the agent reads bytes and branches on mime_type, not the filename — so an
+# unknown kind just gets no suffix.
+_EXT = {"image": ".jpg", "audio": ".ogg", "file": ""}
+
+
+def save(data: bytes, kind: str, attachment_id: str) -> str:
+    """Persist an inbound blob; return its **absolute** path.
+
+    The filename embeds the hub's `att_…` id (already unique and filename-safe),
+    so the same media re-resolves across turns without re-download.
+    """
+    filename = f"{kind}_{attachment_id}{_EXT.get(kind, '')}"
+    abs_path = os.path.join(_CACHE_DIR, filename)
+    with open(abs_path, "wb") as f:
+        f.write(data)
+    return abs_path
+
+
+def trim(retention_days: int = _RETENTION_DAYS) -> None:
+    """Evict cache files not modified within retention_days (mtime proxy — blobs
+    are written once on arrival and never modified)."""
+    if not os.path.isdir(_CACHE_DIR):
+        return
+    cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
+    for filename in os.listdir(_CACHE_DIR):
+        filepath = os.path.join(_CACHE_DIR, filename)
+        if not os.path.isfile(filepath):
+            continue
+        mtime = datetime.fromtimestamp(os.path.getmtime(filepath), tz=timezone.utc)
+        if mtime < cutoff:
+            os.remove(filepath)
+
+
+# Channel owns its own cache hygiene: prune stale blobs once at import.
+trim()

--- a/gateway/channels/jarvis_app/router.py
+++ b/gateway/channels/jarvis_app/router.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import re
 
 from gateway.base import InboundMessage, OnMessage
 from gateway.commands import list_commands
@@ -31,6 +32,10 @@ logger = logging.getLogger(__name__)
 # outage neither spins nor logs a line per attempt.
 _BACKOFF_START_S = 1.0
 _BACKOFF_MAX_S = 60.0
+
+# The hub pins attachment ids to this shape. The id names the cache file, so a
+# value that doesn't match is rejected before it can reach a filesystem path.
+_ATT_ID_RE = re.compile(r"^att_[0-9A-HJKMNP-TV-Z]{26}$")
 
 
 class JarvisAppInboundRouter:
@@ -143,12 +148,16 @@ class JarvisAppInboundRouter:
             return
         text = message.get("text") or ""
 
-        attachments = await self._download_attachments(message.get("attachments") or [])
-        # An attachment-only message still needs text for the turn; mirror the
-        # Telegram router's placeholder so the model knows something arrived.
-        if not text and attachments:
-            kinds = ", ".join(a["kind"] for a in attachments)
-            text = f"[attachments: {kinds}]"
+        raw_attachments = message.get("attachments") or []
+        attachments = await self._download_attachments(raw_attachments)
+        # An attachment-only message still needs text so the model knows something
+        # arrived. If every download failed, say that rather than run an empty turn.
+        if not text:
+            if attachments:
+                kinds = ", ".join(a["kind"] for a in attachments)
+                text = f"[attachments: {kinds}]"
+            elif raw_attachments:
+                text = "[an attachment was sent but could not be retrieved]"
 
         # The hub carries no per-message user id (the bot token scopes the single
         # owner), so user_id/chat_id are placeholders — nothing downstream reads
@@ -175,12 +184,15 @@ class JarvisAppInboundRouter:
             kind = att.get("kind")
             if not att_id or not kind:
                 continue
+            if not _ATT_ID_RE.match(att_id):
+                logger.warning("jarvis-app skipping attachment with malformed id %r", att_id)
+                continue
             try:
                 data = await self._client.download_attachment(att_id)
+                path = await asyncio.to_thread(media_cache.save, data, kind, att_id)
             except Exception as exc:
                 logger.warning("jarvis-app attachment %s download failed: %s", att_id, exc)
                 continue
-            path = await asyncio.to_thread(media_cache.save, data, kind, att_id)
             out.append(
                 {
                     "kind": kind,

--- a/gateway/channels/jarvis_app/router.py
+++ b/gateway/channels/jarvis_app/router.py
@@ -1,0 +1,139 @@
+"""
+jarvis-app inbound router — long-polls the hub and runs one turn at a time.
+
+The poll loop is two tasks over a queue, and the shape is load-bearing. A fetcher
+long-polls and, per update, advances the offset and enqueues it *before* any turn
+runs — so the next poll, which acks the previous batch, goes out while a turn is
+still in flight. A single consumer runs turns one at a time, so two messages in a
+row never overlap (the per-conversation ordering the other transports provide).
+Each inbound update becomes an InboundMessage and flows through the shared
+on_message handler, exactly like any channel.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+
+from gateway.base import InboundMessage, OnMessage
+from gateway.channels.jarvis_app.channel import JarvisAppChannel
+from gateway.channels.jarvis_app.client import (
+    HubClient,
+    PINNED_CONTRACT_VERSION,
+)
+
+logger = logging.getLogger(__name__)
+
+# Degraded-mode backoff: a failed poll waits, doubling to a ceiling, so a hub
+# outage neither spins nor logs a line per attempt.
+_BACKOFF_START_S = 1.0
+_BACKOFF_MAX_S = 60.0
+
+
+class JarvisAppInboundRouter:
+    def __init__(
+        self, channel: JarvisAppChannel, client: HubClient, on_message: OnMessage
+    ) -> None:
+        self._channel = channel
+        self._client = client
+        self._on_message = on_message
+        self._queue: asyncio.Queue = asyncio.Queue()
+        self._stop = asyncio.Event()
+        self._degraded = False  # True while the hub is unreachable — for log-once
+
+    def request_stop(self) -> None:
+        self._stop.set()
+
+    async def run(self) -> None:
+        """Poll and answer until request_stop(); then drain in-flight turns."""
+        await self._check_contract()
+        fetcher = asyncio.create_task(self._fetch_loop())
+        consumer = asyncio.create_task(self._consume_loop())
+
+        await self._stop.wait()
+
+        # Drain: stop fetching (a hanging poll just drops — anything fetched is
+        # already queued, since the ack was the poll), finish queued turns, exit.
+        fetcher.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await fetcher
+        await self._queue.join()
+        consumer.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await consumer
+
+    async def _check_contract(self) -> None:
+        """Warn (never fail) if the hub's contract_version differs from the one
+        this adapter was written against. Silently skipped if the hub is down —
+        the poll loop's degraded mode reports that."""
+        try:
+            health = await self._client.get_health()
+        except Exception:
+            return
+        reported = health.get("contract_version")
+        if reported != PINNED_CONTRACT_VERSION:
+            logger.warning(
+                "jarvis-app hub contract_version %r != pinned %r — proceeding, "
+                "payloads may skew",
+                reported,
+                PINNED_CONTRACT_VERSION,
+            )
+
+    async def _fetch_loop(self) -> None:
+        offset = 0
+        backoff = _BACKOFF_START_S
+        while not self._stop.is_set():
+            try:
+                updates = await self._client.get_updates(offset)
+            except Exception as exc:
+                # A dropped poll must not kill the fetcher — the consumer would sit
+                # idle forever. Log once on entering degraded mode, back off, retry.
+                if not self._degraded:
+                    logger.warning("jarvis-app hub unreachable, backing off: %s", exc)
+                    self._degraded = True
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, _BACKOFF_MAX_S)
+                continue
+            if self._degraded:
+                logger.info("jarvis-app hub reachable again")
+                self._degraded = False
+            backoff = _BACKOFF_START_S
+            for update in updates:
+                # Advance + enqueue before any turn runs: the next poll (which acks
+                # this batch) must not wait behind the turn.
+                offset = update["update_id"] + 1
+                await self._queue.put(update)
+
+    async def _consume_loop(self) -> None:
+        while True:
+            update = await self._queue.get()
+            try:
+                await self._handle(update)
+            except Exception:  # one bad turn must not take the consumer down
+                logger.exception("jarvis-app turn failed")
+            finally:
+                self._queue.task_done()
+
+    async def _handle(self, update: dict) -> None:
+        if update.get("type") != "message":
+            return  # non-message updates carry no turn; the poll already acked them
+        message = update.get("message") or {}
+        # Only the owner's own messages drive a turn — never the agent's own sends
+        # echoed back, which would loop.
+        if message.get("role") != "user":
+            return
+        text = message.get("text") or ""
+
+        # The hub carries no per-message user id (the bot token scopes the single
+        # owner), so user_id/chat_id are placeholders — nothing downstream reads
+        # them; the thread id is what namespaces the conversation.
+        inbound = InboundMessage(
+            user_id=0,
+            chat_id=0,
+            thread_id=self._channel.owner_thread_id,
+            user_text=text,
+        )
+        reply = await self._on_message(inbound)
+        if reply:
+            await self._channel.send(self._channel.owner_thread_id, reply)

--- a/gateway/channels/jarvis_app/router.py
+++ b/gateway/channels/jarvis_app/router.py
@@ -17,6 +17,7 @@ import contextlib
 import logging
 
 from gateway.base import InboundMessage, OnMessage
+from gateway.commands import list_commands
 from gateway.channels.jarvis_app.channel import JarvisAppChannel
 from gateway.channels.jarvis_app.client import (
     HubClient,
@@ -48,6 +49,7 @@ class JarvisAppInboundRouter:
     async def run(self) -> None:
         """Poll and answer until request_stop(); then drain in-flight turns."""
         await self._check_contract()
+        await self._declare_commands()
         fetcher = asyncio.create_task(self._fetch_loop())
         consumer = asyncio.create_task(self._consume_loop())
 
@@ -62,6 +64,21 @@ class JarvisAppInboundRouter:
         consumer.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await consumer
+
+    async def _declare_commands(self) -> None:
+        """Publish the shared slash-command list to the hub so the app's command
+        menu matches the gateway's commands (same source Telegram's menu uses).
+        Non-fatal — a hub that's down at startup just skips it; the poll loop's
+        degraded mode carries on."""
+        commands = [
+            {"name": c.name, "description": c.description} for c in list_commands()
+        ]
+        try:
+            await self._client.declare_commands(commands)
+        except Exception as exc:
+            logger.warning("jarvis-app command declaration skipped: %s", exc)
+        else:
+            logger.info("declared %d slash commands to the jarvis-app hub", len(commands))
 
     async def _check_contract(self) -> None:
         """Warn (never fail) if the hub's contract_version differs from the one

--- a/gateway/channels/jarvis_app/router.py
+++ b/gateway/channels/jarvis_app/router.py
@@ -18,6 +18,7 @@ import logging
 
 from gateway.base import InboundMessage, OnMessage
 from gateway.commands import list_commands
+from gateway.channels.jarvis_app import media_cache
 from gateway.channels.jarvis_app.channel import JarvisAppChannel
 from gateway.channels.jarvis_app.client import (
     HubClient,
@@ -142,6 +143,13 @@ class JarvisAppInboundRouter:
             return
         text = message.get("text") or ""
 
+        attachments = await self._download_attachments(message.get("attachments") or [])
+        # An attachment-only message still needs text for the turn; mirror the
+        # Telegram router's placeholder so the model knows something arrived.
+        if not text and attachments:
+            kinds = ", ".join(a["kind"] for a in attachments)
+            text = f"[attachments: {kinds}]"
+
         # The hub carries no per-message user id (the bot token scopes the single
         # owner), so user_id/chat_id are placeholders — nothing downstream reads
         # them; the thread id is what namespaces the conversation.
@@ -150,7 +158,35 @@ class JarvisAppInboundRouter:
             chat_id=0,
             thread_id=self._channel.owner_thread_id,
             user_text=text,
+            attachments=attachments,
         )
         reply = await self._on_message(inbound)
         if reply:
             await self._channel.send(self._channel.owner_thread_id, reply)
+
+    async def _download_attachments(self, raw: list[dict]) -> list[dict]:
+        """Download each inbound attachment to the channel-owned cache and return
+        the neutral dicts the agent reads (kind, path, mime_type, source). A blob
+        that fails to download is logged and skipped — one bad attachment must not
+        sink the whole turn."""
+        out: list[dict] = []
+        for att in raw:
+            att_id = att.get("id")
+            kind = att.get("kind")
+            if not att_id or not kind:
+                continue
+            try:
+                data = await self._client.download_attachment(att_id)
+            except Exception as exc:
+                logger.warning("jarvis-app attachment %s download failed: %s", att_id, exc)
+                continue
+            path = await asyncio.to_thread(media_cache.save, data, kind, att_id)
+            out.append(
+                {
+                    "kind": kind,
+                    "path": path,
+                    "mime_type": att.get("mime_type") or "",
+                    "source": "jarvis-app",
+                }
+            )
+        return out

--- a/gateway/commands/handlers.py
+++ b/gateway/commands/handlers.py
@@ -19,9 +19,13 @@ logger = logging.getLogger(__name__)
 
 @command("help", "List available slash commands")
 async def _help(inbound: InboundMessage, args: list[str]) -> str:
-    lines = ["**Available commands:**"]
+    # A markdown bullet list (blank line after the header) so both renderers keep
+    # the commands on separate lines: a CommonMark client (the app) treats a bare
+    # newline as a soft break and would otherwise flow them onto one line, while
+    # Telegram's converter renders "- " as "• ".
+    lines = ["**Available commands:**", ""]
     for c in list_commands():
-        lines.append(f"/{c.name} — {c.description}")
+        lines.append(f"- `/{c.name}` — {c.description}")
     return "\n".join(lines)
 
 

--- a/gateway/factory.py
+++ b/gateway/factory.py
@@ -12,9 +12,10 @@ owner-config value (ALLOWED_USER_ID for Telegram) are read here and nowhere
 else — the host process never sees channel-specific configuration.
 """
 
+import asyncio
 import logging
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from typing import Awaitable, Callable, Protocol
 
@@ -28,6 +29,9 @@ from gateway.channels.telegram.channel import TelegramChannel
 from gateway.channels.telegram.confirmation import TelegramConfirmationUI
 from gateway.channels.telegram.host import TelegramHost
 from gateway.channels.telegram.router import TelegramInboundRouter
+from gateway.channels.jarvis_app.channel import JarvisAppChannel
+from gateway.channels.jarvis_app.client import HubClient
+from gateway.channels.jarvis_app.router import JarvisAppInboundRouter
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +62,26 @@ class TelegramStack:
 
     async def stop(self) -> None:
         await self.host.stop()
+
+
+@dataclass
+class JarvisAppStack:
+    channel: JarvisAppChannel
+    client: HubClient
+    router: JarvisAppInboundRouter
+    outbox: Outbox
+    _task: "asyncio.Task | None" = field(default=None, init=False)
+
+    async def start(self) -> None:
+        """Launch the poll-loop router as a background task; returns immediately."""
+        self._task = asyncio.create_task(self.router.run())
+
+    async def stop(self) -> None:
+        """Signal the router to drain in-flight turns, await it, close the client."""
+        self.router.request_stop()
+        if self._task is not None:
+            await self._task
+        await self.client.aclose()
 
 
 # Runtime channel registry for proactive routing. Populated when a stack is
@@ -192,8 +216,42 @@ def _build_telegram_stack(
     )
 
 
+def _build_jarvis_app_stack(
+    on_message: OnMessage,
+    on_confirmation_outcome: Callable[[str, str, Outbox], Awaitable[None]] | None = None,
+    log_sink: LogSink | None = None,
+) -> JarvisAppStack:
+    """Construct and wire the jarvis-app channel — HubClient, channel, outbox, and
+    the poll-loop router — and register the channel for proactive routing. Reads
+    APP_HUB_URL / APP_HUB_BOT_TOKEN / APP_OWNER_USER_ID from the environment.
+
+    No confirmation store is registered yet: a destructive tool on an app-origin
+    turn currently falls back to the default channel's store (a later step gives
+    the app its own handling), so on_confirmation_outcome is accepted for
+    signature parity but unused here."""
+    base_url = os.getenv("APP_HUB_URL")
+    if not base_url:
+        raise ValueError("APP_HUB_URL not set in the environment")
+    token = os.getenv("APP_HUB_BOT_TOKEN")
+    if not token:
+        raise ValueError("APP_HUB_BOT_TOKEN not set in the environment")
+    owner = os.getenv("APP_OWNER_USER_ID")
+    if not owner:
+        raise ValueError("APP_OWNER_USER_ID not set in the environment")
+
+    client = HubClient(base_url, token)
+    channel = JarvisAppChannel(client, owner)
+    outbox = Outbox(channel, log_sink)
+    router = JarvisAppInboundRouter(channel, client, on_message)
+
+    register_channel(channel, outbox)
+    logger.info("jarvis-app stack built (owner=%s)", owner)
+    return JarvisAppStack(channel=channel, client=client, router=router, outbox=outbox)
+
+
 _STACK_BUILDERS: dict[str, Callable[..., Stack]] = {
     "telegram": _build_telegram_stack,
+    "jarvis-app": _build_jarvis_app_stack,
 }
 
 

--- a/main.py
+++ b/main.py
@@ -196,6 +196,22 @@ async def main() -> None:
         log_sink=async_append_notification_log,
     )
 
+    # Optional second channel: the jarvis-app hub, built only when APP_HUB_URL is
+    # set — an instance without it (prod today) constructs nothing and is
+    # byte-identical to before. A misconfigured app channel must never take down
+    # the primary channel, so a build failure logs and continues without it.
+    app_stack = None
+    if os.getenv("APP_HUB_URL"):
+        try:
+            app_stack = build_stack(
+                "jarvis-app",
+                on_message=process_inbound_message,
+                on_confirmation_outcome=on_confirmation_outcome,
+                log_sink=async_append_notification_log,
+            )
+        except Exception:
+            logger.exception("jarvis-app channel misconfigured — continuing without it")
+
     # Media notifications go through the stack's Outbox (send + log-on-success).
     async def _llm_format(prompt: str) -> str:
         return await asyncio.to_thread(ask_jarvis_once, prompt)
@@ -229,6 +245,12 @@ async def main() -> None:
     # Channel up: binds the outbox loop and starts inbound handling, so
     # everything after this point (past-due reminders, scheduler jobs) can send.
     await stack.start()
+
+    # Second channel, if built: start its poll loop (a background task). The
+    # primary channel's start() already bound the shared outbox loop.
+    if app_stack is not None:
+        await app_stack.start()
+        logger.info("jarvis-app channel active (hub polling).")
 
     try:
         # Restore pending reminders from file (wakeups are handled via HEARTBEAT.md).
@@ -281,6 +303,8 @@ async def main() -> None:
     finally:
         logger.info("Shutdown signal received. Stopping channel...")
         scheduler.shutdown(wait=False)
+        if app_stack is not None:
+            await app_stack.stop()
         await stack.stop()
 
     logger.info("Jarvis shut down cleanly.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,7 @@ langsmith==0.9.7
 orjson==3.11.7
 ormsgpack==1.12.2
 packaging==26.0
+Pillow==12.3.0
 proto-plus==1.27.2
 protobuf==6.33.6
 pyasn1==0.6.3


### PR DESCRIPTION
## Stage C — the app channel (jarvis-app), text + media

Ships the custom app as a second channel beside Telegram, without ever making the owner's Telegram loop the test surface. Contract pinned at `3b3a48f330f09a39`; an independent audit confirmed we're **in sync** with `roiguri/jarvis-app-v2@main` (no re-pin).

### What's included
- **C1** — text round-trip (new `gateway/channels/jarvis_app/`: `HubClient`, `JarvisAppChannel`, two-task poll-loop router). Verified live on the phone.
- **C2** — slash commands declared to the hub (`declare_commands`, non-fatal).
- **C6** — origin channel injected into the system-prompt envelope (`[Channel: <name>]`, user scope, derived from the thread-id prefix — no channel-name literal; CI channel-agnostic gate passes).
- **C3** — outbound media: upload (`POST /bot/v1/attachments`, multipart `file`) → send `attachment_ids`. image/audio pass through (image sniffs PNG/JPEG); any other kind raises `NotImplementedError` (Outbox reports a failed send).
- **C4** — inbound media: router downloads `Message.attachments` → channel-owned `media_cache` → `InboundMessage.attachments` → Gemini. Includes review follow-ups: reject malformed `att_` ids before a filesystem path + basename guard; `save` inside the per-attachment try; retrieval note instead of an empty turn when downloads fail.
- **§4** — image upload metadata: `width`/`height` + a base64 blur-up thumbnail (Pillow), so the app reserves aspect ratio (no reflow) and shows a placeholder. Optional and best-effort; `duration_ms` omitted (no outbound-audio producer).
- **`file`-kind honest fallback** — the agent surfaces any unreadable kind as text instead of silently dropping it. Real PDF/video ingestion tracked in #51.
- **`/help`** rendered as a markdown list, portable across renderers.

### Safety / blast radius
- The app channel is built **only when `APP_HUB_URL` is set** — prod (var unset) constructs nothing and is byte-identical. A misconfigured app channel logs and continues; the primary channel is never taken down.
- Hub unreachable → degraded backoff (1→60s), Telegram + heartbeat unaffected.
- `Pillow==12.3.0` added; its import in the channel is guarded so a deploy without it still imports cleanly.

### Deferred (tracked)
- C5 → B2 (`AppConfirmationUI`); app-origin confirmations fall back to Telegram (safe) meanwhile.
- Real `file`-kind ingestion (PDF/video, mime-routed + size guard) → #51.

### Review
- Two independent reviewers (code + upstream-repo) run; all findings resolved or tracked.
- `code-review` skill: **MERGEABLE**, 0 blockers. G3 (agent.py changed channel-neutrally) confirmed intended; docs media-cache rows added.

### Verification status
Media paths verified by driving the real channel code against the live hub (upload/download byte-exact, hub stored width/height/blur_preview, `_handle` cases). **On-device pass through the running service (photo→describe, poster render) + Telegram regression pending a staging restart.**

https://claude.ai/code/session_01TFvpxHSedNUmMzr1TUBQRx
