### PR TITLE
Ingest inbound documents and videos across channels (#51)

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -621,11 +621,11 @@ def ask_jarvis(
                     if not media_type or not media_path:
                         continue
 
-                    # A media kind this build can't feed to the model (e.g. a
-                    # "file" — documents today, video later). Surface it as text so
-                    # the reply is honest rather than silently ignoring the
-                    # attachment, and skip reading bytes we have no way to use.
-                    if media_type not in ("image", "audio", "video"):
+                    # A media kind this build can't feed to the model — a "file",
+                    # meaning the channel could not identify it. Surface it as
+                    # text so the reply is honest rather than silently ignoring
+                    # the attachment, and skip reading bytes we can't use.
+                    if media_type not in ("image", "audio", "video", "document"):
                         label = f"{media_type} ({mime_type})" if mime_type else media_type
                         content.append({
                             "type": "text",
@@ -698,6 +698,20 @@ def ask_jarvis(
                         content.append({
                             "type": "text",
                             "text": f"\n[Video attached: {media_path}]"
+                        })
+                    elif media_type == "document":
+                        if not mime_type:
+                            mime_type = "application/pdf"
+                        b64_data = base64.b64encode(media_data).decode("utf-8")
+                        content.append({
+                            "type": "media",
+                            "mime_type": mime_type,
+                            "data": b64_data,
+                        })
+                        # Keep a lightweight textual hint for models that ignore raw media blocks.
+                        content.append({
+                            "type": "text",
+                            "text": f"\n[Document attached: {media_path}]"
                         })
                 except Exception as e:
                     logger.warning(f"Failed to load media {media_path}: {e}")

--- a/agent.py
+++ b/agent.py
@@ -50,6 +50,49 @@ MAX_MESSAGES = 50
 # which the API constrains separately (<1 min guideline for inline video).
 INLINE_MEDIA_MAX_BYTES = 100 * 1024 * 1024
 
+# The formats the model accepts, per kind, transcribed from the API's published
+# lists. Channels classify a blob into a kind; which *formats* of that kind are
+# readable is a model fact, so it lives here in one copy rather than in every
+# channel's router, where it would go stale on the next model swap. Outside
+# these sets the attachment gets an honest note instead of an opaque API error.
+SUPPORTED_MEDIA_MIMES = {
+    "image": {"image/png", "image/jpeg", "image/webp", "image/heic", "image/heif"},
+    "audio": {"audio/wav", "audio/mp3", "audio/aiff", "audio/aac", "audio/ogg",
+              "audio/flac"},
+    "video": {"video/mp4", "video/mpeg", "video/mov", "video/avi", "video/x-flv",
+              "video/mpg", "video/webm", "video/wmv", "video/3gpp"},
+    "document": {"application/pdf"},
+}
+
+# Clients name some formats differently from the API (.mov is sent as
+# video/quicktime, .mp3 as audio/mpeg). Normalize to the documented spelling so
+# the check sees a known name and the blob is sent under one the API expects.
+MEDIA_MIME_ALIASES = {
+    "video/quicktime": "video/mov",
+    "video/x-msvideo": "video/avi",
+    "video/x-ms-wmv": "video/wmv",
+    "video/3gpp2": "video/3gpp",
+    "audio/mpeg": "audio/mp3",
+    "audio/mpg": "audio/mp3",
+    "audio/x-wav": "audio/wav",
+    "audio/x-aiff": "audio/aiff",
+    "audio/x-flac": "audio/flac",
+    "image/jpg": "image/jpeg",
+}
+
+
+def _article(word: str) -> str:
+    """'a' or 'an' for a word the model will read back to the owner."""
+    return "an" if word[:1].lower() in "aeiou" else "a"
+
+
+def _normalize_media_mime(mime_type: str) -> str:
+    """Strip parameters/case from a mime and resolve client spellings to the
+    names the API publishes. Empty in, empty out — an absent mime is handled by
+    the per-kind defaults in the media loop, not here."""
+    mime = mime_type.split(";")[0].strip().lower()
+    return MEDIA_MIME_ALIASES.get(mime, mime)
+
 
 def _strip_media_blobs(msg):
     """Replace base64 media content blocks with lightweight text references.
@@ -645,16 +688,33 @@ def ask_jarvis(
                             "media too large to inline: %s (%d bytes, kind=%s)",
                             abs_path, media_size, media_type,
                         )
-                        article = "an" if media_type[:1] in "aeiou" else "a"
                         content.append({
                             "type": "text",
                             "text": (
-                                f"\n[Received {article} {media_type} "
+                                f"\n[Received {_article(media_type)} {media_type} "
                                 f"({media_size / (1024 * 1024):.0f} MB) — "
                                 "too large for me to read.]"
                             )
                         })
                         continue
+
+                    # A format the model can't read. An absent mime skips the
+                    # check — the per-kind defaults below cover that case.
+                    if mime_type:
+                        mime_type = _normalize_media_mime(mime_type)
+                        if mime_type not in SUPPORTED_MEDIA_MIMES.get(media_type, ()):
+                            logger.info(
+                                "unsupported media format: %s (kind=%s)",
+                                mime_type, media_type,
+                            )
+                            content.append({
+                                "type": "text",
+                                "text": (
+                                    f"\n[Received {_article(media_type)} {media_type} "
+                                    f"({mime_type}) — I can't read that format.]"
+                                )
+                            })
+                            continue
 
                     with open(abs_path, "rb") as f:
                         media_data = f.read()

--- a/agent.py
+++ b/agent.py
@@ -40,6 +40,16 @@ from observability import telemetry
 # to SQLite, so storage stays bounded regardless of conversation length.
 MAX_MESSAGES = 50
 
+# Gemini's documented ceiling for inline media. The API also recommends the
+# Files API past a ~20 MB request, but that is a recommendation, not a limit —
+# a 42 MB video inlines and is read correctly. A backstop, not a policy: every
+# channel today caps its own uploads well below this, so it exists to meet a
+# future one with an honest note rather than an opaque API failure. Enforced
+# here rather than per channel because it is a model limit — every channel
+# inherits it, and a model swap moves one constant. It cannot see duration,
+# which the API constrains separately (<1 min guideline for inline video).
+INLINE_MEDIA_MAX_BYTES = 100 * 1024 * 1024
+
 
 def _strip_media_blobs(msg):
     """Replace base64 media content blocks with lightweight text references.
@@ -624,6 +634,27 @@ def ask_jarvis(
                         continue
 
                     abs_path = media_path
+
+                    # Too large to inline. Checked before open() so an oversized
+                    # blob is never read into memory only to be refused. Same
+                    # honest-note shape as an unreadable kind — the reply names
+                    # no channel, transport limit, or ceiling.
+                    media_size = os.path.getsize(abs_path)
+                    if media_size > INLINE_MEDIA_MAX_BYTES:
+                        logger.info(
+                            "media too large to inline: %s (%d bytes, kind=%s)",
+                            abs_path, media_size, media_type,
+                        )
+                        article = "an" if media_type[:1] in "aeiou" else "a"
+                        content.append({
+                            "type": "text",
+                            "text": (
+                                f"\n[Received {article} {media_type} "
+                                f"({media_size / (1024 * 1024):.0f} MB) — "
+                                "too large for me to read.]"
+                            )
+                        })
+                        continue
 
                     with open(abs_path, "rb") as f:
                         media_data = f.read()

--- a/docs/architecture/GATEWAY.md
+++ b/docs/architecture/GATEWAY.md
@@ -343,12 +343,19 @@ Channel router (per-channel)                               └── video_<file
   ├── channel.download_media(remote_id) ─────────────────▶ bytes
   ├── <channel>.media_cache.save(bytes, kind, id) ───────▶ ABSOLUTE path (channel-owned cache)
   └── InboundMessage.attachments.append({
-        kind:       "image" | "video" | "audio",
+        kind:       "image" | "video" | "audio" | "document",
         path:       ABSOLUTE filesystem path, channel-produced (open as-is),
         mime_type:  RFC 6838 type from the source,
         source:     channel name (e.g. "telegram"),
       })
 ```
+
+**The neutral kind is the channel's translation, not the source's tag.** A source
+whose own vocabulary is coarser (the jarvis-app hub tags everything that isn't an
+image or audio as `file`) resolves it against the mime type at the boundary, the
+same way Telegram's router tags `kind="video"`. A kind outside the neutral set —
+notably `file` — means **unidentified**: the agent surfaces it to the model as
+text and never feeds the bytes.
 
 **The channel owns media end to end.** Each channel ships its own
 `gateway/channels/<channel>/media_cache.py` (`save(bytes, kind, id) -> absolute path`,

--- a/docs/plans/MEDIA_INGESTION_PLAN.md
+++ b/docs/plans/MEDIA_INGESTION_PLAN.md
@@ -26,14 +26,18 @@ wrong on layering too: it pushes a model constraint into transport, so a model s
 hub deploy plus an app-version skew window, and an oversized send would fail as a composer upload
 error instead of something Jarvis can answer conversationally.
 
-**Plan.** Two shippable slices plus a gated third, split along one principle: **channels translate
-into the neutral vocabulary; the model boundary owns model limits.**
+**Plan.** Four shippable slices plus a gated fifth, split along one principle: **channels translate
+into the neutral vocabulary; the model boundary owns model limits.** Each slice is one topic — the
+size guard and the `document` branch both live in `agent.py`'s media loop, but they answer different
+questions (*how much may I send?* vs *what can I read?*), so they ship and revert separately.
 
 | # | Slice | Layer | Size | Effect |
 |---|---|---|---|---|
 | 1 | Neutral `document` kind + app-router kind mapping | channel-owned | small | `file`+mime resolves to a real kind at the boundary, as Telegram already does |
-| 2 | Size guard + `document` branch in `agent.py` | model boundary | small | PDFs/videos ingested; oversized media refused honestly — **for every channel** |
-| 3 | Files API for >15 MB media | model boundary | medium | **Gated** — only if oversized sends prove to matter |
+| 2 | Inline size guard in `agent.py` | model boundary | small | Oversized media refused honestly — **for every channel**, including Telegram's existing hole |
+| 3 | `document` branch in `agent.py` | model boundary | small | PDFs ingested rather than described as unreadable |
+| 4 | Telegram document handler | channel-owned | small | Closes a **silent drop**: a PDF sent over Telegram currently reaches nothing at all |
+| 5 | Files API for >15 MB media | model boundary | medium | **Gated** — only if oversized sends prove to matter |
 
 **Why slice 2 is worth doing on its own merits.** The size guard is not app-channel work. Telegram
 has *no* size handling anywhere (`gateway/channels/telegram/router.py:133` downloads and stores
@@ -41,10 +45,17 @@ unconditionally), and the Bot API permits downloads up to 20 MB — which base64
 exceed the request cap today. The hole already exists on the older channel; it has never fired only
 because the single video that has ever flowed through production was 1 MB. Slice 2 closes it once,
 at the one place that knows what is being fed to the model, and every future channel inherits it.
+It stands alone: it is worth shipping even if no other slice here ever lands.
 
-**Risk posture.** Slices 1 and 2 are additive — new kinds and a new guard on a path that currently
-terminates in a text note. Both are independently revertable. Slice 3 carries a real latent hazard
-(see below) and is deliberately separated.
+**Risk posture.** Slices 1–4 are additive — new kinds, a new guard, a new branch, and a handler on
+paths that currently terminate in a text note or in nothing. Each is independently revertable. Slice
+5 carries a real latent hazard (see below) and is deliberately separated.
+
+**Ordering constraint.** Slice 1 makes app videos *reachable* by `agent.py`'s existing `video`
+branch, and slice 4 makes Telegram documents reachable — both inline bytes with no ceiling until the
+guard lands. Ship those before slice 2 and an oversized send trades an honest note (or, on Telegram,
+a silent drop) for a failed turn. **Slice 2 should land no later than the first of the other two**;
+everything after it is order-free.
 
 ---
 
@@ -92,31 +103,71 @@ keeps the cache dir legible.
 **`docs/architecture/GATEWAY.md:346`** — vocabulary gains `document`; add a line stating that `file`
 means "unidentified — surfaced to the agent as text, never fed to the model".
 
-## Slice 2 — Model boundary (channel-agnostic)
+## Slice 2 — Inline size guard (model boundary, channel-agnostic)
 
-All in `agent.py`, media loop at `:604-670`:
+One question: *how much may I send the model?* Independent of which kinds are readable — it applies
+to the image, audio and video branches that exist today, and to `document` whenever slice 3 lands.
 
-1. **Size guard**, between the kind check (`:618`) and the read (`:628`). Use `os.path.getsize`
-   *before* `open()`, so a 50 MB blob is never pulled into memory only to be refused. Constant near
-   `MAX_MESSAGES`:
+In `agent.py`, media loop at `:604-670`: a size check between the kind check (`:618`) and the read
+(`:628`). Use `os.path.getsize` *before* `open()`, so a 50 MB blob is never pulled into memory only
+to be refused. Constant near `MAX_MESSAGES`:
 
-   ```python
-   # Gemini caps the whole request at ~20 MB. Inline media is base64 in JSON
-   # (+33%), so the raw-bytes ceiling is ~15 MB, leaving headroom for the prompt.
-   INLINE_MEDIA_MAX_BYTES = 15 * 1024 * 1024
-   ```
+```python
+# Gemini caps the whole request at ~20 MB. Inline media is base64 in JSON
+# (+33%), so the raw-bytes ceiling is ~15 MB, leaving headroom for the prompt.
+INLINE_MEDIA_MAX_BYTES = 15 * 1024 * 1024
+```
 
-   Over the limit → the same honest-note shape as `:618`, sized and channel-neutral:
-   `[Received a video (38 MB) — too large for me to read.]` No channel, hub, or cap is named.
+Over the limit → the same honest-note shape as `:618`, sized and channel-neutral:
+`[Received a video (38 MB) — too large for me to read.]` No channel, hub, or cap is named.
 
-2. **`document` branch** alongside `video` (`:657`): a `{"type": "media", "mime_type": …,
+## Slice 3 — `document` branch (model boundary, channel-agnostic)
+
+The other question: *what can I read?* Also in `agent.py`'s media loop, and deliberately not bundled
+with the guard — a readable-kind regression and a size-ceiling regression have nothing in common,
+and either should be revertable without the other.
+
+1. **`document` branch** alongside `video` (`:657`): a `{"type": "media", "mime_type": …,
    "data": b64}` block plus the lightweight text hint, identical in shape to the audio and video
    branches. `_strip_media_blobs` (`:71`) already drops `media` blocks carrying `data`, so nothing
    new accumulates in thread state.
 
-3. Add `"document"` to the readable-kinds tuple at `:618`.
+2. Add `"document"` to the readable-kinds tuple at `:618`.
 
-## Slice 3 — Files API (gated)
+## Slice 4 — Telegram document handler (channel-owned)
+
+**The defect.** `gateway/channels/telegram/host.py:60-63` registers exactly four handlers — `TEXT`,
+`PHOTO`, `VIDEO`, `VOICE`. A PDF arrives as `msg.document`, matches none of them, and is **dropped
+before any gateway code runs**: no `InboundMessage`, no turn, no reply. Worse than the app channel's
+pre-slice-1 state, which at least produced an honest note. Same for a video the sender attached as a
+file rather than as a video — Telegram delivers that as a document too.
+
+**`gateway/channels/telegram/host.py`** — register
+`MessageHandler(filters.Document.ALL, self._router.handle_document)` alongside the other four.
+
+**`gateway/channels/telegram/router.py`** — `handle_document`, mirroring `handle_video` (`:95`):
+read `msg.document.mime_type`, resolve it to a neutral kind, `_download_and_store`, dispatch with
+`msg.caption or "[DOCUMENT attachment]"`. The mapping is `application/pdf`→`document`,
+`video/*`-allowlisted→`video`, anything else→`file` (honest note — still a strict improvement on the
+silent drop).
+
+**Each channel owns its own mapping.** Do **not** import the app router's `_neutral_kind`: channels
+never import each other, and the inputs differ — PTB exposes a mime directly on the message, where
+the hub supplies a coarse kind *plus* a mime. Shared vocabulary, separate translations. If a third
+channel ever repeats it, promote the table to `gateway/base.py`; two is not yet duplication worth
+centralizing.
+
+**`gateway/channels/telegram/media_cache.py:20`** — `_EXT` gains `"document": ".pdf"`.
+
+**Depends on slice 2** (the guard), and on slice 3 for PDFs to be *read* rather than noted. The Bot
+API permits downloads up to 20 MB, which base64s to ~27 MB and exceeds the request cap on its own;
+without the guard this slice converts a silent drop into a failed turn.
+
+**Still unhandled after this slice** (each a distinct defect, not folded in): `filters.AUDIO` (music
+files, as opposed to voice notes), animations/GIFs, and video notes. All are silently dropped today
+for the same reason.
+
+## Slice 5 — Files API (gated)
 
 Only if oversized media proves to matter in practice. Cheaper than the issue assumed:
 `google-genai==1.68.0` is already installed, and the LangChain adapter accepts `file_uri` in the
@@ -129,12 +180,12 @@ Two hard requirements before it ships:
   (`agent.py:71`), so a `file_uri` block *survives* into thread history — and Files API URIs expire
   after 48h. A stale URI re-sent on a later turn errors, and because the whole window is re-sent it
   can brick that thread for its 50-message life. Change to
-  `"data" in block or "file_uri" in block`. Landing slice 3 without this is a latent thread-breaker.
+  `"data" in block or "file_uri" in block`. Landing slice 5 without this is a latent thread-breaker.
 - **Latency has no seam.** Upload plus Gemini's PROCESSING poll blocks the turn for tens of seconds
   with no intermediate ack in the current flow. Decide that UX before building.
 
-**Recommendation:** ship 1+2 and leave #51's size question answered as **cap-and-note**. An honest
-"too large to read" is a fine terminal state for a 40 MB video.
+**Recommendation:** ship 1–3 (+4 for channel parity) and leave #51's size question answered as
+**cap-and-note**. An honest "too large to read" is a fine terminal state for a 40 MB video.
 
 ---
 
@@ -150,10 +201,13 @@ against logs and a live round-trip.
    - PDF from the app → Jarvis answers about its contents, not a "can't read" note.
    - Video sent as a file from the app → Jarvis describes it.
    - Oversized video → the sized honest note; no traceback in `journalctl -u jarvis-staging`.
-3. **Telegram regression** (slice 2 touches the shared path): photo, voice note, and a small video
-   still ingest normally.
+3. **Telegram regression** (slices 2 and 3 touch the shared path): photo, voice note, and a small
+   video still ingest normally.
 4. Cache filenames land as `video_att_….mp4` / `document_att_….pdf` in the app channel's
    `media_cache/`.
+5. **Slice 4, after restart:** a PDF over Telegram → Jarvis answers about its contents (today: no
+   reply at all). A `.mp4` sent as a file over Telegram → described as a video. A `.zip` → the
+   honest note, no traceback. Cache filename `document_<file_id>.pdf`.
 
 ## Not in scope
 
@@ -163,4 +217,4 @@ against logs and a live round-trip.
 - **`image/gif`.** The hub allowlists it and this plan would inline it as an image, but Gemini's
   supported image set is png/jpeg/webp/heic/heif. Likely a one-line addition to the readable check,
   but it is a distinct defect from `file`-kind ingestion — recorded here rather than folded in.
-- **Raising the hub's 50 MB cap.** Only becomes interesting if slice 3 ever lands.
+- **Raising the hub's 50 MB cap.** Only becomes interesting if slice 5 ever lands.

--- a/docs/plans/MEDIA_INGESTION_PLAN.md
+++ b/docs/plans/MEDIA_INGESTION_PLAN.md
@@ -37,18 +37,20 @@ Capping the hub was never the right fix regardless: it pushes a model constraint
 a model swap would need a hub deploy plus an app-version skew window, and an oversized send would
 fail as a composer upload error instead of something Jarvis can answer conversationally.
 
-**Plan.** Four shippable slices plus a gated fifth, split along one principle: **channels translate
+**Plan.** Five shippable slices plus a gated sixth, split along one principle: **channels translate
 into the neutral vocabulary; the model boundary owns model limits.** Each slice is one topic — the
-size guard and the `document` branch both live in `agent.py`'s media loop, but they answer different
-questions (*how much may I send?* vs *what can I read?*), so they ship and revert separately.
+size backstop, the `document` branch and the mime allowlist all live in `agent.py`'s media loop, but
+they answer different questions (*how much may I send?* / *what kinds can I read?* / *which formats
+of that kind?*), so they ship and revert separately.
 
 | # | Slice | Layer | Size | Effect |
 |---|---|---|---|---|
 | 1 | Neutral `document` kind + app-router kind mapping | channel-owned | small | `file`+mime resolves to a real kind at the boundary, as Telegram already does |
 | 2 | Inline size backstop in `agent.py` | model boundary | small | Unreachable ceiling made honest instead of opaque — **for every channel** |
 | 3 | `document` branch in `agent.py` | model boundary | small | PDFs ingested rather than described as unreadable |
-| 4 | Telegram document handler | channel-owned | small | Closes a **silent drop**: a PDF sent over Telegram currently reaches nothing at all |
-| 5 | Files API for oversized media | model boundary | medium | **Gated** — no known trigger; see the measurement above |
+| 4 | Per-kind mime allowlist in `agent.py` | model boundary | small | An unsupported format meets an honest note, not an opaque API error — **fixes `image/gif` too** |
+| 5 | Telegram document handler | channel-owned | small | Closes a **silent drop**: a PDF sent over Telegram currently reaches nothing at all |
+| 6 | Files API for oversized media | model boundary | medium | **Gated** — no known trigger; see the measurement above |
 
 **What slice 2 is, after the measurement.** It was scoped as an urgent hole: Telegram has *no* size
 handling anywhere (`gateway/channels/telegram/router.py:133` downloads and stores unconditionally),
@@ -58,13 +60,14 @@ today. It is kept, at the documented ceiling, for two reasons: a future channel 
 — see *Not in scope*) inherits it for free, and the failure it converts is an opaque API error into
 a sentence Jarvis can say. It is no longer urgent, and no longer blocks anything.
 
-**Risk posture.** Slices 1–4 are additive — new kinds, a backstop, a new branch, and a handler on
-paths that currently terminate in a text note or in nothing. Each is independently revertable. Slice
-5 carries a real latent hazard (see below) and is deliberately separated.
+**Risk posture.** Slices 1–5 are additive — new kinds, a backstop, two new branches, and a handler
+on paths that currently terminate in a text note or in nothing. Each is independently revertable.
+Slice 6 carries a real latent hazard (see below) and is deliberately separated.
 
 **Ordering.** The original ordering constraint — *land the guard before anything that makes new
 bytes reachable* — is void: slice 1 shipped, a 42 MB video went through it unguarded, and the model
-read it. The slices are now order-free.
+read it. One soft dependency remains: slice 5 classifies broadly by mime prefix, so it wants slice 4
+to have landed, or an unsupported format reaches the model as an opaque error instead of a note.
 
 ---
 
@@ -83,6 +86,7 @@ block's `mime_type`, as it is today.
 |---|---|---|
 | Which wire format means which kind | channel router | Only the channel knows its source's vocabulary |
 | Which kinds the model can read | `agent.py` | Model capability, not transport |
+| Which *formats* of a kind it can read | `agent.py` | Same table the API publishes; one copy, not one per channel |
 | How large an inline blob may be | `agent.py` | Model limit, not transport |
 | How large an upload may be | hub | Storage/bandwidth policy, independent of any model |
 
@@ -147,7 +151,34 @@ and either should be revertable without the other.
 
 2. Add `"document"` to the readable-kinds tuple at `:618`.
 
-## Slice 4 — Telegram document handler (channel-owned)
+## Slice 4 — Per-kind mime allowlist (model boundary, channel-agnostic)
+
+**Why it exists.** `document` is the third kind whose readability depends on the *format*, not just
+the kind — the API supports exactly one document mime (`application/pdf`), five image mimes, six
+audio, nine video. Today `agent.py` checks the kind and never looks at the mime, so an unsupported
+format is inlined and fails as an opaque API error. That defect is already live: `image/gif` is
+allowlisted by the hub and would inline as an `image`, and the API does not accept GIF. It was
+previously recorded under *Not in scope*; this slice absorbs it.
+
+It is also what lets slice 5 classify broadly. If channels enumerated the model's supported formats
+themselves, the model's capability table would be copied into every channel and go stale on every
+model swap — the exact layering this plan exists to avoid. Channels answer *what kind of thing is
+this?*; the model boundary answers *can I read this format?*
+
+Two constants near `INLINE_MEDIA_MAX_BYTES`, then one check in the media loop after the size
+backstop and before the branches:
+
+- **`SUPPORTED_MEDIA_MIMES`** — `{kind: {mime, …}}`, transcribed from the API's format lists.
+- **`MEDIA_MIME_ALIASES`** — the API names some formats differently from what clients emit (`.mov`
+  arrives as `video/quicktime`, `.mp3` as `audio/mpeg`). Normalize to the documented spelling before
+  the check *and* before the blob is sent, so the media block carries a mime the API recognizes.
+
+An empty mime skips the check — the existing per-branch defaults (`image/jpeg` guessed from the
+filename, `audio/ogg`, `video/mp4`) already handle that case and predate this slice. Outside the
+allowlist → the honest note, naming the format: `[Received an image (image/gif) — I can't read that
+format.]`
+
+## Slice 5 — Telegram document handler (channel-owned)
 
 **The defect.** `gateway/channels/telegram/host.py:60-63` registers exactly four handlers — `TEXT`,
 `PHOTO`, `VIDEO`, `VOICE`. A PDF arrives as `msg.document`, matches none of them, and is **dropped
@@ -155,14 +186,28 @@ before any gateway code runs**: no `InboundMessage`, no turn, no reply. Worse th
 pre-slice-1 state, which at least produced an honest note. Same for a video the sender attached as a
 file rather than as a video — Telegram delivers that as a document too.
 
+**A document is a container, not a type.** It is how Telegram delivers anything that is not a
+compressed photo, a video, or a voice note — so the handler's job is to look at the mime and let
+most of it land on kinds that already work:
+
+| Sent as a document | mime | kind |
+|---|---|---|
+| PDF | `application/pdf` | `document` |
+| Video | `video/*` | `video` |
+| Music, audio clip | `audio/*` | `audio` |
+| Photo "sent as file" (original quality, HEIC off an iPhone) | `image/*` | `image` |
+| Everything else — archives, Office formats, text | — | `file` (honest note) |
+
 **`gateway/channels/telegram/host.py`** — register
 `MessageHandler(filters.Document.ALL, self._router.handle_document)` alongside the other four.
 
 **`gateway/channels/telegram/router.py`** — `handle_document`, mirroring `handle_video` (`:95`):
-read `msg.document.mime_type`, resolve it to a neutral kind, `_download_and_store`, dispatch with
-`msg.caption or "[DOCUMENT attachment]"`. The mapping is `application/pdf`→`document`,
-`video/*`-allowlisted→`video`, anything else→`file` (honest note — still a strict improvement on the
-silent drop).
+read `msg.document.mime_type`, resolve it by prefix per the table above, `_download_and_store`,
+dispatch with `msg.caption or "[DOCUMENT attachment]"`. A missing mime falls back to
+`mimetypes.guess_type` on the filename — the field is client-supplied and not guaranteed.
+
+**Classification is by prefix, deliberately.** The channel does not know which `video/*` the model
+accepts and must not — slice 4 owns that, once, for every channel.
 
 **Each channel owns its own mapping.** Do **not** import the app router's `_neutral_kind`: channels
 never import each other, and the inputs differ — PTB exposes a mime directly on the message, where
@@ -172,15 +217,15 @@ centralizing.
 
 **`gateway/channels/telegram/media_cache.py:20`** — `_EXT` gains `"document": ".pdf"`.
 
-**Depends on slice 3** for PDFs to be *read* rather than noted; independent of slice 2. The Bot API
-caps downloads at 20 MB, comfortably under the inline ceiling, so nothing Telegram can deliver needs
-the backstop.
+**Depends on slice 3** for PDFs to be *read* rather than noted, and wants slice 4 so a format the
+model rejects becomes a note rather than an error. Independent of slice 2: the Bot API caps
+downloads at 20 MB, comfortably under the inline ceiling.
 
 **Still unhandled after this slice** (each a distinct defect, not folded in): `filters.AUDIO` (music
-files, as opposed to voice notes), animations/GIFs, and video notes. All are silently dropped today
-for the same reason.
+files, as opposed to voice notes), animations, and video notes. All are silently dropped today for
+the same reason — a handler that was never registered.
 
-## Slice 5 — Files API (gated)
+## Slice 6 — Files API (gated)
 
 **No known trigger.** This slice existed to rescue media above a ceiling that turned out not to
 exist at the size any channel can produce; the honest reading is that it should stay unbuilt unless
@@ -198,12 +243,12 @@ Two hard requirements before it ships:
   (`agent.py:71`), so a `file_uri` block *survives* into thread history — and Files API URIs expire
   after 48h. A stale URI re-sent on a later turn errors, and because the whole window is re-sent it
   can brick that thread for its 50-message life. Change to
-  `"data" in block or "file_uri" in block`. Landing slice 5 without this is a latent thread-breaker.
+  `"data" in block or "file_uri" in block`. Landing slice 6 without this is a latent thread-breaker.
 - **Latency has no seam.** Upload plus Gemini's PROCESSING poll blocks the turn for tens of seconds
   with no intermediate ack in the current flow. Decide that UX before building.
 
-**Recommendation:** ship 1–3 (+4 for channel parity). #51's size question is answered by measurement
-rather than by design: a 40 MB video needs no special handling at all — it just works.
+**Recommendation:** ship 1–5. #51's size question is answered by measurement rather than by design:
+a 40 MB video needs no special handling at all — it just works.
 
 ---
 
@@ -225,18 +270,23 @@ against logs and a live round-trip.
    video still ingest normally.
 4. Cache filenames land as `video_att_….mp4` / `document_att_….pdf` in the app channel's
    `media_cache/`.
-5. **Slice 4, after restart:** a PDF over Telegram → Jarvis answers about its contents (today: no
-   reply at all). A `.mp4` sent as a file over Telegram → described as a video. A `.zip` → the
-   honest note, no traceback. Cache filename `document_<file_id>.pdf`.
+5. **Slice 4, synthetic:** each kind × a supported mime, an unsupported one (`image/gif`), an
+   aliased one (`video/quicktime`, `audio/mpeg`), and an empty mime.
+6. **Slice 5, after restart:** a PDF over Telegram → Jarvis answers about its contents (today: no
+   reply at all). A `.mp4` sent as a file over Telegram → described as a video. A photo sent as a
+   file → described. A `.zip` → the honest note, no traceback. Cache filename
+   `document_<file_id>.pdf`.
 
 ## Not in scope
 
 - **Outbound video/document.** `gateway/channels/jarvis_app/channel.py:_upload_meta` (`:49`) still
   raises `NotImplementedError` for any kind but image/audio, and the Outbox reports that as a failed
   send. No producer needs it — the notifier sends images.
-- **`image/gif`.** The hub allowlists it and this plan would inline it as an image, but Gemini's
-  supported image set is png/jpeg/webp/heic/heif. Likely a one-line addition to the readable check,
-  but it is a distinct defect from `file`-kind ingestion — recorded here rather than folded in.
+- **Text and code files** (`.txt`, `.md`, `.csv`, `.json`, source). Worth supporting, but not as a
+  `document`: the API extracts them as pure text with no layout understanding, so the better shape is
+  to read the file and inline it as a text block with a length cap. Split out as **issue #60**.
+- **Office formats** (`.docx`, `.xlsx`, `.pptx`). Not supported by the model at all; they would need
+  a conversion step. They reach the honest note via the `file` catch-all.
 - **Raising the hub's 50 MB cap.** Now known to have headroom under the model — the inline ceiling
   is 100 MB — but it is a storage/bandwidth policy on the hub's side, decided there, not here.
 - **Inline video duration.** The API's <1 min guideline for inline video is unmeasured; the 42 MB

--- a/docs/plans/MEDIA_INGESTION_PLAN.md
+++ b/docs/plans/MEDIA_INGESTION_PLAN.md
@@ -19,12 +19,23 @@ downloaded, cached, and then described as *"[Received a file (video/mp4) attachm
 yet.]"*. No silent drop, but no ingestion — and `agent.py` already contains a working `video`
 branch that this path can never reach.
 
-**The edge that shaped the design.** Gemini caps the whole request at ~20 MB while the hub allows
-50 MB. Inline media is base64 in JSON (+33%), so the real raw-bytes ceiling is **~15 MB**, not 20 —
-which also rules out "just cap the hub at 20 MB" as a fix, on the number alone. Capping the hub is
-wrong on layering too: it pushes a model constraint into transport, so a model swap would need a
-hub deploy plus an app-version skew window, and an oversized send would fail as a composer upload
-error instead of something Jarvis can answer conversationally.
+**The edge that was assumed, and measured away.** This plan originally held that Gemini caps the
+whole request at ~20 MB, and that base64 (+33%) put the real raw-bytes ceiling at ~15 MB — which
+would have made size the dominant constraint. **Both halves are wrong.** The API documents inline
+media at **<100 MB**; the ~20 MB figure is its recommendation for *preferring* the Files API, not a
+limit. Measured on 2026-07-30 against `gemini-3-flash-preview`: a **42 MB** mp4 sent from the app
+inlined and was read correctly (specific detail returned — banner text, Hebrew on-screen text,
+scene) with no error, at ~56 MB on the wire after base64.
+
+So no current channel can produce media the model will refuse: the hub caps uploads at 50 MB and
+Telegram's Bot API at 20 MB, both under the inline ceiling. Size stops being a design driver and
+becomes a backstop (slice 2). What the byte count *cannot* see is duration — the API pairs the
+100 MB inline limit with a **<1 min** guideline for video, an axis no size guard detects; unmeasured,
+and out of scope here.
+
+Capping the hub was never the right fix regardless: it pushes a model constraint into transport, so
+a model swap would need a hub deploy plus an app-version skew window, and an oversized send would
+fail as a composer upload error instead of something Jarvis can answer conversationally.
 
 **Plan.** Four shippable slices plus a gated fifth, split along one principle: **channels translate
 into the neutral vocabulary; the model boundary owns model limits.** Each slice is one topic — the
@@ -34,28 +45,26 @@ questions (*how much may I send?* vs *what can I read?*), so they ship and rever
 | # | Slice | Layer | Size | Effect |
 |---|---|---|---|---|
 | 1 | Neutral `document` kind + app-router kind mapping | channel-owned | small | `file`+mime resolves to a real kind at the boundary, as Telegram already does |
-| 2 | Inline size guard in `agent.py` | model boundary | small | Oversized media refused honestly — **for every channel**, including Telegram's existing hole |
+| 2 | Inline size backstop in `agent.py` | model boundary | small | Unreachable ceiling made honest instead of opaque — **for every channel** |
 | 3 | `document` branch in `agent.py` | model boundary | small | PDFs ingested rather than described as unreadable |
 | 4 | Telegram document handler | channel-owned | small | Closes a **silent drop**: a PDF sent over Telegram currently reaches nothing at all |
-| 5 | Files API for >15 MB media | model boundary | medium | **Gated** — only if oversized sends prove to matter |
+| 5 | Files API for oversized media | model boundary | medium | **Gated** — no known trigger; see the measurement above |
 
-**Why slice 2 is worth doing on its own merits.** The size guard is not app-channel work. Telegram
-has *no* size handling anywhere (`gateway/channels/telegram/router.py:133` downloads and stores
-unconditionally), and the Bot API permits downloads up to 20 MB — which base64s to ~25 MB and would
-exceed the request cap today. The hole already exists on the older channel; it has never fired only
-because the single video that has ever flowed through production was 1 MB. Slice 2 closes it once,
-at the one place that knows what is being fed to the model, and every future channel inherits it.
-It stands alone: it is worth shipping even if no other slice here ever lands.
+**What slice 2 is, after the measurement.** It was scoped as an urgent hole: Telegram has *no* size
+handling anywhere (`gateway/channels/telegram/router.py:133` downloads and stores unconditionally),
+so a 20 MB Bot API download would have blown the assumed ~15 MB ceiling. With the real ceiling at
+100 MB and both channels capped below it, **that hole does not exist** and the guard cannot fire
+today. It is kept, at the documented ceiling, for two reasons: a future channel (or a raised hub cap
+— see *Not in scope*) inherits it for free, and the failure it converts is an opaque API error into
+a sentence Jarvis can say. It is no longer urgent, and no longer blocks anything.
 
-**Risk posture.** Slices 1–4 are additive — new kinds, a new guard, a new branch, and a handler on
+**Risk posture.** Slices 1–4 are additive — new kinds, a backstop, a new branch, and a handler on
 paths that currently terminate in a text note or in nothing. Each is independently revertable. Slice
 5 carries a real latent hazard (see below) and is deliberately separated.
 
-**Ordering constraint.** Slice 1 makes app videos *reachable* by `agent.py`'s existing `video`
-branch, and slice 4 makes Telegram documents reachable — both inline bytes with no ceiling until the
-guard lands. Ship those before slice 2 and an oversized send trades an honest note (or, on Telegram,
-a silent drop) for a failed turn. **Slice 2 should land no later than the first of the other two**;
-everything after it is order-free.
+**Ordering.** The original ordering constraint — *land the guard before anything that makes new
+bytes reachable* — is void: slice 1 shipped, a 42 MB video went through it unguarded, and the model
+read it. The slices are now order-free.
 
 ---
 
@@ -103,23 +112,27 @@ keeps the cache dir legible.
 **`docs/architecture/GATEWAY.md:346`** — vocabulary gains `document`; add a line stating that `file`
 means "unidentified — surfaced to the agent as text, never fed to the model".
 
-## Slice 2 — Inline size guard (model boundary, channel-agnostic)
+## Slice 2 — Inline size backstop (model boundary, channel-agnostic)
 
 One question: *how much may I send the model?* Independent of which kinds are readable — it applies
 to the image, audio and video branches that exist today, and to `document` whenever slice 3 lands.
 
 In `agent.py`, media loop at `:604-670`: a size check between the kind check (`:618`) and the read
-(`:628`). Use `os.path.getsize` *before* `open()`, so a 50 MB blob is never pulled into memory only
-to be refused. Constant near `MAX_MESSAGES`:
+(`:628`). Use `os.path.getsize` *before* `open()`, so an oversized blob is never pulled into memory
+only to be refused. Constant near `MAX_MESSAGES`, set to the API's documented inline ceiling rather
+than to a derived figure:
 
 ```python
-# Gemini caps the whole request at ~20 MB. Inline media is base64 in JSON
-# (+33%), so the raw-bytes ceiling is ~15 MB, leaving headroom for the prompt.
-INLINE_MEDIA_MAX_BYTES = 15 * 1024 * 1024
+INLINE_MEDIA_MAX_BYTES = 100 * 1024 * 1024
 ```
 
 Over the limit → the same honest-note shape as `:618`, sized and channel-neutral:
-`[Received a video (38 MB) — too large for me to read.]` No channel, hub, or cap is named.
+`[Received a video (128 MB) — too large for me to read.]` No channel, hub, or cap is named. The
+article is chosen by vowel, so the note reads "an image", not "a image".
+
+**This cannot fire on any channel that exists today** — that is the point of keeping it small and
+never letting it grow a policy. If it ever *does* fire, the ceiling moved or a channel arrived
+without an upload cap; either way the number here is the single place to change.
 
 ## Slice 3 — `document` branch (model boundary, channel-agnostic)
 
@@ -159,9 +172,9 @@ centralizing.
 
 **`gateway/channels/telegram/media_cache.py:20`** — `_EXT` gains `"document": ".pdf"`.
 
-**Depends on slice 2** (the guard), and on slice 3 for PDFs to be *read* rather than noted. The Bot
-API permits downloads up to 20 MB, which base64s to ~27 MB and exceeds the request cap on its own;
-without the guard this slice converts a silent drop into a failed turn.
+**Depends on slice 3** for PDFs to be *read* rather than noted; independent of slice 2. The Bot API
+caps downloads at 20 MB, comfortably under the inline ceiling, so nothing Telegram can deliver needs
+the backstop.
 
 **Still unhandled after this slice** (each a distinct defect, not folded in): `filters.AUDIO` (music
 files, as opposed to voice notes), animations/GIFs, and video notes. All are silently dropped today
@@ -169,7 +182,12 @@ for the same reason.
 
 ## Slice 5 — Files API (gated)
 
-Only if oversized media proves to matter in practice. Cheaper than the issue assumed:
+**No known trigger.** This slice existed to rescue media above a ceiling that turned out not to
+exist at the size any channel can produce; the honest reading is that it should stay unbuilt unless
+something concrete demands it — a channel without an upload cap, video past the <1 min inline
+guideline, or a measured failure. Kept on record because the analysis below is worth not repeating.
+
+If it is ever built, it is cheaper than the issue assumed:
 `google-genai==1.68.0` is already installed, and the LangChain adapter accepts `file_uri` in the
 *same* media block shape the agent already emits (`chat_models.py:493-496` branches on `data` vs
 `file_uri`). So it is a swap inside the existing branch, not a new path.
@@ -184,8 +202,8 @@ Two hard requirements before it ships:
 - **Latency has no seam.** Upload plus Gemini's PROCESSING poll blocks the turn for tens of seconds
   with no intermediate ack in the current flow. Decide that UX before building.
 
-**Recommendation:** ship 1–3 (+4 for channel parity) and leave #51's size question answered as
-**cap-and-note**. An honest "too large to read" is a fine terminal state for a 40 MB video.
+**Recommendation:** ship 1–3 (+4 for channel parity). #51's size question is answered by measurement
+rather than by design: a 40 MB video needs no special handling at all — it just works.
 
 ---
 
@@ -194,13 +212,15 @@ Two hard requirements before it ships:
 Per slice, before moving on. Claude cannot restart the service — the owner restarts, Claude verifies
 against logs and a live round-trip.
 
-1. **Pre-restart, runnable immediately:** the kind mapping and the size guard are pure functions —
-   drive both through the staging venv with synthetic inputs (each hub kind × mime pair; a file just
-   under and just over the ceiling).
+1. **Pre-restart, runnable immediately:** drive the kind mapping through the staging venv with
+   synthetic inputs (each hub kind × mime pair). The backstop is not a pure function — exercise the
+   real media loop with the compiled graph stubbed out and an isolated `JARVIS_ROOT`, asserting on
+   the content blocks it builds (at the ceiling, one byte over, and a readable kind well under).
 2. **After staging restart:**
    - PDF from the app → Jarvis answers about its contents, not a "can't read" note.
-   - Video sent as a file from the app → Jarvis describes it.
-   - Oversized video → the sized honest note; no traceback in `journalctl -u jarvis-staging`.
+   - Video sent as a file from the app → Jarvis describes it. ✅ *done 2026-07-30: 5.5 MB and 42 MB,
+     both read correctly.*
+   - The backstop cannot be exercised live from any current channel — synthetic coverage only.
 3. **Telegram regression** (slices 2 and 3 touch the shared path): photo, voice note, and a small
    video still ingest normally.
 4. Cache filenames land as `video_att_….mp4` / `document_att_….pdf` in the app channel's
@@ -217,4 +237,7 @@ against logs and a live round-trip.
 - **`image/gif`.** The hub allowlists it and this plan would inline it as an image, but Gemini's
   supported image set is png/jpeg/webp/heic/heif. Likely a one-line addition to the readable check,
   but it is a distinct defect from `file`-kind ingestion — recorded here rather than folded in.
-- **Raising the hub's 50 MB cap.** Only becomes interesting if slice 5 ever lands.
+- **Raising the hub's 50 MB cap.** Now known to have headroom under the model — the inline ceiling
+  is 100 MB — but it is a storage/bandwidth policy on the hub's side, decided there, not here.
+- **Inline video duration.** The API's <1 min guideline for inline video is unmeasured; the 42 MB
+  clip that validated size was short. A long-but-small video is the untested corner.

--- a/docs/plans/MEDIA_INGESTION_PLAN.md
+++ b/docs/plans/MEDIA_INGESTION_PLAN.md
@@ -37,7 +37,7 @@ Capping the hub was never the right fix regardless: it pushes a model constraint
 a model swap would need a hub deploy plus an app-version skew window, and an oversized send would
 fail as a composer upload error instead of something Jarvis can answer conversationally.
 
-**Plan.** Five shippable slices plus a gated sixth, split along one principle: **channels translate
+**Plan.** Five shippable slices (a sixth was reframed and moved to #61), split along one principle: **channels translate
 into the neutral vocabulary; the model boundary owns model limits.** Each slice is one topic — the
 size backstop, the `document` branch and the mime allowlist all live in `agent.py`'s media loop, but
 they answer different questions (*how much may I send?* / *what kinds can I read?* / *which formats
@@ -50,7 +50,7 @@ of that kind?*), so they ship and revert separately.
 | 3 | `document` branch in `agent.py` | model boundary | small | PDFs ingested rather than described as unreadable |
 | 4 | Per-kind mime allowlist in `agent.py` | model boundary | small | An unsupported format meets an honest note, not an opaque API error — **fixes `image/gif` too** |
 | 5 | Telegram document handler | channel-owned | small | Closes a **silent drop**: a PDF sent over Telegram currently reaches nothing at all |
-| 6 | Files API for oversized media | model boundary | medium | **Gated** — no known trigger; see the measurement above |
+| 6 | ~~Files API for oversized media~~ | — | — | **Moved to #61** — reframed as multi-turn media access, not a size workaround |
 
 **What slice 2 is, after the measurement.** It was scoped as an urgent hole: Telegram has *no* size
 handling anywhere (`gateway/channels/telegram/router.py:133` downloads and stores unconditionally),
@@ -62,7 +62,8 @@ a sentence Jarvis can say. It is no longer urgent, and no longer blocks anything
 
 **Risk posture.** Slices 1–5 are additive — new kinds, a backstop, two new branches, and a handler
 on paths that currently terminate in a text note or in nothing. Each is independently revertable.
-Slice 6 carries a real latent hazard (see below) and is deliberately separated.
+The one change carrying a real latent hazard is the `file_uri` work, which is why it left this plan
+for #61 rather than sitting here as a slice someone might pick up.
 
 **Ordering.** The original ordering constraint — *land the guard before anything that makes new
 bytes reachable* — is void: slice 1 shipped, a 42 MB video went through it unguarded, and the model
@@ -225,16 +226,17 @@ downloads at 20 MB, comfortably under the inline ceiling.
 files, as opposed to voice notes), animations, and video notes. All are silently dropped today for
 the same reason — a handler that was never registered.
 
-## Slice 6 — Files API (gated)
+## Slice 6 — Files API (gated → moved to #61)
 
-**No known trigger.** This slice existed to rescue media above a ceiling that turned out not to
-exist at the size any channel can produce; the honest reading is that it should stay unbuilt unless
-something concrete demands it — a channel without an upload cap, video past the <1 min inline
-guideline, or a measured failure. Kept on record because the analysis below is worth not repeating.
+**No known trigger, and no longer this plan's business.** This slice existed to rescue media above a
+ceiling that turned out not to exist at the size any channel can produce. What survives is not a size
+workaround but a capability — media is single-turn today, and a `file_uri` is one way to let the
+model look at it again. That framing, the alternatives to it (re-reading the 90-day channel cache is
+cheaper and has no expiry), and the hazards below now live in **issue #61**.
 
-If it is ever built, it is cheaper than the issue assumed:
+Nothing here is planned work. The analysis is kept because it is worth not repeating:
 `google-genai==1.68.0` is already installed, and the LangChain adapter accepts `file_uri` in the
-*same* media block shape the agent already emits (`chat_models.py:493-496` branches on `data` vs
+*same* media block shape the agent already emits (`chat_models.py:493-495` branches on `data` vs
 `file_uri`). So it is a swap inside the existing branch, not a new path.
 
 Two hard requirements before it ships:

--- a/docs/plans/app-plans/EXECUTION_PLAN.md
+++ b/docs/plans/app-plans/EXECUTION_PLAN.md
@@ -7,7 +7,7 @@ metadata — width/height + blur-up placeholder)**. The hub **upgraded to the pi
 `3b3a48f330f09a39`** (skew resolved), and an independent audit confirmed we are **in sync with
 `roiguri/jarvis-app-v2@main`** (no re-pin). **Remaining:** restart staging → on-device verify pass →
 Telegram regression + `code-review` → PR to main. **Deferred:** C5 → B2; real `file`-kind ingestion
-(PDF/video) → **#51**, now planned in [../MEDIA_INGESTION_PLAN.md](../MEDIA_INGESTION_PLAN.md)
+(PDF/video) → **#51**, shipped; see [../archive/MEDIA_INGESTION_PLAN.md](../archive/MEDIA_INGESTION_PLAN.md)
 (interim: an honest "can't read yet" note, never a silent drop). Stages A + B
 merged (#47, #49).
 **Single source of truth.** Absorbs and replaces the former `APP_CHANNEL_PLAN.md` (index),
@@ -66,7 +66,7 @@ stay in Stage D (still no phone renderer).
 - [x] C4 — inbound media: router downloads `Message.attachments` → app `media_cache` → `InboundMessage.attachments` → Gemini (commit `d3e986e`). *Verified* upload→download byte-exact + `_handle` cases; *pending* an on-device photo→describe after restart
 - [x] C4 review follow-ups (commit `bee778c`): reject malformed `att_` ids before a filesystem path + basename guard; `media_cache.save` inside the per-attachment try; retrieval note instead of an empty turn when every download fails
 - [x] §4 — image upload metadata (commit `0783aeb`): `upload_attachment` sends optional `width`/`height`/`blur_preview`; the channel computes them for images via Pillow (`Pillow==12.3.0` added, import guarded). App reserves aspect ratio (no reflow) + shows a blur-up placeholder. `duration_ms` omitted (no outbound-audio producer). *Verified* the hub stored `w/h/blur_preview`
-- [x] `file`-kind honest fallback (commit `23c347d`): the agent surfaces any unreadable kind as text rather than silently dropping it; real PDF/video ingestion tracked in **#51**, planned in [../MEDIA_INGESTION_PLAN.md](../MEDIA_INGESTION_PLAN.md)
+- [x] `file`-kind honest fallback (commit `23c347d`): the agent surfaces any unreadable kind as text rather than silently dropping it; real PDF/video ingestion tracked in **#51**, planned in [../archive/MEDIA_INGESTION_PLAN.md](../archive/MEDIA_INGESTION_PLAN.md)
 - [ ] C5 — **DEFERRED → B2** (decided 2026-07-24). An interim `UnsupportedConfirmation` is throwaway: the real `AppConfirmationUI` (upstream B2) replaces it, and its registration seam already exists. Interim behavior is **safe** — app-origin destructive tools fall back to the default channel's (Telegram) confirmation; nothing fires silently. Build the real UI when the app ships confirmation; don't build the placeholder.
 - [ ] **Restart staging** + Telegram regression + `code-review` skill, then PR `feat/stage-c-app-channel` → main
 
@@ -333,7 +333,7 @@ now" gate:
   degradation (the convention `Outbox._log` uses at `outbox.py:115`) can land with the capability
   work (#50).
 - **Inbound `file`-kind ingestion (#51)** — **planned in
-  [../MEDIA_INGESTION_PLAN.md](../MEDIA_INGESTION_PLAN.md)** (2026-07-29); that doc supersedes this
+  [../archive/MEDIA_INGESTION_PLAN.md](../archive/MEDIA_INGESTION_PLAN.md)** (2026-07-29); that doc supersedes this
   sketch. C4 downloads `file`-kind attachments (the hub's `file` bundles PDF + video by mime), but
   the agent can't yet feed them to the model — it emits an honest "can't read yet" note. **No longer
   gated:** the app composer *can* send a video as a file. Two corrections to the sketch above: the

--- a/docs/plans/archive/MEDIA_INGESTION_PLAN.md
+++ b/docs/plans/archive/MEDIA_INGESTION_PLAN.md
@@ -1,10 +1,20 @@
 # Inbound media ingestion — file-kind attachments + inline size guard
 
+**Status:** ✅ **SHIPPED** — slices 1–5 landed 2026-07-30; archived.
+**Verified:** slice 1 live (a 42 MB video from the app read correctly, which also measured away this
+plan's central premise — see below). Slices 2–5 have **synthetic coverage only** and have not been
+exercised against the live API; the untested bets are the mime alias normalization
+(`video/quicktime`→`video/mov`, `audio/mpeg`→`audio/mp3`) and PDF ingestion end to end.
+**Left open, by decision:** text and code files → **#60**; multi-turn access to media already sent →
+**#61**. Telegram still has no handler for music files, animations or video notes — the same
+missing-handler defect this plan fixed for documents, recorded in slice 5 and not fixed.
+
 **Issue:** #51 — "Ingest inbound file-kind attachments (PDF + video) from the app channel".
-**Date:** 2026-07-29.
-**Touches:** `agent.py` (model boundary, channel-agnostic), `gateway/channels/jarvis_app/`
-(kind mapping, channel-owned), `docs/architecture/GATEWAY.md` (neutral vocabulary).
-**Companion:** [app-plans/EXECUTION_PLAN.md](app-plans/EXECUTION_PLAN.md) — Stage C shipped the
+**Date:** started 2026-07-29, shipped 2026-07-30.
+**Touches:** `agent.py` (model boundary, channel-agnostic), `gateway/channels/jarvis_app/` and
+`gateway/channels/telegram/` (kind mapping, channel-owned), `docs/architecture/GATEWAY.md`
+(neutral vocabulary).
+**Companion:** [../app-plans/EXECUTION_PLAN.md](../app-plans/EXECUTION_PLAN.md) — Stage C shipped the
 transport this plan builds on (C4 inbound media); `file`-kind ingestion was deferred out of it.
 
 ---

--- a/gateway/channels/jarvis_app/media_cache.py
+++ b/gateway/channels/jarvis_app/media_cache.py
@@ -17,10 +17,17 @@ os.makedirs(_CACHE_DIR, exist_ok=True)
 
 _RETENTION_DAYS = 90
 
-# The hub's attachment kinds are image | audio | file. Extensions are cosmetic —
+# Kinds arrive already resolved into the gateway's neutral vocabulary (the
+# router maps the hub's image | audio | file onto it). Extensions are cosmetic —
 # the agent reads bytes and branches on mime_type, not the filename — so an
 # unknown kind just gets no suffix.
-_EXT = {"image": ".jpg", "audio": ".ogg", "file": ""}
+_EXT = {
+    "image": ".jpg",
+    "audio": ".ogg",
+    "video": ".mp4",
+    "document": ".pdf",
+    "file": "",
+}
 
 
 def save(data: bytes, kind: str, attachment_id: str) -> str:

--- a/gateway/channels/jarvis_app/router.py
+++ b/gateway/channels/jarvis_app/router.py
@@ -37,6 +37,25 @@ _BACKOFF_MAX_S = 60.0
 # value that doesn't match is rejected before it can reach a filesystem path.
 _ATT_ID_RE = re.compile(r"^att_[0-9A-HJKMNP-TV-Z]{26}$")
 
+# The hub's wire vocabulary is image | audio | file, where "file" is everything
+# else — so a PDF and a video arrive under the same tag. The neutral vocabulary
+# the agent branches on is image | video | audio | document, and resolving one
+# into the other is the channel's job: only the channel knows its source's
+# vocabulary. "file" survives as "unidentified" and reaches the agent as text.
+_FILE_MIME_KINDS = {
+    "video/mp4": "video",
+    "video/webm": "video",
+    "application/pdf": "document",
+}
+
+
+def _neutral_kind(hub_kind: str, mime_type: str) -> str:
+    """Resolve the hub's kind + mime into the gateway's neutral media kind."""
+    if hub_kind != "file":
+        return hub_kind
+    mime = mime_type.split(";")[0].strip().lower()
+    return _FILE_MIME_KINDS.get(mime, "file")
+
 
 class JarvisAppInboundRouter:
     def __init__(
@@ -181,12 +200,16 @@ class JarvisAppInboundRouter:
         out: list[dict] = []
         for att in raw:
             att_id = att.get("id")
-            kind = att.get("kind")
-            if not att_id or not kind:
+            hub_kind = att.get("kind")
+            if not att_id or not hub_kind:
                 continue
             if not _ATT_ID_RE.match(att_id):
                 logger.warning("jarvis-app skipping attachment with malformed id %r", att_id)
                 continue
+            mime_type = att.get("mime_type") or ""
+            # Resolve before caching, so the cached filename reflects what the
+            # blob actually is rather than the hub's catch-all tag.
+            kind = _neutral_kind(hub_kind, mime_type)
             try:
                 data = await self._client.download_attachment(att_id)
                 path = await asyncio.to_thread(media_cache.save, data, kind, att_id)
@@ -197,7 +220,7 @@ class JarvisAppInboundRouter:
                 {
                     "kind": kind,
                     "path": path,
-                    "mime_type": att.get("mime_type") or "",
+                    "mime_type": mime_type,
                     "source": "jarvis-app",
                 }
             )

--- a/gateway/channels/telegram/host.py
+++ b/gateway/channels/telegram/host.py
@@ -61,6 +61,10 @@ class TelegramHost:
         application.add_handler(MessageHandler(filters.PHOTO, self._router.handle_photo))
         application.add_handler(MessageHandler(filters.VIDEO, self._router.handle_video))
         application.add_handler(MessageHandler(filters.VOICE, self._router.handle_voice))
+        # A document is Telegram's container for anything that is not a
+        # compressed photo, a video or a voice note — the router reads its mime
+        # to decide what it actually is.
+        application.add_handler(MessageHandler(filters.Document.ALL, self._router.handle_document))
         application.add_handler(CallbackQueryHandler(self._confirmation_ui.handle_callback))
 
         await application.initialize()

--- a/gateway/channels/telegram/media_cache.py
+++ b/gateway/channels/telegram/media_cache.py
@@ -17,14 +17,15 @@ os.makedirs(_CACHE_DIR, exist_ok=True)
 
 _RETENTION_DAYS = 90
 
-_EXT = {"image": ".jpg", "video": ".mp4", "audio": ".ogg"}
+_EXT = {"image": ".jpg", "video": ".mp4", "audio": ".ogg", "document": ".pdf"}
 
 
 def save(data: bytes, kind: str, file_id: str) -> str:
     """Persist an inbound blob; return its **absolute** path.
 
-    kind ∈ {"image","video","audio"}. The filename embeds the Telegram
-    file_id so the same media re-resolves across turns without re-download.
+    kind is a neutral media kind; an unknown one just gets no suffix, since
+    extensions are cosmetic here. The filename embeds the Telegram file_id so
+    the same media re-resolves across turns without re-download.
     """
     filename = f"{kind}_{file_id[:20]}{_EXT.get(kind, '')}"
     abs_path = os.path.join(_CACHE_DIR, filename)

--- a/gateway/channels/telegram/router.py
+++ b/gateway/channels/telegram/router.py
@@ -7,6 +7,7 @@ channel.
 
 import asyncio
 import logging
+import mimetypes
 
 from telegram import Update
 
@@ -15,6 +16,24 @@ from gateway.channels.telegram.channel import TelegramChannel, thread_id_for as 
 from gateway.channels.telegram.media_cache import save as _save_media
 
 logger = logging.getLogger(__name__)
+
+
+def _neutral_kind(mime_type: str) -> str:
+    """Resolve a document's mime into the gateway's neutral media kind.
+
+    A Telegram document is a container, not a type — it is how anything that is
+    not a compressed photo, a video or a voice note arrives, so a PDF, a video
+    sent as a file, and a photo sent at original quality all land here. Classify
+    by prefix and let the model boundary decide which formats of a kind it can
+    actually read; the channel must not carry the model's format table.
+    """
+    mime = mime_type.split(";")[0].strip().lower()
+    if mime == "application/pdf":
+        return "document"
+    for prefix, kind in (("image/", "image"), ("audio/", "audio"), ("video/", "video")):
+        if mime.startswith(prefix):
+            return kind
+    return "file"  # unidentified — the agent surfaces it as text
 
 class TelegramInboundRouter:
     def __init__(
@@ -127,6 +146,32 @@ class TelegramInboundRouter:
             chat_id=update.effective_chat.id,
             thread_id=_thread_id(user_id),
             user_text=msg.caption or "[AUDIO attachment]",
+            attachments=[attachment],
+        ))
+
+    async def handle_document(self, update: Update, context) -> None:
+        msg = update.message
+        user_id = msg.from_user.id
+        if not self._authorized(user_id):
+            return
+
+        doc = msg.document
+        # mime_type is client-supplied and may be absent — fall back to the
+        # filename, which Telegram always carries for a document.
+        mime_type = doc.mime_type or ""
+        if not mime_type and doc.file_name:
+            mime_type = mimetypes.guess_type(doc.file_name)[0] or ""
+        kind = _neutral_kind(mime_type)
+
+        attachment = await self._download_and_store(doc.file_id, kind, mime_type)
+        if not attachment:
+            await self._channel.send(str(update.effective_chat.id), "Failed to download media. Please try again.")
+            return
+        await self._dispatch(InboundMessage(
+            user_id=user_id,
+            chat_id=update.effective_chat.id,
+            thread_id=_thread_id(user_id),
+            user_text=msg.caption or f"[{kind.upper()} attachment]",
             attachments=[attachment],
         ))
 


### PR DESCRIPTION
Closes #51.

A PDF or video sent from the app reached Jarvis but never reached the model, and a PDF sent over
Telegram reached *nothing* — it matched no handler and was dropped before any gateway code ran. This
lands five slices along one principle: **channels translate into the neutral vocabulary; the model
boundary owns model limits.**

| # | Slice | Layer |
|---|---|---|
| 1 | Neutral `document` kind + app-router mime resolution | channel-owned |
| 2 | Inline size backstop | model boundary |
| 3 | `document` branch — PDFs readable | model boundary |
| 4 | Per-kind mime allowlist + alias normalization | model boundary |
| 5 | Telegram document handler | channel-owned |

## The premise this plan was built on turned out to be wrong

It assumed Gemini caps a request at ~20 MB and that base64 (+33%) put the real ceiling at ~15 MB,
which made size the dominant constraint. A 42 MB video sent from the app on 2026-07-30 inlined and
was described correctly — banner text, on-screen Hebrew, scene detail — at ~56 MB on the wire. The
API documents inline media at **<100 MB**; the 20 MB figure is its recommendation for *preferring*
the Files API, not a limit.

So slice 2 is a backstop at the documented ceiling that **cannot fire on any current channel** (the
app's hub caps at 50 MB, Telegram's Bot API at 20 MB), kept to convert a future opaque API failure
into a sentence Jarvis can say. And the gated Files API slice lost its reason entirely — reframed
and moved to #61.

## Notable decisions

- **Channels classify, the model boundary judges.** Telegram's handler resolves a document by mime
  *prefix*; which formats of a kind are readable lives once in `agent.py`. A channel carrying the
  model's capability table would go stale on the next model swap.
- **Alias normalization.** Clients spell formats differently from the API — `.mov` arrives as
  `video/quicktime`, `.mp3` as `audio/mpeg` — so those are normalized to the documented name before
  the check *and* before sending, rather than refusing a valid file over its spelling.
- **`image/gif` fixed in passing.** It is allowlisted upstream and would have inlined as an image
  that the API cannot decode; the allowlist now refuses it with the format named.
- **PDF is the only document format.** The API's document vision is PDF-specific; other types are
  extracted as pure text, so text and code files are not documents — split out as #60.

## Verification

Synthetic suites drive the real media loop with the compiled graph stubbed out and an isolated
`JARVIS_ROOT`, asserting on the content blocks built: kind resolution across hub kind × mime pairs,
the backstop at/over the ceiling, alias normalization reaching what is actually sent, refusals for
`image/gif` / `image/bmp` / `audio/x-ms-wma` / `video/ogg`, and Telegram classification including
`.docx` and `.zip` → honest note.

**Only slice 1 has run against the live API.** Slices 2–5 are synthetic-only; the untested bets are
alias normalization and PDF ingestion end to end. Staging has not been restarted on this branch.

## Follow-ups (deliberately not here)

- **#60** — text and code files, inlined as text rather than as a document.
- **#61** — multi-turn access to media already sent; absorbs the Files API work.
- Telegram still has no handler for music files (`filters.AUDIO`), animations, or video notes — the
  same missing-handler defect, recorded in the archived plan.