### PR TITLE
Cost telemetry: correct MODEL_PRICES (6.5x), record reasoning tokens, add cost-review skill

### DIFF
--- a/docs/architecture/OBSERVABILITY.md
+++ b/docs/architecture/OBSERVABILITY.md
@@ -59,6 +59,7 @@ All four live in `/app/jarvis_data/logs/`. All four use the shared `_append_line
   "input_tokens": 4501,
   "cache_read_tokens": 0,
   "output_tokens": 312,
+  "reasoning_tokens": 240,
   "total_tokens": 4813,
   "model": "gemini-3-flash-preview",
   "active_skills_start": [],
@@ -71,6 +72,10 @@ All four live in `/app/jarvis_data/logs/`. All four use the shared `_append_line
 Source: built up across a turn by `observability.telemetry.record_turn_start` (at entry) / `record_llm_call` (per LLM invocation) and flushed by `record_turn_end` (at exit).
 
 `cache_read_tokens` is the count of input tokens served from the provider's prompt cache. It is the signal for evaluating prompt-cache effectiveness — `cache_read_tokens / input_tokens` is the cache hit rate. Reads 0 when caching is not enabled or no cached prefix matched. Sourced from `response.usage_metadata.input_token_details.cache_read` for the langchain-google-genai backend; the field is `None`-safe at every level for providers that don't expose it.
+
+`reasoning_tokens` is the thinking-token slice **of** `output_tokens` — a subset, not an addition, so `input + output` still reconciles with `total_tokens`. Sourced from `response.usage_metadata.output_token_details.reasoning`; `None`-safe at every level, and reads 0 both for non-thinking models and for turns recorded before the field existed (2026-07-30).
+
+It is a **diagnostic, not a billing field**, and this is the one way it differs from `cache_read_tokens`. Cache reads are *input* billed at a discount, so `estimate_usd` subtracts them out of the billable-input bucket. Reasoning tokens are *output* billed at the ordinary output rate and are already counted in `output_tokens` — adding them anywhere in `estimate_usd` would double-count. They are recorded because `thinking_level` (Gemini 3.x) is the largest cost/quality dial available and this is the only observable it moves: without it, a successful `thinking_level` tuning cannot be distinguished from a quality regression, and a model whose reasoning appetite is eating the budget is invisible until the invoice arrives.
 
 `no_action` is `true` iff `scope == "heartbeat"` and the tick sent the user no message. It mirrors delivery: when the tick's `heartbeat_respond` ack is present, `no_action = not ack.notify`; only when the ack is missing does it fall back to checking whether the response text begins with `[NO_ACTION]`. Computed in `ask_jarvis`'s `finally`.
 

--- a/docs/plans/CONTEXT_HANDLING_PLAN.md
+++ b/docs/plans/CONTEXT_HANDLING_PLAN.md
@@ -33,12 +33,18 @@
 
 From `observability.usage` over `turns.jsonl`:
 
-- **Total:** 408 turns, 1,461 LLM calls, 2,777 tool calls, 27.1M input (34% cache-read), 682.6k output, $1.72.
-- **Heartbeat scope:** 335 turns, 22.8M input, $1.44 (84% of spend), 296 `[NO_ACTION]` (88%). No-op tick ≈ 66.3k input / 3.7 LLM calls; acting tick ≈ 79.5k / 4.3.
-- **User scope:** 73 turns, 4.3M input, $0.28, ~59k input per turn, 25% cache-read.
+> **Dollar figures restated 2026-07-29.** The originals were computed with a
+> `MODEL_PRICES` table that priced `gemini-3-flash-preview` 6.5x too low (see
+> [COST_TELEMETRY_PLAN.md](COST_TELEMETRY_PLAN.md) slice A). Token and turn counts
+> below are unchanged and were always correct; only the costs moved. Recomputed
+> over `2026-06-26..2026-07-10`, the window that reproduces the counts below.
+
+- **Total:** 408 turns, 1,461 LLM calls, 2,777 tool calls, 27.1M input (34% cache-read), 682.6k output, **$11.47** (was reported as $1.72).
+- **Heartbeat scope:** 335 turns, 22.8M input, **$9.57** (83% of spend), 296 `[NO_ACTION]` (88%). No-op tick ≈ 66.3k input / 3.7 LLM calls; acting tick ≈ 79.5k / 4.3.
+- **User scope:** 73 turns, 4.3M input, **$1.90**, ~59k input per turn, 25% cache-read.
 - **Cache interpretation:** the `[Current time: … HH:MM …]` envelope is the first line of every system prompt (`agent.py:336-339`) and changes per minute, so no cross-turn prefix survives; the measured 25–40% cache reads are consecutive calls *within* one turn sharing a same-minute prompt.
 
-Absolute cost is small (~$3.7/month on `gemini-3-flash-preview`) — the point is structural: the same architecture on a stronger model, or with more heartbeat tasks, scales linearly with the waste. Latency and answer quality (less noise in context) benefit too.
+Absolute cost is modest (~$25/month on `gemini-3-flash-preview`; originally stated as ~$3.7 under the wrong price table) but the point is structural: the same architecture on a stronger model, or with more heartbeat tasks, scales linearly with the waste. At the corrected rate the stronger-model case is no longer hypothetical — `gemini-3.6-flash` would put this workload near $75/month before any growth. Latency and answer quality (less noise in context) benefit too.
 
 ---
 

--- a/docs/plans/CONTEXT_HANDLING_PLAN.md
+++ b/docs/plans/CONTEXT_HANDLING_PLAN.md
@@ -35,7 +35,7 @@ From `observability.usage` over `turns.jsonl`:
 
 > **Dollar figures restated 2026-07-29.** The originals were computed with a
 > `MODEL_PRICES` table that priced `gemini-3-flash-preview` 6.5x too low (see
-> [COST_TELEMETRY_PLAN.md](COST_TELEMETRY_PLAN.md) slice A). Token and turn counts
+> [COST_TELEMETRY_PLAN.md](archive/COST_TELEMETRY_PLAN.md) slice A). Token and turn counts
 > below are unchanged and were always correct; only the costs moved. Recomputed
 > over `2026-06-26..2026-07-10`, the window that reproduces the counts below.
 

--- a/docs/plans/COST_TELEMETRY_PLAN.md
+++ b/docs/plans/COST_TELEMETRY_PLAN.md
@@ -134,6 +134,10 @@ is the identical defect fixed for `/help` in `899fe67`.
 Verified by rendering through the real `markdown_to_html.convert()`, plus an
 assertion that no emitted line is anything but a list item or a header.
 
+`/usage` is the third handler fixed for this one-at-a-time. The systematic pass —
+write the renderer contract down, add shared layout helpers, convert the rest, and
+add a regression test so it cannot recur — is tracked in **#54**, out of scope here.
+
 ### A4 — doc sync
 
 | file | change |

--- a/docs/plans/COST_TELEMETRY_PLAN.md
+++ b/docs/plans/COST_TELEMETRY_PLAN.md
@@ -212,6 +212,19 @@ must not print a misleading "0% reasoning" for the older half.
 Backfill is a non-issue: the `int(t.get(...) or 0)` idiom already used throughout
 handles absent keys.
 
+### Surfaced by B, deferred — #55
+
+`reasoning_tokens` is the first field ever added mid-stream to `turns.jsonl` (every
+other field has 100% coverage since 2026-05-21), so a rollup window spanning its
+deploy dilutes the thinking percentage — unmeasured output sits in the denominator.
+Self-resolving once the window clears; noted in `_reasoning_pct`.
+
+Checking whether that shape affected anything else turned up a pre-existing case
+that does **not** self-resolve: `no_action_rate` divides heartbeat no-ops by *all*
+turns in the bucket, though only heartbeat turns can ever be one — 87.9% reads as
+70.3%. Latent (the rate is computed but never rendered) and out of scope here.
+Tracked in **#55**.
+
 ### B3 — doc sync
 
 | file | change |
@@ -360,10 +373,10 @@ A ──► B ──► C
 - [x] A4 — `CONTEXT_HANDLING_PLAN.md` baseline restated: the whole dollar block was wrong, not just the `:41` monthly figure
 - [x] A5 — `/usage` rendering: real `- ` list items (fixes app-channel line collapse), `**bold**`, split totals block, magnitude-aware `_usd()`
 - [ ] A — **restart + `/usage week` verified live** (needs the owner)
-- [ ] B1 — `reasoning_tokens` captured in `record_turn_start` / `record_llm_call`
-- [ ] B2 — rolled up + conditionally rendered in `usage.py`
-- [ ] B3 — `OBSERVABILITY.md` schema block + prose paragraph
-- [ ] B — restart + non-zero `reasoning_tokens` on a fresh turn verified live
+- [x] B1 — `reasoning_tokens` captured in `record_turn_start` / `record_llm_call`; `estimate_usd` deliberately untouched (asserted in test)
+- [x] B2 — rolled up + conditionally rendered as `(N% thinking)` in `usage.py`
+- [x] B3 — `OBSERVABILITY.md` schema block + prose paragraph (states the diagnostic-not-billing distinction)
+- [ ] B — **restart + non-zero `reasoning_tokens` on a fresh turn verified live** (needs the owner)
 - [ ] C1 — boundary against `heartbeat-assert` settled (and its description trimmed if needed)
 - [ ] C2 — `.claude/skills/cost-review/SKILL.md`
 - [ ] C3 — skill listed wherever the other two are

--- a/docs/plans/COST_TELEMETRY_PLAN.md
+++ b/docs/plans/COST_TELEMETRY_PLAN.md
@@ -330,6 +330,41 @@ errors the skill warns its reader about:
   stopped thinking" rather than "not recorded yet". Now prints `n/a`, matching the
   honesty rule `_reasoning_pct` applies in the renderer.
 
+### Validated by adversarial run, 2026-07-30
+
+A subagent executed the skill end to end as a fresh reader and was asked to attack it.
+Its core worked — 18/18 rates diffed against the live page, and step 6's
+rank-by-computed-cost was vindicated when two models with identical $0.30 stickers
+landed 47% apart. The scaffolding around it did not. Fixed:
+
+- **Step 2 asked a question its own command could not answer** — the `sed` began *at*
+  `MODEL_PRICES`, hiding the provenance comment the assertion was about. Now anchored
+  on the comment, and cross-checked against the file's git mtime.
+- **Step 2 instructed an edit** ("the date should be refreshed") inside a skill that
+  says twice it changes nothing. Now recommends; never edits.
+- **Step 4's `→ $X/30d` was a no-op** at the default window (`tot/30*30`), an arrow
+  between two identical numbers implying a derivation. Now suppressed unless the
+  window differs.
+- **The window argument was honoured three different ways** — ignored in step 3,
+  hand-edited in step 4, hardcoded in step 6. Now one exported `DAYS`, read by all.
+- **Two assertions referenced a "last review" that cannot exist** — the skill stores
+  no baseline by design. Replaced with a per-day trend series and an explicit
+  statement that no trend claim is possible without the operator's prior output.
+- **Step 7's outcomes were presented as exhaustive and exclusive** and were neither:
+  the run landed in *rates fine, model fine, instrumentation compromised*, which had
+  no slot. Now three independent axes, one of them **measurement apparatus** — a run
+  finding correct rates on broken instrumentation is explicitly not green.
+- Added: log-integrity reporting (records / unparseable / staleness), a
+  priced-but-no-longer-served check, and honest `temperature` wording — the
+  ignored-on-newest-models behaviour is *not* established for `gemini-3-flash-preview`,
+  so the skill now records it as unverified rather than asserting either way.
+
+The log-integrity step immediately earned itself: it surfaced a corrupt record at
+`turns.jsonl:362` that every prior step had silently dropped. Diagnosis — two records
+interleaved mid-line, dated 2026-05-31, five weeks before the repo's first commit.
+`_append_line` holds `_APPEND_LOCK` today and 1,558 turns plus 12,738 tool calls have
+been written cleanly since. Historical, not live; no issue filed.
+
 ### C3 — doc sync
 
 There is **no index of Claude Code skills anywhere in the repo** — verified: neither

--- a/docs/plans/COST_TELEMETRY_PLAN.md
+++ b/docs/plans/COST_TELEMETRY_PLAN.md
@@ -111,6 +111,29 @@ takes Telegram voice notes. `MODEL_PRICES` is single-rate per model and cannot e
 this, so audio-heavy days under-report slightly. Document it in the module docstring;
 do not build modality tiering for a rounding error.
 
+### A5 — `/usage` rendering (added 2026-07-29, not in the original plan)
+
+Folded in while the file was open. Presentation, not correctness — but one part
+*was* a latent bug: `_row_line` emitted a **literal `•`**, which is not a markdown
+list item. Telegram's converter only rewrites `^[-*+]\s`, so the literal bullet
+passed through fine there — but a CommonMark client (the app channel) treats the
+bare newlines between rows as soft breaks and flows every row onto one line. This
+is the identical defect fixed for `/help` in `899fe67`.
+
+- Rows become real `- ` list items; blank line after the title and around the
+  breakdown, so both renderers keep the blocks apart.
+- `**bold**` throughout. `*group*` was hitting `_inline`'s *italic* rule
+  (`markdown_to_html.py:103`), not bold — inconsistent with the `**` title the
+  handler passes in.
+- The eight-field totals line splits into one metric family per line; it was
+  wrapping mid-metric on a phone.
+- `_usd()` replaces `:.4f`: cents at or above $0.01, 4dp below. `$21.1543` was
+  noise on a monthly total, while a sub-cent day still needs the precision.
+- Thousands separators on turn/call counts.
+
+Verified by rendering through the real `markdown_to_html.convert()`, plus an
+assertion that no emitted line is anything but a list item or a header.
+
 ### A4 — doc sync
 
 | file | change |
@@ -327,11 +350,12 @@ A ──► B ──► C
 
 ## Checklist
 
-- [ ] A1 — corrected `MODEL_PRICES` + dated source comment
-- [ ] A2 — unpriced-model marker through `_empty_bucket` / `summarize_usage` / `format_usage_table`
-- [ ] A3 — audio-rate limitation documented in the module docstring
-- [ ] A4 — `CONTEXT_HANDLING_PLAN.md:41` figure corrected
-- [ ] A — restart + `/usage week` verified live
+- [x] A1 — corrected `MODEL_PRICES` (6 models priced) + source dated 2026-07-29
+- [x] A2 — unpriced-model marker through `_empty_bucket` / `summarize_usage` / `_row_line` / `format_usage_table`; rendered on the totals line too, since single-bucket rollups skip the per-row breakdown
+- [x] A3 — audio-rate limitation documented above `MODEL_PRICES` (adjacent to the table it constrains) rather than the module docstring
+- [x] A4 — `CONTEXT_HANDLING_PLAN.md` baseline restated: the whole dollar block was wrong, not just the `:41` monthly figure
+- [x] A5 — `/usage` rendering: real `- ` list items (fixes app-channel line collapse), `**bold**`, split totals block, magnitude-aware `_usd()`
+- [ ] A — **restart + `/usage week` verified live** (needs the owner)
 - [ ] B1 — `reasoning_tokens` captured in `record_turn_start` / `record_llm_call`
 - [ ] B2 — rolled up + conditionally rendered in `usage.py`
 - [ ] B3 — `OBSERVABILITY.md` schema block + prose paragraph

--- a/docs/plans/COST_TELEMETRY_PLAN.md
+++ b/docs/plans/COST_TELEMETRY_PLAN.md
@@ -319,6 +319,17 @@ Steps, each ending in a verdict backed by evidence lines:
 Include the working `models.list` and rollup snippets from this session so the skill is
 executable rather than aspirational.
 
+**Built 2026-07-30.** All six snippets were run against prod data before shipping, which
+caught two defects in the skill's own code — worth recording, because both are the exact
+errors the skill warns its reader about:
+
+- The comparison table sorted by `input_per_m`, printing `$19.89` above `$13.54`. Cost is
+  not monotonic in the sticker price once cache-read rates differ — trap #1 in the skill's
+  own text. Now ranks by computed cost and marks the configured model.
+- The spend rollup printed `think=0%` where nothing had been measured, reading as "it
+  stopped thinking" rather than "not recorded yet". Now prints `n/a`, matching the
+  honesty rule `_reasoning_pct` applies in the renderer.
+
 ### C3 — doc sync
 
 There is **no index of Claude Code skills anywhere in the repo** — verified: neither
@@ -340,8 +351,14 @@ independently reproduce the numbers in this document's baseline table. If it can
 the skill is wrong — this doc's figures were derived by hand from the same sources and
 are the fixture.
 
-**Done when** a clean run reports "rates correct" (A having fixed them) and a
-deliberately corrupted `MODEL_PRICES` entry makes step 2 fail loudly.
+**Done when** a clean run reproduces the baseline and reports "rates correct" — A
+having fixed them.
+
+No corrupted-rate test: step 2 is a fetch-and-compare judgment, not code with a
+red/green state, so "prove it notices a wrong number" reduces to proving a reader can
+read. The mechanical half of that risk — a model priced at $0.00 because it is missing
+from the table — is the one with a real failure mode, and it is covered by assertions
+on `unpriced_models` in slice A.
 
 ---
 
@@ -377,10 +394,10 @@ A ──► B ──► C
 - [x] B2 — rolled up + conditionally rendered as `(N% thinking)` in `usage.py`
 - [x] B3 — `OBSERVABILITY.md` schema block + prose paragraph (states the diagnostic-not-billing distinction)
 - [ ] B — **restart + non-zero `reasoning_tokens` on a fresh turn verified live** (needs the owner)
-- [ ] C1 — boundary against `heartbeat-assert` settled (and its description trimmed if needed)
-- [ ] C2 — `.claude/skills/cost-review/SKILL.md`
-- [ ] C3 — skill listed wherever the other two are
-- [ ] C — clean run reproduces this doc's baseline; corrupted-rate run fails loudly
+- [x] C1 — boundary settled: `heartbeat-assert`'s description now points at `cost-review` for spend, and its §3 states it is regression detection, not a cost check
+- [x] C2 — `.claude/skills/cost-review/SKILL.md`, all six snippets executed against prod data before shipping
+- [x] C3 — no skill index exists in the repo; deliberately not creating one (see A5-style reasoning in C3 above)
+- [ ] C — **clean `/cost-review` run reproduces the baseline** (after the restart, so the numbers mean something)
 - [ ] Two-week reasoning-token baseline accrued → revisit the upgrade question
 
 ---

--- a/docs/plans/COST_TELEMETRY_PLAN.md
+++ b/docs/plans/COST_TELEMETRY_PLAN.md
@@ -1,0 +1,365 @@
+# Cost telemetry — correctness, then visibility, then a repeatable review
+
+**Issue:** _(unfiled)_ — successor concern to #33 "reduce token spend".
+**Date:** 2026-07-29.
+**Inputs:** live `models.list` against the production key; the Gemini pricing page
+(read 2026-07-29); a tool-calling smoke test of `gemini-3.6-flash` /
+`gemini-3.5-flash-lite` through the installed `langchain-google-genai` 4.2.6;
+30-day rollup of `turns.jsonl` (757 turns, 3,076 LLM calls).
+**Companion:** [CONTEXT_HANDLING_PLAN.md](CONTEXT_HANDLING_PLAN.md) — WS2/WS3 attack the
+spend this plan learns to *measure*. Slice A corrects a number that plan quotes.
+
+---
+
+## Manager summary
+
+**Problem.** We cannot currently answer "what does Jarvis cost" correctly. Three
+compounding faults:
+
+1. `MODEL_PRICES` (`observability/usage.py:32`) prices `gemini-3-flash-preview` at
+   $0.075/$0.30 per M tokens. The real rate is **$0.50/$3.00**. Every cost figure
+   the system has ever produced — `/usage`, the `$3.7/month` in
+   [CONTEXT_HANDLING_PLAN.md](CONTEXT_HANDLING_PLAN.md#L41) — is **6.5x low**. Real
+   30-day spend is ~$22, not ~$3.37.
+2. An unknown model silently prices at **$0.00** (`MODEL_PRICES.get(model, _ZERO_PRICE)`).
+   Swapping `agent.py:165` without touching `usage.py` makes `/usage` report zero
+   forever, with no warning.
+3. Output tokens are majority *reasoning* tokens on every Gemini 3.x model, and we
+   don't record them. `thinking_level` is the single biggest cost/quality dial
+   available, and we are blind to the only observable it moves.
+
+**Plan.** Three slices, strictly ordered. Each is independently shippable and
+revertable; none requires deciding on a model upgrade.
+
+| # | Slice | Fixes | Size | Deliverable |
+|---|---|---|---|---|
+| A | Price-table correctness | faults 1 + 2 | ~1h | `/usage` tells the truth, retroactively |
+| B | Reasoning-token capture | fault 3 | ~2h | The `thinking_level` dial becomes measurable |
+| C | `cost-review` skill | recurrence | ~2h | The analysis is repeatable, not a one-off chat |
+
+**Why this order.** A is pure read-side and **retroactively corrects all history** —
+`usd_cost` is computed at read time by `estimate_usd` inside `summarize_usage`, never
+stored in `turns.jsonl`. So fixing the table repairs every rollup back to May without
+touching a log line. B is write-side and only accrues data *forward* from deploy, so
+the sooner it lands the sooner a baseline exists. C consumes both and is worth little
+before they are correct.
+
+**Explicitly out of scope.** The model upgrade itself. This plan makes the decision
+*measurable*; it does not make it. See [Appendix: the upgrade question](#appendix--the-upgrade-question).
+
+---
+
+## Measured baseline (30 days to 2026-07-29)
+
+| scope | turns | LLM calls | input | cache read | output |
+|---|---|---|---|---|---|
+| heartbeat | 587 | 2,619 | 46.2M | 19.6M | 1.05M |
+| user | 170 | 457 | 11.9M | 4.2M | 0.12M |
+| **total** | **757** | **3,076** | **58.1M** | **23.8M** (41%) | **1.17M** |
+
+At corrected rates: **$21.83 / 30d**. Heartbeat is ~80% of it. Reported today: $3.37.
+
+---
+
+## Slice A — price-table correctness
+
+**Goal.** `/usage` reports real dollars, and a model swap can never again silently
+report zero.
+
+### A1 — correct the rate and date the source
+
+`observability/usage.py`, the `MODEL_PRICES` dict and the comment above it. Current
+entry is wrong; the comment's "best-effort estimate … verify against the live pricing
+page" hedge is *why nobody caught it*. Replace the hedge with a verification date.
+
+Rates read from the pricing page on 2026-07-29, USD per M tokens:
+
+| model | input | cache read | output |
+|---|---|---|---|
+| `gemini-3-flash-preview` (current) | 0.50 | 0.05 | 3.00 |
+| `gemini-3.6-flash` | 1.50 | 0.15 | 7.50 |
+| `gemini-3.5-flash` | 1.50 | 0.15 | 9.00 |
+| `gemini-3.5-flash-lite` | 0.30 | — (no context cache) | 2.50 |
+| `gemini-3.1-flash-lite` | 0.25 | 0.025 | 1.50 |
+| `gemini-2.5-flash` | 0.30 | 0.03 | 2.50 |
+
+Pre-populate **all** of them, not just the one in use — that is what makes a future
+model swap a one-line change in `agent.py` instead of a silent-zero incident.
+
+`gemini-3.5-flash-lite` has no standard-tier context caching. Encode it honestly
+(`cache_read_per_m` equal to the input rate, with a comment) so `estimate_usd`'s
+subtract-then-reprice arithmetic still yields the correct total rather than a
+discount that does not exist.
+
+### A2 — make an unpriced model visible
+
+`_ZERO_PRICE` must stay as the fallback (records legitimately carry `model: null` when
+a turn made no LLM call — raising would break `/usage` on real history). But silence
+is the bug. Surface it instead:
+
+- `_empty_bucket` gains an `unpriced_models: set()`.
+- `summarize_usage` adds any `model` that missed `MODEL_PRICES` **and is not `None`**.
+- `_row_line` / `format_usage_table` append a `⚠ unpriced: <name>` marker when the set
+  is non-empty.
+
+A cost of `$0.0000` next to a warning is honest. A cost of `$0.0000` alone is a lie.
+
+### A3 — known limitation, documented not fixed
+
+Audio input bills at 2x text ($1.00/M vs $0.50/M on the current model) and Jarvis
+takes Telegram voice notes. `MODEL_PRICES` is single-rate per model and cannot express
+this, so audio-heavy days under-report slightly. Document it in the module docstring;
+do not build modality tiering for a rounding error.
+
+### A4 — doc sync
+
+| file | change |
+|---|---|
+| `docs/plans/CONTEXT_HANDLING_PLAN.md:41` | `~$3.7/month` → corrected figure. It is the stated justification for WS2 — the true number (~$22/mo, 80% heartbeat) makes that case *stronger* |
+| `observability/usage.py` module comment | hedge → "verified against the pricing page 2026-07-29" |
+
+`docs/architecture/OBSERVABILITY.md` needs no change in this slice — it documents the
+schema, and no schema field moves.
+
+### Verify
+
+Offline first, no restart needed (pure read side):
+
+```bash
+JARVIS_ROOT=/app/jarvis_staging venv/bin/python -c "
+from observability import summarize_usage, israel_last_n_days
+since, until = israel_last_n_days(30)
+rows = summarize_usage(since=since, until=until, group_by='scope')
+for r in rows: print(r['group'], round(r['usd_cost'], 2))"
+```
+
+Expect heartbeat ≈ \$18, user ≈ \$4. Then **ask the owner to restart staging** and run
+`/usage week` on Telegram — the figure should jump ~6.5x versus what it printed before.
+
+**Done when** the offline number matches the table above and `/usage` on the live
+staging bot agrees.
+
+---
+
+## Slice B — reasoning-token capture
+
+**Goal.** Make `thinking_level` measurable before there is any reason to change it.
+
+### Why this is not a cosmetic counter
+
+Reasoning tokens are the *majority* of output on Gemini 3.x. On an identical trivial
+prompt the smoke test returned `reasoning: 59` of 76 output tokens for
+`gemini-3-flash-preview` and `reasoning: 74` of 91 for `gemini-3.6-flash`. Output is
+the expensive side of the bill ($3.00/M today, $7.50/M on 3.6). Without this field we
+cannot distinguish a successful `thinking_level="low"` tuning from a quality
+regression, nor see a model's reasoning appetite eating the budget before the invoice.
+
+**Billing note, and the difference from `cache_read_tokens`:** `cache_read` is a
+*discounted slice of input*, so `estimate_usd` subtracts it out — it changes the
+arithmetic. `reasoning` is a slice of output billed at the **ordinary output rate**.
+It is a **diagnostic, not a billing field**, and `estimate_usd` must stay untouched.
+Getting this backwards would double-count.
+
+### B1 — write side
+
+`observability/telemetry.py`, mirroring the existing `cache_read` handling exactly:
+
+- `record_turn_start`'s accumulator gains `"reasoning_tokens": 0`, positioned with the
+  other token counters.
+- `record_llm_call` reads `usage.get("output_token_details") or {}` then
+  `.get("reasoning")`, with the same None-safe idiom already used for
+  `input_token_details` (providers vary; the field is absent on non-thinking models).
+- Update the `record_llm_call` docstring's `usage_metadata` shape sketch — it currently
+  documents only `input_token_details`.
+
+Field confirmed present in `langchain-google-genai` 4.2.6: the smoke test returned
+`output_token_details={'reasoning': 59}`.
+
+### B2 — read side
+
+`observability/usage.py`: `_empty_bucket`, the `summarize_usage` accumulation loop, and
+`_row_line`. Render it **conditionally**, following the `_cache_pct` precedent — records
+written before this slice have no such key, and a rollup spanning the deploy boundary
+must not print a misleading "0% reasoning" for the older half.
+
+Backfill is a non-issue: the `int(t.get(...) or 0)` idiom already used throughout
+handles absent keys.
+
+### B3 — doc sync
+
+| file | change |
+|---|---|
+| `docs/architecture/OBSERVABILITY.md` (~L50) | add `reasoning_tokens` to the `turns.jsonl` JSON sample **and** a prose paragraph beneath it |
+
+That file documents every non-obvious field with its `usage_metadata` sourcing — the
+`cache_read_tokens` paragraph is the template. The new paragraph must state the
+diagnostic-not-billing distinction, or a future reader will "fix" `estimate_usd` to
+subtract it.
+
+`DEVELOPMENT.md` needs no change in this slice — no new runtime constant. Its
+`LLM_MODEL` / `LLM_TEMPERATURE` rows are the *upgrade's* problem, not this plan's.
+
+### Verify
+
+Restart staging (owner), send one Telegram message, then:
+
+```bash
+JARVIS_ROOT=/app/jarvis_staging venv/bin/python -c "
+import json
+r = [json.loads(l) for l in open('/app/jarvis_staging/jarvis_data/logs/turns.jsonl') if l.strip()][-1]
+print({k: r[k] for k in ('model','output_tokens','reasoning_tokens')})"
+```
+
+**Done when** the newest record carries a non-zero `reasoning_tokens` strictly less
+than its `output_tokens`, and `/usage today` renders the new figure while `/usage`
+over a pre-deploy date still renders cleanly without it.
+
+---
+
+## Slice C — the `cost-review` skill
+
+**Goal.** Turn this conversation into something re-runnable monthly, so price drift
+and model drift get caught by a procedure instead of by chance.
+
+**Placement decision.** A **Claude Code skill** at `.claude/skills/cost-review/SKILL.md`,
+alongside the existing `code-review` and `heartbeat-assert`. Deliberately *not* a
+Jarvis skill under `tools/`: the owner-facing runtime surface already exists as
+`/usage` (`gateway/commands/handlers.py:297`), and a `tools/cost/` skill would
+duplicate it while adding tokens to every prompt. What is missing is the **dev-side
+audit** — the part that reads the live pricing page and the live model list, which
+Jarvis has no business doing hourly.
+
+### C1 — define the boundary against `heartbeat-assert`
+
+`heartbeat-assert` already claims "token usage vs baseline" in its description. Left
+alone, the two skills drift into contradicting each other. The split:
+
+| | `heartbeat-assert` | `cost-review` |
+|---|---|---|
+| Question | is the heartbeat **healthy**? | is our spend **correct and efficient**? |
+| Window | last 48h | last 30d |
+| Unit | ticks, acks, gate decisions | dollars, tokens, rates |
+| External calls | none | pricing page + `models.list` |
+
+`cost-review` must not re-run heartbeat health checks; where the heartbeat's *share* of
+spend looks wrong, it defers to `heartbeat-assert` by name. Trim the token clause from
+`heartbeat-assert`'s description if it reads as overlapping once C ships.
+
+### C2 — the skill itself
+
+Frontmatter per house style: `name`, `description` with explicit triggers ("what does
+Jarvis cost", "cost review", "are we on the right model", "check model pricing").
+`disable-model-invocation: true`, following `heartbeat-assert` — this is an
+owner-initiated audit that makes external web calls, not something to fire
+opportunistically.
+
+Report-only, like both existing skills. It proposes edits; it does not make them.
+
+Steps, each ending in a verdict backed by evidence lines:
+
+1. **Ground truth** — read `agent.py:165` for the model actually configured. Never
+   assume.
+2. **Rate drift** — fetch the pricing page; diff every entry in `MODEL_PRICES` against
+   it. Any mismatch is a **finding**, because it silently corrupts every downstream
+   figure. This is the check that would have caught the 6.5x.
+3. **Coverage** — assert the configured model has a `MODEL_PRICES` entry, and that no
+   model appearing in the last 30d of `turns.jsonl` is unpriced (consumes A2's marker).
+4. **Spend rollup** — 30d by scope via `summarize_usage`; report total, per-scope split,
+   cache hit rate, and (post-B) reasoning share of output.
+5. **Model-landscape check** — live `models.list` against the key; flag newly available
+   models and any configured-model deprecation notice. Note that shutdown dates in
+   Google's table are *earliest possible*, not scheduled.
+6. **Comparison table** — recompute the 30d bill under each priced model at current
+   token volumes. State the two traps explicitly: cache-less models do not deliver
+   their sticker discount, and holding output constant misprices models whose default
+   `thinking_level` differs.
+7. **Verdict** — one of: rates correct + model appropriate; rates stale (list them); or
+   model worth revisiting (with the delta).
+
+Include the working `models.list` and rollup snippets from this session so the skill is
+executable rather than aspirational.
+
+### C3 — doc sync
+
+There is **no index of Claude Code skills anywhere in the repo** — verified: neither
+`CLAUDE.md` nor `DEVELOPMENT.md` mentions `.claude/skills/`, and the only reference in
+`docs/` is a passing one to `code-review` in `DEPLOY.md:159`. So this is not a
+row-append.
+
+Cheapest honest option: nothing. The skills are self-describing and Claude Code
+discovers them. Do **not** create a three-row table that then rots.
+
+If a pointer feels warranted, one line in `CLAUDE.md`'s "Key Files to Know" table
+noting that `.claude/skills/` holds dev-session skills is the whole change — and it
+should be a separate decision, not smuggled in with slice C.
+
+### Verify
+
+Run `/cost-review` against the current tree **after A and B have landed**. It must
+independently reproduce the numbers in this document's baseline table. If it cannot,
+the skill is wrong — this doc's figures were derived by hand from the same sources and
+are the fixture.
+
+**Done when** a clean run reports "rates correct" (A having fixed them) and a
+deliberately corrupted `MODEL_PRICES` entry makes step 2 fail loudly.
+
+---
+
+## Sequencing & house rules
+
+Branch: `feat/cost-telemetry` off `main`. One commit per slice, so any slice reverts
+alone.
+
+```
+A ──► B ──► C
+│     │     └── consumes both; fixture is this doc's baseline table
+│     └── forward-only data; land early to start the baseline
+└── retroactive; unblocks every cost claim in CONTEXT_HANDLING_PLAN.md
+```
+
+- **A and B each need an owner restart** before the live `/usage` reflects them. Claude
+  cannot restart the service — after each slice, ask, then verify from the journal and a
+  Telegram round-trip. Never infer service state.
+- **No commit without approval.** Implement, verify, summarize, then ask.
+- Slice C touches no runtime code and needs no restart.
+- After B lands, let **two weeks** of reasoning-token data accrue before drawing any
+  conclusion about `thinking_level`. A day is not a baseline.
+
+## Checklist
+
+- [ ] A1 — corrected `MODEL_PRICES` + dated source comment
+- [ ] A2 — unpriced-model marker through `_empty_bucket` / `summarize_usage` / `format_usage_table`
+- [ ] A3 — audio-rate limitation documented in the module docstring
+- [ ] A4 — `CONTEXT_HANDLING_PLAN.md:41` figure corrected
+- [ ] A — restart + `/usage week` verified live
+- [ ] B1 — `reasoning_tokens` captured in `record_turn_start` / `record_llm_call`
+- [ ] B2 — rolled up + conditionally rendered in `usage.py`
+- [ ] B3 — `OBSERVABILITY.md` schema block + prose paragraph
+- [ ] B — restart + non-zero `reasoning_tokens` on a fresh turn verified live
+- [ ] C1 — boundary against `heartbeat-assert` settled (and its description trimmed if needed)
+- [ ] C2 — `.claude/skills/cost-review/SKILL.md`
+- [ ] C3 — skill listed wherever the other two are
+- [ ] C — clean run reproduces this doc's baseline; corrupted-rate run fails loudly
+- [ ] Two-week reasoning-token baseline accrued → revisit the upgrade question
+
+---
+
+## Appendix — the upgrade question
+
+Not part of this plan; recorded so the context is not lost.
+
+The configured model, `gemini-3-flash-preview`, is **neither the cheapest nor the most
+capable** option the key can reach — it is 4th of 5 on price. At current volumes:
+`gemini-3.1-flash-lite` $10.92/30d · `gemini-2.5-flash` $13.92 · `gemini-3.5-flash-lite`
+$20.34 · **current $21.83** · `gemini-3.6-flash` $63.75.
+
+Nothing forces a move: `gemini-3-flash-preview` has **no announced shutdown date**
+(unlike `gemini-3-pro-preview`, retired 2026-03-09). The real blockers on any move to a
+3.x-latest model are behavioral, not commercial — `temperature` is accepted but
+**silently ignored**, which nullifies `agent.py:166`'s `temperature=0.2` and its
+"deterministic tool usage" rationale; and `thinking_level` replaces it as the control
+surface. Neither can be evaluated responsibly until slice B is measuring.
+
+Revisit after the two-week baseline, and after
+[CONTEXT_HANDLING_PLAN.md](CONTEXT_HANDLING_PLAN.md) WS2/WS3 — halving heartbeat context
+changes every row in that comparison.

--- a/docs/plans/archive/COST_TELEMETRY_PLAN.md
+++ b/docs/plans/archive/COST_TELEMETRY_PLAN.md
@@ -1,12 +1,15 @@
 # Cost telemetry — correctness, then visibility, then a repeatable review
 
+**Status:** all three slices shipped & verified on staging 2026-07-30; plan archived.
+Prod picks them up on the next `deploy/deploy.sh` run — until then prod's `/usage`
+still reports the 6.5x-low figures and records no `reasoning_tokens`.
 **Issue:** _(unfiled)_ — successor concern to #33 "reduce token spend".
-**Date:** 2026-07-29.
+**Date:** 2026-07-29 → archived 2026-07-30.
 **Inputs:** live `models.list` against the production key; the Gemini pricing page
 (read 2026-07-29); a tool-calling smoke test of `gemini-3.6-flash` /
 `gemini-3.5-flash-lite` through the installed `langchain-google-genai` 4.2.6;
 30-day rollup of `turns.jsonl` (757 turns, 3,076 LLM calls).
-**Companion:** [CONTEXT_HANDLING_PLAN.md](CONTEXT_HANDLING_PLAN.md) — WS2/WS3 attack the
+**Companion:** [CONTEXT_HANDLING_PLAN.md](../CONTEXT_HANDLING_PLAN.md) — WS2/WS3 attack the
 spend this plan learns to *measure*. Slice A corrects a number that plan quotes.
 
 ---
@@ -19,7 +22,7 @@ compounding faults:
 1. `MODEL_PRICES` (`observability/usage.py:32`) prices `gemini-3-flash-preview` at
    $0.075/$0.30 per M tokens. The real rate is **$0.50/$3.00**. Every cost figure
    the system has ever produced — `/usage`, the `$3.7/month` in
-   [CONTEXT_HANDLING_PLAN.md](CONTEXT_HANDLING_PLAN.md#L41) — is **6.5x low**. Real
+   [CONTEXT_HANDLING_PLAN.md](../CONTEXT_HANDLING_PLAN.md#L41) — is **6.5x low**. Real
    30-day spend is ~$22, not ~$3.37.
 2. An unknown model silently prices at **$0.00** (`MODEL_PRICES.get(model, _ZERO_PRICE)`).
    Swapping `agent.py:165` without touching `usage.py` makes `/usage` report zero
@@ -424,16 +427,16 @@ A ──► B ──► C
 - [x] A3 — audio-rate limitation documented above `MODEL_PRICES` (adjacent to the table it constrains) rather than the module docstring
 - [x] A4 — `CONTEXT_HANDLING_PLAN.md` baseline restated: the whole dollar block was wrong, not just the `:41` monthly figure
 - [x] A5 — `/usage` rendering: real `- ` list items (fixes app-channel line collapse), `**bold**`, split totals block, magnitude-aware `_usd()`
-- [ ] A — **restart + `/usage week` verified live** (needs the owner)
+- [x] A — verified live on staging 2026-07-30: `/usage week` renders the new layout, and the same week that printed $0.0254 under the old table now prints $0.17 (6.7x)
 - [x] B1 — `reasoning_tokens` captured in `record_turn_start` / `record_llm_call`; `estimate_usd` deliberately untouched (asserted in test)
 - [x] B2 — rolled up + conditionally rendered as `(N% thinking)` in `usage.py`
 - [x] B3 — `OBSERVABILITY.md` schema block + prose paragraph (states the diagnostic-not-billing distinction)
-- [ ] B — **restart + non-zero `reasoning_tokens` on a fresh turn verified live** (needs the owner)
+- [x] B — verified live on staging 2026-07-30: a real `jarvis-app` turn recorded `reasoning_tokens: 478` of 778 output (61%), and `/usage` renders `(N% thinking)`
 - [x] C1 — boundary settled: `heartbeat-assert`'s description now points at `cost-review` for spend, and its §3 states it is regression detection, not a cost check
 - [x] C2 — `.claude/skills/cost-review/SKILL.md`, all six snippets executed against prod data before shipping
 - [x] C3 — no skill index exists in the repo; deliberately not creating one (see A5-style reasoning in C3 above)
-- [ ] C — **clean `/cost-review` run reproduces the baseline** (after the restart, so the numbers mean something)
-- [ ] Two-week reasoning-token baseline accrued → revisit the upgrade question
+- [x] C — an adversarial subagent run reproduced the prod baseline ($21.25/30d, 79.4% heartbeat) and diffed 18/18 rates green; the eleven scaffolding defects it found are fixed and re-tested
+- [ ] **Carried forward, not done here:** deploy to prod, then let a two-week `reasoning_tokens` baseline accrue → revisit the upgrade question (see Appendix)
 
 ---
 
@@ -454,5 +457,5 @@ Nothing forces a move: `gemini-3-flash-preview` has **no announced shutdown date
 surface. Neither can be evaluated responsibly until slice B is measuring.
 
 Revisit after the two-week baseline, and after
-[CONTEXT_HANDLING_PLAN.md](CONTEXT_HANDLING_PLAN.md) WS2/WS3 — halving heartbeat context
+[CONTEXT_HANDLING_PLAN.md](../CONTEXT_HANDLING_PLAN.md) WS2/WS3 — halving heartbeat context
 changes every row in that comparison.

--- a/observability/telemetry.py
+++ b/observability/telemetry.py
@@ -66,6 +66,7 @@ def record_turn_start(
         "input_tokens": 0,
         "cache_read_tokens": 0,
         "output_tokens": 0,
+        "reasoning_tokens": 0,
         "total_tokens": 0,
         "model": model,
         "active_skills_start": sorted(active_skills_start or []),
@@ -82,11 +83,21 @@ def record_llm_call(response: Any) -> None:
 
     Gemini's usage_metadata shape (via langchain-google-genai):
         {"input_tokens": ..., "output_tokens": ..., "total_tokens": ...,
-         "input_token_details": {"cache_read": ...}}
+         "input_token_details": {"cache_read": ...},
+         "output_token_details": {"reasoning": ...}}
 
     `cache_read` is the count of input tokens served from the prompt cache —
-    the dollar-saving metric for Lever 4 of #33. Treat usage_metadata and
-    its sub-dicts as None-safe; providers vary.
+    the dollar-saving metric for Lever 4 of #33.
+
+    `reasoning` is the thinking-token slice of output_tokens. Unlike cache_read
+    it does NOT change the cost arithmetic: cache reads are input billed at a
+    discount, whereas reasoning is output billed at the ordinary output rate and
+    is already inside output_tokens. It is recorded as a diagnostic — it is the
+    only observable that `thinking_level` moves, so without it a tuning change
+    cannot be told apart from a regression.
+
+    Treat usage_metadata and its sub-dicts as None-safe; providers vary, and
+    non-thinking models omit output_token_details entirely.
     """
     acc = TURN_ACC.get()
     if acc is None:
@@ -99,6 +110,8 @@ def record_llm_call(response: Any) -> None:
         acc["total_tokens"] += int(usage.get("total_tokens") or 0)
         details = usage.get("input_token_details") or {}
         acc["cache_read_tokens"] += int(details.get("cache_read") or 0)
+        out_details = usage.get("output_token_details") or {}
+        acc["reasoning_tokens"] += int(out_details.get("reasoning") or 0)
     if acc.get("model") is None:
         md = getattr(response, "response_metadata", None) or {}
         model = md.get("model_name") or md.get("model")

--- a/observability/usage.py
+++ b/observability/usage.py
@@ -23,16 +23,56 @@ _IL_TZ = ZoneInfo("Asia/Jerusalem")
 
 GroupBy = Literal["day", "week", "scope", "day+scope"]
 
-# USD per million tokens. Update from https://ai.google.dev/pricing when the
-# model changes. Cache-reads are billed separately at a discounted rate; the
-# rate below is a best-effort estimate (Gemini Flash family historically
-# ~25% of the normal input price) — verify against the live pricing page
-# before reading dollar figures literally.
+# USD per million tokens, read from https://ai.google.dev/gemini-api/docs/pricing
+# and verified 2026-07-29. Re-verify on the same page before trusting any dollar
+# figure — these are transcribed constants, not a live feed, and a stale entry
+# silently corrupts every rollup rather than failing. The `cost-review` skill
+# exists to diff this table against the page on demand.
+#
+# Every model we might plausibly switch to is priced here, not just the one in
+# use: an unknown model falls back to _ZERO_PRICE, so a one-line model swap in
+# agent.py would otherwise report $0.00 forever. summarize_usage flags that case
+# via `unpriced_models`, but a present entry is better than a caught mistake.
+#
+# Known limitation: audio input bills at roughly 2x text on these models (e.g.
+# $1.00/M vs $0.50/M for gemini-3-flash-preview), and Telegram voice notes do
+# reach the model. One rate per model cannot express that, so audio-heavy days
+# under-report slightly. Deliberately not modelled — modality tiering is a lot
+# of machinery for a rounding error at current volumes.
 MODEL_PRICES: dict[str, dict[str, float]] = {
     "gemini-3-flash-preview": {
-        "input_per_m": 0.075,
-        "cache_read_per_m": 0.01875,
-        "output_per_m": 0.30,
+        "input_per_m": 0.50,
+        "cache_read_per_m": 0.05,
+        "output_per_m": 3.00,
+    },
+    "gemini-3.6-flash": {
+        "input_per_m": 1.50,
+        "cache_read_per_m": 0.15,
+        "output_per_m": 7.50,
+    },
+    "gemini-3.5-flash": {
+        "input_per_m": 1.50,
+        "cache_read_per_m": 0.15,
+        "output_per_m": 9.00,
+    },
+    "gemini-3.5-flash-lite": {
+        "input_per_m": 0.30,
+        # No context caching on the standard tier for this model. Pricing cache
+        # reads at the full input rate keeps estimate_usd's subtract-then-reprice
+        # arithmetic correct; a lower number here would invent a discount that
+        # the bill does not give us.
+        "cache_read_per_m": 0.30,
+        "output_per_m": 2.50,
+    },
+    "gemini-3.1-flash-lite": {
+        "input_per_m": 0.25,
+        "cache_read_per_m": 0.025,
+        "output_per_m": 1.50,
+    },
+    "gemini-2.5-flash": {
+        "input_per_m": 0.30,
+        "cache_read_per_m": 0.03,
+        "output_per_m": 2.50,
     },
 }
 _ZERO_PRICE = {"input_per_m": 0.0, "cache_read_per_m": 0.0, "output_per_m": 0.0}
@@ -137,6 +177,11 @@ def _empty_bucket(key: str) -> dict:
         "no_action_count": 0,
         "errors": 0,
         "usd_cost": 0.0,
+        # Models seen in this bucket that MODEL_PRICES has no entry for, so their
+        # tokens contributed $0.00 to usd_cost. A set while accumulating;
+        # summarize_usage converts it to a sorted list before returning so rows
+        # stay JSON-serializable.
+        "unpriced_models": set(),
     }
 
 
@@ -148,6 +193,11 @@ def summarize_usage(
 ) -> list[dict]:
     """Group + roll up turns in [since, until). Returns rows sorted ascending
     by group key. Each row also carries ``no_action_rate`` for convenience.
+
+    Rows carry ``unpriced_models`` (sorted list): models whose tokens fell
+    through to _ZERO_PRICE and so contributed nothing to ``usd_cost``. A
+    zero-dollar row is indistinguishable from a free one otherwise, which is
+    how a wrong price table stays hidden — callers should surface it.
 
     Pure: no I/O beyond load_turns; no global state. Suitable for REPL use:
         >>> from tools.core.usage import summarize_usage
@@ -171,15 +221,21 @@ def summarize_usage(
             b["no_action_count"] += 1
         if t.get("error"):
             b["errors"] += 1
+        model = t.get("model")
+        # A null model means the turn made no LLM call (nothing to price), which
+        # is not a pricing gap — only a named model we cannot price is.
+        if model and model not in MODEL_PRICES:
+            b["unpriced_models"].add(model)
         b["usd_cost"] += estimate_usd(
             int(t.get("input_tokens") or 0),
             int(t.get("cache_read_tokens") or 0),
             int(t.get("output_tokens") or 0),
-            t.get("model"),
+            model,
         )
     rows = sorted(buckets.values(), key=lambda r: r["group"])
     for r in rows:
         r["no_action_rate"] = (r["no_action_count"] / r["turns"]) if r["turns"] else 0.0
+        r["unpriced_models"] = sorted(r["unpriced_models"])
     return rows
 
 
@@ -199,41 +255,98 @@ def _human_tokens(n: int) -> str:
 
 
 def _cache_pct(input_tokens: int, cache_read_tokens: int) -> str:
-    """Render '23% cached' or just '' when there's nothing meaningful to show."""
+    """Render ' (23% cached)' or just '' when there's nothing meaningful to show."""
     if input_tokens <= 0 or cache_read_tokens <= 0:
         return ""
-    return f", {cache_read_tokens / input_tokens:.0%} cached"
+    return f" ({cache_read_tokens / input_tokens:.0%} cached)"
+
+
+def _usd(amount: float) -> str:
+    """Money at a precision that suits the magnitude. A 30-day total wants
+    '$21.15', not '$21.1543'; a single cheap turn genuinely needs '$0.0008'.
+
+    Two tiers, not three: cents everywhere they carry information, and 4dp only
+    below a cent. A middle tier reads as inconsistent when sibling rows in one
+    breakdown land on either side of it ('$3.24' next to '$0.784')."""
+    if amount >= 0.01:
+        return f"${amount:,.2f}"
+    return f"${amount:.4f}"
+
+
+def _unpriced_note(models: list[str]) -> str:
+    """Render '⚠ unpriced: gemini-x' or '' — the marker that keeps a $0.00 from
+    reading as free. Rendered on the totals block as well as per-row, because
+    single-bucket rollups skip the per-row breakdown entirely."""
+    if not models:
+        return ""
+    return f"⚠ unpriced: {', '.join(models)}"
+
+
+def _extras(no_action: int, errors: int, unpriced: list[str]) -> list[str]:
+    """The optional trailing annotations shared by the totals block and each
+    row. Returned as parts so callers choose their own separator — the totals
+    block renders them as a standalone line, a row appends them inline."""
+    parts = []
+    if no_action:
+        parts.append(f"{no_action} NO_ACTION")
+    if errors:
+        parts.append(f"{errors} error{'s' if errors != 1 else ''}")
+    note = _unpriced_note(unpriced)
+    if note:
+        parts.append(note)
+    return parts
 
 
 def _row_line(r: dict) -> str:
-    """One bullet for a group row: key — turns, tokens, cost, extras."""
-    extras = []
-    if r.get("no_action_count"):
-        extras.append(f"{r['no_action_count']} NO_ACTION")
-    if r.get("errors"):
-        extras.append(f"{r['errors']} error{'s' if r['errors'] != 1 else ''}")
-    extras_str = f" · {' · '.join(extras)}" if extras else ""
+    """One markdown list item for a group row: key — turns, tokens, cost, extras.
+
+    A real '- ' list item, not a literal '•': Telegram's converter renders '- '
+    as '• ', while a CommonMark client (the app) needs genuine list syntax —
+    given bare newlines it treats them as soft breaks and flows every row onto
+    one line. Same reasoning as the /help handler.
+    """
+    parts = _extras(
+        r.get("no_action_count", 0), r.get("errors", 0), r.get("unpriced_models") or []
+    )
     return (
-        f"• *{r['group']}* — {r['turns']} turn{'s' if r['turns'] != 1 else ''}, "
+        f"- **{r['group']}** — {r['turns']:,} turn{'s' if r['turns'] != 1 else ''} · "
         f"{_human_tokens(r['input_tokens'])} in"
         f"{_cache_pct(r['input_tokens'], r['cache_read_tokens'])}"
-        f" → {_human_tokens(r['output_tokens'])} out"
-        f", ${r['usd_cost']:.4f}{extras_str}"
+        f" → {_human_tokens(r['output_tokens'])} out · "
+        f"{_usd(r['usd_cost'])}"
+        + (f" · {' · '.join(parts)}" if parts else "")
     )
 
 
 def format_usage_table(rows: list[dict], title: str = "") -> str:
-    """Render rollup rows as a compact text summary:
+    """Render rollup rows as a markdown summary:
 
-        *Title*
-        Total: N turns · IN → OUT tokens · $USD [· extras]
+        **Title**
 
-        • *group key* — N turns, IN in [, P% cached] → OUT out, $USD [· extras]
+        - **N** turns · N LLM calls · N tool calls
+        - **IN** in (P% cached) → **OUT** out
+        - **$USD** total
+        - N NO_ACTION · N errors            (omitted when all zero)
+
+        **Breakdown**
+
+        - **group key** — N turns · IN in (P% cached) → OUT out · $USD [· extras]
         ...
 
+    Every block is a real markdown list separated by blank lines, because the
+    output crosses two renderers: Telegram converts '- ' to '• ', while a
+    CommonMark client (the app) collapses bare newlines into one paragraph and
+    needs genuine list syntax to keep rows apart. Emphasis is '**bold**' for the
+    same reason — single '*' is *italic* in both, which is not what the numbers
+    want. See the /help handler for the precedent.
+
+    `extras` carries NO_ACTION / error counts and, when any model in the period
+    is missing from MODEL_PRICES, an '⚠ unpriced' marker — without it a $0.00
+    from a stale price table is indistinguishable from a genuinely free period.
+
     Function name kept (format_usage_table) for compatibility with the slash
-    command and existing callers, but the layout is now a vertical summary
-    rather than a fixed-width table — readable on mobile, no horizontal scroll.
+    command and existing callers, though the layout is a vertical summary rather
+    than a fixed-width table — readable on mobile, no horizontal scroll.
     """
     if not rows:
         return (
@@ -251,29 +364,33 @@ def format_usage_table(rows: list[dict], title: str = "") -> str:
     totals_errors = sum(r["errors"] for r in rows)
     totals_usd = sum(r["usd_cost"] for r in rows)
 
-    extras = []
-    if totals_no_action:
-        extras.append(f"{totals_no_action} NO_ACTION")
-    if totals_errors:
-        extras.append(f"{totals_errors} error{'s' if totals_errors != 1 else ''}")
-    extras_str = f" · {' · '.join(extras)}" if extras else ""
+    totals_unpriced = sorted({m for r in rows for m in (r.get("unpriced_models") or [])})
+    extras_parts = _extras(totals_no_action, totals_errors, totals_unpriced)
 
     out: list[str] = []
     if title:
-        out.append(title)
+        # Blank line after the header, or a CommonMark client runs it into the
+        # first list item.
+        out.extend([title, ""])
+    # One metric family per line rather than eight fields on one — the single
+    # line wrapped mid-metric on a phone, which is what made it unreadable.
     out.append(
-        f"Total: {totals_turns} turn{'s' if totals_turns != 1 else ''} · "
-        f"{totals_llm} LLM · "
-        f"{totals_tools} tool{'s' if totals_tools != 1 else ''} · "
-        f"{_human_tokens(totals_in)} in"
-        f"{_cache_pct(totals_in, totals_cache)} → "
-        f"{_human_tokens(totals_out)} out · "
-        f"${totals_usd:.4f}{extras_str}"
+        f"- **{totals_turns:,}** turn{'s' if totals_turns != 1 else ''} · "
+        f"{totals_llm:,} LLM call{'s' if totals_llm != 1 else ''} · "
+        f"{totals_tools:,} tool call{'s' if totals_tools != 1 else ''}"
     )
+    out.append(
+        f"- **{_human_tokens(totals_in)}** in"
+        f"{_cache_pct(totals_in, totals_cache)}"
+        f" → **{_human_tokens(totals_out)}** out"
+    )
+    out.append(f"- **{_usd(totals_usd)}** total")
+    if extras_parts:
+        out.append(f"- {' · '.join(extras_parts)}")
     # Single-row tables (one bucket = whole period) are redundant — totals already
     # cover the whole story. Show the per-row breakdown only when there are 2+.
     if len(rows) > 1:
-        out.append("")
+        out.extend(["", "**Breakdown**", ""])
         for r in rows:
             out.append(_row_line(r))
     return "\n".join(out)

--- a/observability/usage.py
+++ b/observability/usage.py
@@ -173,6 +173,10 @@ def _empty_bucket(key: str) -> dict:
         "input_tokens": 0,
         "cache_read_tokens": 0,
         "output_tokens": 0,
+        # Thinking-token slice of output_tokens. Diagnostic only — billed at the
+        # ordinary output rate, so it never enters estimate_usd. Reads 0 for
+        # records written before the field existed, and for non-thinking models.
+        "reasoning_tokens": 0,
         "total_tokens": 0,
         "no_action_count": 0,
         "errors": 0,
@@ -199,6 +203,10 @@ def summarize_usage(
     zero-dollar row is indistinguishable from a free one otherwise, which is
     how a wrong price table stays hidden — callers should surface it.
 
+    ``reasoning_tokens`` is the thinking slice of ``output_tokens``, not an
+    addition to it, and carries no separate price — do not add it to usd_cost.
+    Reads 0 for turns recorded before the field existed.
+
     Pure: no I/O beyond load_turns; no global state. Suitable for REPL use:
         >>> from tools.core.usage import summarize_usage
         >>> rows = summarize_usage(group_by="day+scope")
@@ -216,6 +224,7 @@ def summarize_usage(
         b["input_tokens"] += int(t.get("input_tokens") or 0)
         b["cache_read_tokens"] += int(t.get("cache_read_tokens") or 0)
         b["output_tokens"] += int(t.get("output_tokens") or 0)
+        b["reasoning_tokens"] += int(t.get("reasoning_tokens") or 0)
         b["total_tokens"] += int(t.get("total_tokens") or 0)
         if t.get("no_action"):
             b["no_action_count"] += 1
@@ -259,6 +268,21 @@ def _cache_pct(input_tokens: int, cache_read_tokens: int) -> str:
     if input_tokens <= 0 or cache_read_tokens <= 0:
         return ""
     return f" ({cache_read_tokens / input_tokens:.0%} cached)"
+
+
+def _reasoning_pct(output_tokens: int, reasoning_tokens: int) -> str:
+    """Render ' (61% thinking)' or ''. Conditional for the same reason as
+    _cache_pct, plus one of its own: records written before reasoning_tokens
+    existed carry no such key, so a bucket containing only those must stay
+    silent rather than claim a measured '0% thinking'.
+
+    A bucket that *mixes* pre- and post-field turns still dilutes the ratio —
+    unmeasured output sits in the denominator. Inherent to introducing a metric
+    mid-stream; per-day rows isolate it, and it resolves once the window clears
+    the deploy. Don't read a boundary-spanning aggregate as a trend."""
+    if output_tokens <= 0 or reasoning_tokens <= 0:
+        return ""
+    return f" ({reasoning_tokens / output_tokens:.0%} thinking)"
 
 
 def _usd(amount: float) -> str:
@@ -312,7 +336,8 @@ def _row_line(r: dict) -> str:
         f"- **{r['group']}** — {r['turns']:,} turn{'s' if r['turns'] != 1 else ''} · "
         f"{_human_tokens(r['input_tokens'])} in"
         f"{_cache_pct(r['input_tokens'], r['cache_read_tokens'])}"
-        f" → {_human_tokens(r['output_tokens'])} out · "
+        f" → {_human_tokens(r['output_tokens'])} out"
+        f"{_reasoning_pct(r['output_tokens'], r.get('reasoning_tokens', 0))} · "
         f"{_usd(r['usd_cost'])}"
         + (f" · {' · '.join(parts)}" if parts else "")
     )
@@ -324,7 +349,7 @@ def format_usage_table(rows: list[dict], title: str = "") -> str:
         **Title**
 
         - **N** turns · N LLM calls · N tool calls
-        - **IN** in (P% cached) → **OUT** out
+        - **IN** in (P% cached) → **OUT** out (P% thinking)
         - **$USD** total
         - N NO_ACTION · N errors            (omitted when all zero)
 
@@ -357,6 +382,7 @@ def format_usage_table(rows: list[dict], title: str = "") -> str:
     totals_in = sum(r["input_tokens"] for r in rows)
     totals_cache = sum(r["cache_read_tokens"] for r in rows)
     totals_out = sum(r["output_tokens"] for r in rows)
+    totals_reasoning = sum(r.get("reasoning_tokens", 0) for r in rows)
     totals_turns = sum(r["turns"] for r in rows)
     totals_llm = sum(r["llm_calls"] for r in rows)
     totals_tools = sum(r["tool_calls"] for r in rows)
@@ -383,6 +409,7 @@ def format_usage_table(rows: list[dict], title: str = "") -> str:
         f"- **{_human_tokens(totals_in)}** in"
         f"{_cache_pct(totals_in, totals_cache)}"
         f" → **{_human_tokens(totals_out)}** out"
+        f"{_reasoning_pct(totals_out, totals_reasoning)}"
     )
     out.append(f"- **{_usd(totals_usd)}** total")
     if extras_parts:


### PR DESCRIPTION
Every dollar figure this project has ever produced was **6.5x low**, and nothing
was looking for it. `MODEL_PRICES` priced `gemini-3-flash-preview` at $0.075/$0.30
per M tokens; the real rate is $0.50/$3.00. Real 30-day spend is **$21.25**, not
$3.37. The system behaved perfectly throughout — it simply lied about money, which
is why no behavioral check ever caught it.

Three slices, planned in `docs/plans/archive/COST_TELEMETRY_PLAN.md` (archived in
this PR).

## A — price-table correctness

`usd_cost` is computed by `estimate_usd` at read time and never stored in
`turns.jsonl`, so correcting the table **repairs every historical rollup** rather
than only future ones. `CONTEXT_HANDLING_PLAN`'s measured baseline is restated
accordingly ($1.72 → $11.47 over the window that reproduces its turn counts); its
token and turn counts were always correct and are untouched.

All six plausible successor models are priced, not just the one in use — an unknown
model falls through to `_ZERO_PRICE`, so a one-line model swap in `agent.py` would
otherwise report $0.00 forever. Where a gap survives anyway, `summarize_usage` now
reports it via `unpriced_models` and the renderer marks it; a `$0.00` next to a
warning is honest, a bare `$0.00` is a lie.

Also fixes a latent `/usage` rendering bug: `_row_line` emitted a **literal `•`**,
which is not a markdown list item. Telegram's converter passed it through, but a
CommonMark client (the app channel) collapses the bare newlines between rows into
one paragraph — the same defect fixed for `/help` in 899fe67. Third handler hit by
this; the systematic pass is **#54**.

## B — reasoning-token capture

A live call for *"why is the sky blue, one sentence"* returned 358 output tokens of
which **338 — 94% — were reasoning**. Output is the expensive side of the bill
($3.00/M now, $7.50/M on 3.6) and none of it was recorded. `thinking_level` is the
largest cost/quality dial these models expose and this is the only observable it
moves.

**Diagnostic, not billing** — the one way it differs from `cache_read_tokens`, and
the distinction is stated in `OBSERVABILITY.md` so a future reader does not "fix"
it. Cache reads are input billed at a discount, so `estimate_usd` subtracts them.
Reasoning is output billed at the ordinary rate and already inside `output_tokens`;
adding it anywhere would double-count. A test asserts the word does not appear in
that function's source.

## C — a `cost-review` skill

The check that would have caught the 6.5x: diff `MODEL_PRICES` against the live
pricing page. Kept separate from `heartbeat-assert` rather than merged into one
"health" skill — they take ground truth from opposite directions (a frozen internal
baseline vs. the network), run on different cadences, and diffing a hardcoded table
against a vendor page is closer to a dependency-staleness audit than a health check.
The skill file itself is gitignored; only its plan record is tracked here.

An adversarial subagent ran it end to end and found eleven scaffolding defects,
all fixed and re-tested. The sharpest: step 7's outcomes were framed as exhaustive
and exclusive and were neither — the run landed in *rates correct, model fine,
instrumentation compromised*, which had no slot. In a skill that exists because a
measurement was silently wrong, that was the hole. Correct rates on broken
instrumentation is now explicitly **not** a green run.

## Verification

Verified live on staging: `/usage week` renders the new layout, and the same week
that printed $0.0254 under the old table now prints **$0.17 (6.7x)**. A real
`jarvis-app` turn recorded `reasoning_tokens: 478` of 778 output (61%).

Unit-level: live Gemini call through the real telemetry path; full JSONL write path
against a temp log (a response with no `output_token_details` adds 0 and does not
crash); backward compatibility over pre-field records; `reasoning <= output`;
`input + output` still reconciling with `total_tokens`; the `⚠ unpriced` marker on
both totals and row; rows JSON-serializable; and every `/usage` line rendered through
the real `markdown_to_html.convert()`.

## Not in this PR

**Prod still runs the old code** — it is deploy-only and this branch has not been
deployed, so prod's `/usage` still reports the 6.5x-low figures and records no
`reasoning_tokens`. The two-week baseline that would inform the model-upgrade
decision cannot start accruing until `deploy/deploy.sh` runs.

The archived plan's Appendix carries the only record of the upgrade blockers —
`temperature` becoming a no-op on newer 3.x models, `thinking_level` replacing it,
prefilled model turns returning 400. That decision is open and should move to a
live surface rather than stay in `archive/`.

Also filed along the way: **#54** (slash-command reply formatting) and **#55**
(`no_action_rate` divides by all turns though only heartbeat turns can be no-ops —
87.9% reads as 70.3%; latent, since the rate is computed but never rendered).
