### PR TITLE
Unify slash-command reply formatting behind shared helpers (#54)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,11 +4,14 @@
 # Active only where core.hooksPath points here (one-time per checkout):
 #     git config core.hooksPath .githooks
 #
-# Runs the same static guards as CI's "path-isolation" job: no module hardcodes a
-# prod state path (check_paths.py), and the app stays channel-agnostic
+# Runs the two static guards: no module hardcodes a prod state path
+# (check_paths.py), and the app stays channel-agnostic
 # (check_channel_agnostic.py). Fast local feedback; the unbypassable gate is CI +
 # branch protection (see docs/DEPLOY.md). Bypass in a genuine emergency with:
 #     git commit --no-verify
+#
+# check_command_replies.py deliberately runs in CI only — it boots the whole app
+# to render each reply, which is a poor fit for a commit-time hook.
 set -euo pipefail
 
 REPO="$(git rev-parse --show-toplevel)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,15 @@
 name: CI
 
 # The unbypassable half of the regression gate: runs on every PR and on pushes to
-# main. Two independent static guards, one job each:
+# main. Three independent guards, one job each:
 #   - path-isolation    — no module hardcodes a prod state path (check_paths.py)
 #   - channel-agnostic  — the app stays channel-agnostic (check_channel_agnostic.py)
+#   - command-replies   — slash-command replies survive both renderers
+#                         (check_command_replies.py)
 # Make each a hard gate with a branch-protection rule on `main` (GitHub → Settings →
 # Branches) requiring its check to pass. (The pre-commit hook is the fast local half
-# and runs both; see docs/DEPLOY.md.)
+# and runs the first two — command-replies boots the app, too slow for a hook; see
+# docs/DEPLOY.md.)
 on:
   push:
     branches: [main]
@@ -38,3 +41,18 @@ jobs:
       - name: Channel-agnosticism check
         # Pure static source scan — no app import and no deps, so no pip install.
         run: python scripts/ci/check_channel_agnostic.py
+
+  command-replies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Slash-command reply-layout check
+        # Runs every registered command against a seeded scratch JARVIS_ROOT (same
+        # dummy-secret trick as check_paths) and validates the reply markdown.
+        run: python scripts/ci/check_command_replies.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,8 @@ Jarvis is a stateful, proactive AI assistant running as a systemd service on a h
 │   ├── confirmation/          # Confirmation/ConfirmationUI ABCs + InMemoryConfirmationStore
 │   ├── commands/              # Channel-agnostic slash-command dispatch (pre-LLM short-circuit)
 │   │   ├── router.py          #   @command decorator + try_handle_command(inbound) entry point
-│   │   └── handlers.py        #   built-in handlers (/help, /clear, /skills, /status, /memory, /heartbeat, /logs)
+│   │   ├── handlers.py        #   built-in handlers (/help, /clear, /skills, /status, /memory, /heartbeat, /logs)
+│   │   └── format.py          #   reply-layout helpers (section/kv_section/document/join) + check_reply
 │   ├── channels/              # Concrete channels, one dir each
 │   │   └── telegram/          # ONLY Telegram-specific code: channel.py, router.py, confirmation.py, host.py (PTB lifecycle)
 │   └── webhook/               # Channel-agnostic: server.py (FastAPI), notifier.py (media aggregator)
@@ -210,7 +211,7 @@ message. Never infer or fake service state.
 |------|------|
 | Add a new tool | Add it under `tools/core/` (always-on) or `tools/<skill>/` (activatable skill); decorate `@tool_register(namespace=..., destructive=...)` above `@tool`. Nothing else — the registry auto-discovers it. New skill = new `tools/<name>/` dir + a `tools/<name>/SKILL.md` (YAML frontmatter `name`/`description` + optional rules body). **Sub-skill** = a `tools/<parent>/<child>/` subpackage (`__init__.py` importing its module + its own `SKILL.md`) with `namespace="<parent>/<child>"`; the parent's `__init__.py` imports the subpackage, and a parent may own zero tools (pure discovery index — children stay hidden until the parent is activated). |
 | Add a new channel (email, etc.) | New dir `gateway/channels/<channel>/` implementing `Channel`; register in `gateway/factory.py`. No tool/agent edits. See docs/architecture/GATEWAY.md |
-| Add a slash command | Add an `async def` handler in `gateway/commands/handlers.py` decorated with `@command(name, description)`. The router auto-discovers it; `/help` and each channel's command-menu (e.g. Telegram autocomplete via `register_command_menu()`) pick it up next start. Handlers receive `(InboundMessage, args: list[str])` and return reply text — they may import `agent`/`tools` but **not** any concrete channel. See docs/architecture/GATEWAY.md (Plane 1 — Slash-Command Dispatch). |
+| Add a slash command | Add an `async def` handler in `gateway/commands/handlers.py` decorated with `@command(name, description)`. The router auto-discovers it; `/help` and each channel's command-menu (e.g. Telegram autocomplete via `register_command_menu()`) pick it up next start. Handlers receive `(InboundMessage, args: list[str])` and return reply text — they may import `agent`/`tools` but **not** any concrete channel. Build the reply with `gateway/commands/format.py` (`section`/`kv_section`/`document`/`join`), never hand-rolled markdown, and add a case to `scripts/ci/check_command_replies.py` (the guard fails on an uncovered command). See docs/architecture/GATEWAY.md (Plane 1 — Slash-Command Dispatch + Reply formatting). |
 | Change Jarvis's personality | Edit `/app/jarvis_memory/SOUL.md` directly |
 | Change behavioral rules | `/app/jarvis_code/prompts/AGENTS.md` (always-on) or `prompts/heartbeat.md` (heartbeat-scope only); a skill's own rules go in `tools/<ns>/SKILL.md`. Tool usage is driven by tool docstrings, not prompt prose. |
 | Add a heartbeat task | Ask Jarvis (it uses `manage_heartbeat_task`, validated before write), or hand-edit `/app/jarvis_memory/HEARTBEAT.md` following the grammar in docs/architecture/HEARTBEAT.md (a malformed hand edit degrades to always-due, never a silent drop) |

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -143,11 +143,11 @@ venv/bin/python scripts/ci/check_paths.py    # exit 0 clean, 1 on a leak
   ```
   Fast local feedback; bypassable with `git commit --no-verify`.
 - **Merge** — `.github/workflows/ci.yml` runs the guards on every PR and push to `main`, as
-  two independent jobs (`path-isolation`, `channel-agnostic`). Make each unbypassable by
-  enabling a **branch-protection rule** on `main` (GitHub → Settings → Branches) requiring its
-  check to pass. This is the real gate. (`path-isolation` is already required; add
-  `channel-agnostic` to the required set to enforce it too — until then it runs and reports but
-  does not block.)
+  three independent jobs (`path-isolation`, `channel-agnostic`, `command-replies`). Make each
+  unbypassable by enabling a **branch-protection rule** on `main` (GitHub → Settings → Branches)
+  requiring its check to pass. This is the real gate. (`path-isolation` is already required; add
+  the other two to the required set to enforce them too — until then they run and report but
+  do not block.)
 - **Deploy** — `deploy/deploy.sh` runs the path check before the restart hand-off.
 
 ## `scripts/ci/check_channel_agnostic.py` — channel-agnostic guard
@@ -165,6 +165,25 @@ venv/bin/python scripts/ci/check_channel_agnostic.py   # exit 0 clean, 1 on a le
 Runs at **commit** (pre-commit hook) and **merge** (its own `channel-agnostic` CI job) — the
 same first two layers as the path guard. It is **not** run at deploy: it is architecture
 hygiene, not runtime-state safety, and `main` has already passed it.
+
+## `scripts/ci/check_command_replies.py` — slash-command reply-layout guard
+
+Runs every registered slash command against a seeded scratch `JARVIS_ROOT` (same dummy-secret
+trick as the path guard — no real secrets, no network call) and checks each reply against the
+layout contract in [architecture/GATEWAY.md](architecture/GATEWAY.md) § Reply formatting: bold
+header, blank line, real `- ` list items, no literal `•`. Handler markdown crosses two
+renderers with different newline semantics, and the same collapse defect was fixed three times
+in isolation before this existed. A command registered without a case in `CASES` fails the
+guard, so a new command can't join without a decision about its layout.
+
+```bash
+venv/bin/python scripts/ci/check_command_replies.py   # exit 0 clean, 1 on a defect
+```
+
+**Merge** only — its own `command-replies` CI job. Not in the pre-commit hook (it boots
+the whole app to render each reply, ~1.5s, too slow for a commit-time guard) and not at
+deploy (layout hygiene, not runtime-state safety). Run it by hand when touching
+`gateway/commands/`.
 
 ---
 

--- a/docs/architecture/GATEWAY.md
+++ b/docs/architecture/GATEWAY.md
@@ -167,6 +167,7 @@ The store is **channel-agnostic**. The UI plug-in is the only Telegram-specific 
 gateway/commands/
 ├── router.py     # @command decorator + registry + try_handle_command(inbound) entry point
 ├── handlers.py   # built-in handlers — must import only `agent`, `tools`, neutral gateway code
+├── format.py     # reply-layout helpers + check_reply (the contract below, executable)
 └── __init__.py   # imports handlers so @command side-effects register before first dispatch
 ```
 
@@ -193,6 +194,38 @@ async def try_handle_command(inbound) -> str | None
 ```
 
 `process_inbound_message` (`main.py`) calls `try_handle_command(inbound)` **first**. A non-`None` result short-circuits: it is logged to `chat_history.jsonl` just like an agent reply (so subsequent turns see the command/reply exchange) and sent via the channel's normal reply path.
+
+### Reply formatting — one layout, two renderers
+
+A handler returns **neutral markdown**; the channel it came from renders it. The channels disagree about a bare newline, and that disagreement is the single most repeated bug in this module:
+
+| | renderer | bare `\n` between two plain lines |
+|---|---|---|
+| Telegram | `markdown_to_html.convert()` — line-based | preserved; renders as a line break |
+| jarvis-app | CommonMark | **soft break — the lines flow into one paragraph** |
+
+So a reply that looks correct in the Telegram client can silently collapse on the app. Any layout relying on a bare newline to separate lines is a latent app-channel bug.
+
+**The contract** — the shape that satisfies both:
+
+- A **bold header**, a **blank line**, then real `- ` list items. Telegram rewrites `^[-*+]\s` into `• `; CommonMark keeps genuine list items on their own lines.
+- **Never a literal `•`** — Telegram's converter only rewrites the markdown marker, so a hand-typed bullet passes there and stays inert prose in the app.
+- Emphasis is `**bold**`. A single `*` is *italic* in both, which is not what a header wants.
+- Blocks are separated by a **blank line**, never a single newline.
+- Two leading spaces nest a list item one level (clears the parent's content column for CommonMark; Telegram indents to match).
+
+**Do not hand-roll it.** `gateway/commands/format.py` owns the layout:
+
+```python
+section("Available commands", items)      # **header**, blank line, "- item" per entry
+kv_section("Jarvis status", pairs)        # same, rendered "- **key**: value"
+document("HEARTBEAT.md", body)            # a header above raw file content
+join(block_a, block_b)                    # blank-line-separated blocks
+```
+
+`check_reply(text)` in the same module is the executable half of the contract, and `scripts/ci/check_command_replies.py` runs it over every registered command's reply as its own CI job. Replies that are **verbatim file content** (`/memory <file>`, `/logs`, `/heartbeat <task>`) are exempt — the handler doesn't own that layout — and the guard reports them as skipped rather than silently passing them.
+
+> Length is a separate concern: Telegram truncates the source markdown at 4096/1024 chars (`gateway/channels/telegram/channel.py`); the app channel has no equivalent cap. Handlers that return whole files (`/memory <file>`, `/logs`, `/heartbeat`) can exceed either. Tracked in #23 (paginate rather than truncate) — the app-side gap is unfixed there.
 
 ### Channel discoverability — optional but encouraged
 

--- a/docs/architecture/OBSERVABILITY.md
+++ b/docs/architecture/OBSERVABILITY.md
@@ -121,7 +121,7 @@ A `uuid4().hex` minted at the **top of every turn** and propagated through every
 
 ## The Two Query Surfaces
 
-### `/usage` — Telegram slash command
+### `/usage` — slash command
 
 Lives in `gateway/commands/handlers.py`. Thin wrapper around `observability.summarize_usage` + `format_usage_table`.
 
@@ -138,7 +138,7 @@ Lives in `gateway/commands/handlers.py`. Thin wrapper around `observability.summ
 
 Trailing `user` or `heartbeat` always narrows the rollup; combine freely with any date token. The handler reuses `_parse_log_date` from `/logs` for date parsing.
 
-Rendering is a compact summary (totals line + per-bucket bullets when ≥ 2 buckets) — readable on mobile, no horizontal scroll, no fixed-width tables.
+Rendering is a compact summary (totals line + per-bucket bullets when ≥ 2 buckets) — readable on mobile, no horizontal scroll, no fixed-width tables. It follows the slash-command reply contract (bold header, blank line, real `- ` items) so it survives both the Telegram and CommonMark renderers — see [GATEWAY.md](GATEWAY.md) § Reply formatting.
 
 ### `observability` Python module — REPL / scripts
 

--- a/gateway/channels/telegram/channel.py
+++ b/gateway/channels/telegram/channel.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 # Telegram's hard caps: 4096 chars for text, 1024 for photo captions. We
 # truncate the *source markdown* (not the converted HTML, which could be cut
 # mid-tag) with headroom for HTML entity expansion. This is a safety net,
-# not a feature — see issue #52 for proper paragraph-aware pagination.
+# not a feature — see issue #23 for proper paragraph-aware pagination.
 _TEXT_LIMIT = 3800
 _CAPTION_LIMIT = 900
 _TRUNCATION_TAIL = "\n\n_…(truncated — output too long for one message)_"

--- a/gateway/commands/format.py
+++ b/gateway/commands/format.py
@@ -1,0 +1,126 @@
+"""Reply layout for slash commands — one contract, two renderers.
+
+A handler returns neutral markdown; whichever channel the command arrived on
+renders it. The channels disagree about a bare newline:
+
+| renderer   | how it reads `\\n` between two plain lines                     |
+|------------|----------------------------------------------------------------|
+| Telegram   | `markdown_to_html.convert()` is line-based — a newline is a newline |
+| jarvis-app | CommonMark — a **soft break**: the two lines flow into one paragraph |
+
+So a layout that looks right in the Telegram client can silently collapse on
+the app. The shape that satisfies both is: **a bold header, a blank line, then
+real `- ` list items.** Telegram rewrites `^[-*+]\\s` into `• `; CommonMark keeps
+genuine list items on their own lines. Emphasis is `**bold**` — a single `*` is
+*italic* in both, which is not what a header wants.
+
+Handlers build replies from the helpers here instead of hand-rolling layout:
+the same soft-break defect was fixed three times in isolation (`/help`,
+`/usage`, ...) because the contract was written down nowhere. `check_reply` is
+the executable half of it — `scripts/ci/check_command_replies.py` runs it over
+every handler's output in CI, so a fourth recurrence fails on the PR rather than
+on the owner's phone. Prose version: docs/architecture/GATEWAY.md § Reply
+formatting.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, Sequence
+
+# An empty section says so on its own plain line rather than as a bullet — a
+# lone "- (none)" reads as an entry in the list it is denying.
+_EMPTY = "_(none)_"
+
+_LIST_ITEM_RE = re.compile(r"^\s*(?:[-*+]|\d+[.)])\s+\S")
+_HEADING_RE = re.compile(r"^\s*#{1,6}\s+\S")
+
+
+def _bullet(item: str) -> str:
+    """`- item`, preserving any leading indent as a nesting level.
+
+    Two leading spaces nest one level: that clears the parent's content column
+    (`- ` is two chars), which is what CommonMark requires for a sub-list, and
+    Telegram's converter indents by `len(indent) // 2` to match.
+    """
+    stripped = item.lstrip(" ")
+    indent = " " * (len(item) - len(stripped))
+    return f"{indent}- {stripped}"
+
+
+def section(header: str, items: Iterable[str], *, empty: str = _EMPTY) -> str:
+    """A bold header, a blank line, and one `- ` list item per entry.
+
+    Items are plain text — the bullet marker is added here so no handler
+    hand-rolls it (a hand-typed `•` is inert prose in CommonMark). Pass `empty`
+    to override the placeholder shown when there are no items.
+    """
+    body = "\n".join(_bullet(i) for i in items)
+    return f"**{header}**\n\n{body or empty}"
+
+
+def kv_section(header: str, pairs: Sequence[tuple[str, object]], **kwargs) -> str:
+    """`section` over key/value pairs, rendered `- **key**: value`.
+
+    One convention for the field-list shape, which `/status`, `/skills` and
+    `/usage` each used to spell differently.
+    """
+    return section(header, [f"**{k}**: {v}" for k, v in pairs], **kwargs)
+
+
+def document(header: str, body: str) -> str:
+    """A bold header above raw file content.
+
+    The blank line is the entire point: without it the header runs into the
+    file's first line on a CommonMark client.
+    """
+    return f"**{header}**\n\n{body.strip()}"
+
+
+def join(*blocks: str) -> str:
+    """Blank-line-separated blocks — the only separator both renderers agree on.
+    Falsy blocks are dropped so callers can inline a conditional."""
+    return "\n\n".join(b for b in blocks if b)
+
+
+def check_reply(text: str) -> list[str]:
+    """Contract violations in a reply string; empty list means it conforms.
+
+    Two rules, both about what CommonMark does that Telegram does not:
+
+    1. A literal `•` is not a list item. Telegram's converter only rewrites
+       `^[-*+]\\s`, so a hand-typed bullet passes there and stays inert prose in
+       the app.
+    2. A plain (non-list, non-heading) line must be followed by a blank line, a
+       code fence, or the end of the reply. A second plain line *or* a list item
+       after it is a soft break in CommonMark — the lines flow together. (A list
+       may legally interrupt a paragraph in CommonMark, but requiring the blank
+       line keeps one shape instead of two and costs nothing in either renderer.)
+
+    Fenced code blocks are exempt — both renderers keep them verbatim.
+
+    Only `scripts/ci/check_command_replies.py` calls this; it lives here so the
+    rule and the helpers that satisfy it stay in one file.
+    """
+    problems: list[str] = []
+    lines = text.split("\n")
+    in_fence = False
+
+    for i, line in enumerate(lines):
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if "•" in line:
+            problems.append(f"line {i + 1}: literal '•' — use a real '- ' list item")
+        if not line.strip() or _LIST_ITEM_RE.match(line) or _HEADING_RE.match(line):
+            continue
+        nxt = lines[i + 1] if i + 1 < len(lines) else ""
+        if nxt.strip() and not nxt.lstrip().startswith("```"):
+            problems.append(
+                f"line {i + 1}: plain line followed by a non-blank line — "
+                f"CommonMark soft-breaks these into one paragraph "
+                f"({line.strip()[:40]!r} → {nxt.strip()[:40]!r})"
+            )
+    return problems

--- a/gateway/commands/handlers.py
+++ b/gateway/commands/handlers.py
@@ -4,6 +4,37 @@ the user; the router (`gateway/commands/router.py`) drives dispatch.
 Handlers reach into `agent` for the LangGraph executor and the shared sqlite
 connection — that's the gateway↔agent boundary, not the channel↔gateway
 boundary, so it's fine. No handler may import a concrete channel module.
+
+Adding a handler
+----------------
+An `async def` taking `(inbound, args)` and returning the reply text, decorated
+with `@command(name, description)`. The router auto-discovers it.
+
+**Build the reply with `gateway.commands.format` — never hand-rolled markdown.**
+A reply crosses two renderers that disagree about a bare newline: Telegram's
+converter is line-based, CommonMark (the app) treats it as a soft break and
+flows the lines into one paragraph. The same collapse was fixed three times in
+isolation before the helpers existed. They are:
+
+    section("Available commands", items)   # **header**, blank line, "- item" each
+    kv_section("Jarvis status", pairs)     # same, rendered "- **key**: value"
+    document("HEARTBEAT.md", body)         # a header above raw file content
+    join(block_a, block_b)                 # blank-line-separated blocks
+
+    @command("things", "List the things")
+    async def _things(inbound: InboundMessage, args: list[str]) -> str:
+        return section("Things", [f"`{t.name}` — {t.detail}" for t in things()])
+
+A one-line reply ("Conversation reset.") needs no helper — the rules only bite
+once a reply has two lines. Never emit a literal `•`: Telegram's converter only
+rewrites the `- ` marker, so a hand-typed bullet passes there and stays inert
+prose in the app.
+
+Then add a case to `scripts/ci/check_command_replies.py` — it fails on any
+command registered without one, so the layout decision is made explicitly
+(`strict`, or `raw` when the reply is verbatim file content the handler doesn't
+own). Full contract: `gateway/commands/format.py` and
+docs/architecture/GATEWAY.md § Reply formatting.
 """
 
 from __future__ import annotations
@@ -12,6 +43,7 @@ import asyncio
 import logging
 
 from gateway.base import InboundMessage
+from gateway.commands.format import document, join, kv_section, section
 from gateway.commands.router import command, list_commands
 
 logger = logging.getLogger(__name__)
@@ -19,14 +51,10 @@ logger = logging.getLogger(__name__)
 
 @command("help", "List available slash commands")
 async def _help(inbound: InboundMessage, args: list[str]) -> str:
-    # A markdown bullet list (blank line after the header) so both renderers keep
-    # the commands on separate lines: a CommonMark client (the app) treats a bare
-    # newline as a soft break and would otherwise flow them onto one line, while
-    # Telegram's converter renders "- " as "• ".
-    lines = ["**Available commands:**", ""]
-    for c in list_commands():
-        lines.append(f"- `/{c.name}` — {c.description}")
-    return "\n".join(lines)
+    return section(
+        "Available commands",
+        [f"`/{c.name}` — {c.description}" for c in list_commands()],
+    )
 
 
 @command("clear", "Reset this conversation (wipe agent memory for this thread)")
@@ -79,7 +107,7 @@ async def _skills(inbound: InboundMessage, args: list[str]) -> str:
 
     def _line(ns: str, indent: int = 0) -> str:
         desc, _ = registry._skill_meta(ns)
-        return f"{'  ' * indent}- {ns}: {desc or '(no description)'}"
+        return f"{'  ' * indent}**{ns}**: {desc or '(no description)'}"
 
     # Active section — every active namespace must appear here.
     active_lines: list[str] = []
@@ -101,19 +129,17 @@ async def _skills(inbound: InboundMessage, args: list[str]) -> str:
     available_lines: list[str] = []
     for ns in top:
         if ns in active:
-            available_lines.append(f"- {ns} (active — see above)")
+            available_lines.append(f"**{ns}** (active — see above)")
             for child in children.get(ns, []):
                 if child not in active:
                     available_lines.append(_line(child, indent=1))
         else:
             available_lines.append(_line(ns))
 
-    parts = ["**Active skills:**"]
-    parts.append("\n".join(active_lines) if active_lines else "(none)")
-    parts.append("")
-    parts.append("**Available skills:**")
-    parts.append("\n".join(available_lines) if available_lines else "(none)")
-    return "\n".join(parts)
+    return join(
+        section("Active skills", active_lines),
+        section("Available skills", available_lines),
+    )
 
 
 @command("status", "Show runtime status (model, scope, active skills, tools)")
@@ -124,15 +150,19 @@ async def _status(inbound: InboundMessage, args: list[str]) -> str:
     core_n, skill_n, ns_n = registry.registered_counts()
     active = _active_skills(inbound.thread_id)
     model_name = getattr(agent.llm, "model", "unknown")
-    lines = [
-        "**Jarvis status:**",
-        f"- model: {model_name}",
-        f"- scope: user",
-        f"- thread: {inbound.thread_id}",
-        f"- active skills: {', '.join(sorted(active)) if active else 'none'}",
-        f"- tools registered: {core_n} core + {skill_n} skill across {ns_n} namespace(s)",
-    ]
-    return "\n".join(lines)
+    return kv_section(
+        "Jarvis status",
+        [
+            ("model", model_name),
+            ("scope", "user"),
+            ("thread", inbound.thread_id),
+            ("active skills", ", ".join(sorted(active)) if active else "none"),
+            (
+                "tools registered",
+                f"{core_n} core + {skill_n} skill across {ns_n} namespace(s)",
+            ),
+        ],
+    )
 
 
 def _memory_list_top_level() -> str:
@@ -151,7 +181,7 @@ def _memory_list_top_level() -> str:
         return f"Error listing memory: {e}"
     if not entries:
         return "No top-level memory files."
-    return "**Memory files:**\n" + "\n".join(f"- {e}" for e in entries)
+    return section("Memory files", entries)
 
 
 @command(
@@ -186,7 +216,7 @@ def _heartbeat_list_tasks() -> str:
         return f"Error listing heartbeat tasks: {e}"
     if not entries:
         return "No heartbeat task state files yet."
-    return "**Heartbeat task state files:**\n" + "\n".join(f"- {e}" for e in entries)
+    return section("Heartbeat task state files", entries)
 
 
 @command(
@@ -210,7 +240,7 @@ async def _heartbeat(inbound: InboundMessage, args: list[str]) -> str:
     body = await asyncio.to_thread(agent.load_or_blank, agent._HEARTBEAT_MD_PATH)
     if not body:
         return "HEARTBEAT.md is empty or unreadable."
-    return f"**HEARTBEAT.md:**\n{body}"
+    return document("HEARTBEAT.md", body)
 
 
 def _parse_log_date(arg: str) -> str | None:
@@ -265,6 +295,16 @@ def _parse_log_date(arg: str) -> str | None:
     return None
 
 
+_LOGS_USAGE = section(
+    "Usage",
+    [
+        "`/logs [today|yesterday|D[.M[.Y]]]` — `.` or `/` as the date separator",
+        "Examples: `/logs`, `/logs yesterday`, `/logs 21` (this month), "
+        "`/logs 21.5`, `/logs 21.5.2026`",
+    ],
+)
+
+
 @command(
     "logs",
     "Show today's daily log. Sub: /logs today|yesterday|D[.M[.Y]]",
@@ -277,20 +317,20 @@ async def _logs(inbound: InboundMessage, args: list[str]) -> str:
     else:
         iso = _parse_log_date(" ".join(args).strip())
         if iso is None:
-            return (
-                "Invalid date. Try /logs, /logs today, /logs yesterday, "
-                "/logs 21 (this month), /logs 21.5, or /logs 21.5.2026 "
-                "(also accepts '/' as the separator)."
-            )
+            return join("Invalid date.", _LOGS_USAGE)
 
     return await asyncio.to_thread(
         read_memory.invoke, {"filename": f"daily/daily_{iso}.md"}
     )
 
 
-_USAGE_USAGE = (
-    "Usage: /usage [today|yesterday|week|D[.M[.Y]]] [user|heartbeat]\n"
-    "Examples: /usage, /usage yesterday, /usage week, /usage week user, /usage 21.5"
+_USAGE_USAGE = section(
+    "Usage",
+    [
+        "`/usage [today|yesterday|week|D[.M[.Y]]] [user|heartbeat]`",
+        "Examples: `/usage`, `/usage yesterday`, `/usage week`, "
+        "`/usage week user`, `/usage 21.5`",
+    ],
 )
 
 
@@ -325,7 +365,7 @@ async def _usage(inbound: InboundMessage, args: list[str]) -> str:
     else:
         iso = _parse_log_date(range_token)
         if iso is None:
-            return f"Invalid date.\n{_USAGE_USAGE}"
+            return join("Invalid date.", _USAGE_USAGE)
         since, until = israel_day_range(iso)
         group_by = "day" if scope_filter else "scope"
         title = f"**Usage — {iso}**" + (f" ({scope_filter})" if scope_filter else "")

--- a/observability/usage.py
+++ b/observability/usage.py
@@ -363,7 +363,10 @@ def format_usage_table(rows: list[dict], title: str = "") -> str:
     CommonMark client (the app) collapses bare newlines into one paragraph and
     needs genuine list syntax to keep rows apart. Emphasis is '**bold**' for the
     same reason — single '*' is *italic* in both, which is not what the numbers
-    want. See the /help handler for the precedent.
+    want. That is the slash-command reply contract (gateway/commands/format.py,
+    docs/architecture/GATEWAY.md § Reply formatting); the layout is built here
+    rather than with those helpers only to keep observability free of a gateway
+    import. scripts/ci/check_command_replies.py validates this output via /usage.
 
     `extras` carries NO_ACTION / error counts and, when any model in the period
     is missing from MODEL_PRICES, an '⚠ unpriced' marker — without it a $0.00

--- a/scripts/ci/check_command_replies.py
+++ b/scripts/ci/check_command_replies.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""CI guard: every slash-command reply survives both renderers.
+
+A handler's reply is neutral markdown rendered by whichever channel the command
+arrived on, and the two disagree about a bare newline: Telegram's converter is
+line-based, CommonMark (the app) treats it as a soft break and flows the lines
+into one paragraph. The same defect was fixed three times in isolation (/help,
+/usage, ...) before the contract was written down; this asserts it holds for
+every command at once, so a fourth recurrence fails here instead of on the
+owner's phone.
+
+Runs each registered command against a seeded scratch JARVIS_ROOT and feeds the
+reply to `gateway.commands.format.check_reply` — the contract's executable half
+(bold header, blank line, real `- ` items; no literal bullets). Replies that are
+verbatim file content are marked `raw` below: the handler does not own their
+layout, so they are reported as skipped rather than silently passed.
+
+Run:  python3 scripts/ci/check_command_replies.py    (exit 0 = clean, 1 = defect)
+Must run in a fresh interpreter — it sets JARVIS_ROOT before the app imports.
+"""
+import asyncio
+import datetime as dt
+import json
+import os
+import shutil
+import sys
+import tempfile
+from zoneinfo import ZoneInfo
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# (command line, mode). "strict" validates the whole reply; "raw" means the reply
+# is a file's own content — only its existence is checked. Every registered
+# command must appear here at least once (asserted below), so a new command
+# cannot join without a decision about how its reply is laid out.
+CASES: list[tuple[str, str]] = [
+    ("/help", "strict"),
+    ("/clear", "strict"),
+    ("/skills", "strict"),
+    ("/status", "strict"),
+    ("/memory", "raw"),            # MEMORY.md verbatim
+    ("/memory list", "strict"),
+    ("/memory notes.md", "raw"),   # requested file verbatim
+    ("/heartbeat", "strict"),      # header + HEARTBEAT.md body — the header is ours
+    ("/heartbeat list", "strict"),
+    ("/heartbeat morning", "raw"), # per-task notes verbatim
+    ("/logs", "raw"),              # daily log verbatim
+    ("/logs 32.13", "strict"),     # invalid date → usage help
+    ("/usage", "strict"),
+    ("/usage week", "strict"),
+    ("/usage today heartbeat", "strict"),
+    ("/usage 32.13", "strict"),    # invalid date → usage help
+    ("/nope", "strict"),           # router's unknown-command reply
+]
+
+# Seeded so the list handlers take their non-empty branch and /heartbeat has a
+# body to run into. The HEARTBEAT.md seed opens with a plain line on purpose:
+# that is exactly what collapses onto the header if the blank line is ever
+# dropped again.
+MEMORY_SEED = {
+    "MEMORY.md": "# Memory index\n\n- notes.md — scratch\n",
+    "notes.md": "Some note.\n",
+    "HEARTBEAT.md": "Heartbeat tasks.\n\n- morning · every 4h\n",
+    "heartbeat/morning.md": "# morning\n\nlast_run: 2026-07-30T06:00:00Z\n",
+}
+
+TURNS_SEED = [
+    {"scope": "user", "model": "gemini-3-flash-preview", "llm_calls": 2,
+     "tool_calls": 1, "input_tokens": 40000, "cache_read_tokens": 12000,
+     "output_tokens": 900, "reasoning_tokens": 300, "total_tokens": 40900},
+    # A second scope so the rollup has 2+ buckets and renders the breakdown
+    # block, and an unpriced model so the '⚠ unpriced' marker is exercised too.
+    {"scope": "heartbeat", "model": "gemini-9-not-in-price-table", "llm_calls": 1,
+     "tool_calls": 0, "input_tokens": 8000, "cache_read_tokens": 0,
+     "output_tokens": 120, "reasoning_tokens": 0, "total_tokens": 8120,
+     "no_action": True},
+]
+
+
+def _seed(scratch: str) -> None:
+    import agent
+    import config
+    from observability.telemetry import TURNS_LOG
+
+    # SqliteSaver creates its tables lazily on first use; /clear deletes from
+    # them directly, so a never-used scratch db would fail there for a reason
+    # that has nothing to do with layout.
+    agent.memory.setup()
+
+    for rel, body in MEMORY_SEED.items():
+        path = os.path.join(config.MEMORY_DIR, rel)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(body)
+
+    israel_today = dt.datetime.now(dt.timezone.utc).astimezone(
+        ZoneInfo("Asia/Jerusalem")
+    ).date()
+    daily = os.path.join(config.MEMORY_DIR, "daily", f"daily_{israel_today}.md")
+    os.makedirs(os.path.dirname(daily), exist_ok=True)
+    with open(daily, "w", encoding="utf-8") as f:
+        f.write(f"# {israel_today}\n\n- seeded by check_command_replies\n")
+
+    # Mid-day UTC so the record lands on the same Israel day the rollup asks for
+    # regardless of when CI runs.
+    ts = dt.datetime.combine(israel_today, dt.time(9, 0), tzinfo=dt.timezone.utc)
+    os.makedirs(os.path.dirname(TURNS_LOG), exist_ok=True)
+    with open(TURNS_LOG, "w", encoding="utf-8") as f:
+        for rec in TURNS_SEED:
+            f.write(json.dumps({"ts": ts.isoformat(), **rec}) + "\n")
+
+
+def _run_cases() -> list[str]:
+    from gateway.base import InboundMessage
+    from gateway.commands import list_commands, try_handle_command
+    from gateway.commands.format import check_reply
+
+    failures: list[str] = []
+    skipped: list[str] = []
+
+    registered = {c.name for c in list_commands()}
+    covered = {line.split()[0].lstrip("/") for line, _ in CASES}
+    for missing in sorted(registered - covered):
+        failures.append(
+            f"/{missing}: registered but has no case in CASES — add one "
+            f"(mode 'strict', or 'raw' if the reply is verbatim file content)"
+        )
+
+    for line, mode in CASES:
+        inbound = InboundMessage(
+            user_id=1, chat_id=1, thread_id="check_command_replies", user_text=line
+        )
+        reply = asyncio.run(try_handle_command(inbound))
+        if not isinstance(reply, str) or not reply.strip():
+            failures.append(f"{line}: handler returned {reply!r}")
+            continue
+        if "failed — check logs" in reply:
+            failures.append(f"{line}: handler raised (router caught it) — {reply!r}")
+            continue
+        if mode == "raw":
+            skipped.append(line)
+            continue
+        for problem in check_reply(reply):
+            failures.append(f"{line}: {problem}")
+
+    if skipped:
+        print(f"note: layout not checked for verbatim-file replies: {', '.join(skipped)}")
+    # A cold scratch root has no active skills, so /skills only ever renders its
+    # empty branch here — the nested (active-parent) layout is the helper's
+    # concern, not this guard's.
+    return failures
+
+
+def main() -> int:
+    assert "config" not in sys.modules and "agent" not in sys.modules, \
+        "check_command_replies must run in a fresh interpreter (config/agent not yet imported)"
+
+    scratch = tempfile.mkdtemp(prefix="jarvis-check-replies-")
+    try:
+        os.makedirs(os.path.join(scratch, "secrets"))
+        # agent.py asserts GOOGLE_API_KEY at import; a dummy lets the import
+        # complete without real secrets. No handler makes a network call.
+        with open(os.path.join(scratch, "secrets", ".env"), "w") as f:
+            f.write("GOOGLE_API_KEY=dummy-for-check-command-replies\n")
+        os.environ["JARVIS_ROOT"] = scratch
+        sys.path.insert(0, REPO_ROOT)
+
+        import tools  # noqa: F401 — populates the registry so /skills and /status see it
+
+        _seed(scratch)
+        failures = _run_cases()
+        if failures:
+            print("FAIL: slash-command replies break the layout contract:")
+            for f in failures:
+                print("   ", f)
+            print(
+                "\nBuild replies with gateway/commands/format.py "
+                "(section / kv_section / document / join). "
+                "Contract: docs/architecture/GATEWAY.md § Reply formatting."
+            )
+            return 1
+        print(f"OK: {len(CASES)} slash-command replies conform to the layout contract")
+        return 0
+    finally:
+        shutil.rmtree(scratch, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #54.

## Problem

Handler replies cross two renderers with different newline semantics:

| | renderer | bare `\n` between two plain lines |
|---|---|---|
| Telegram | `markdown_to_html.convert()` — line-based | preserved; renders as a line break |
| jarvis-app | CommonMark | **soft break — the lines flow into one paragraph** |

Markdown that looks correct in the Telegram client silently collapses on the app. The same defect had been fixed three times in isolation (`/help` `899fe67`, `/usage` `06365c1`) because the contract was written down nowhere.

## The contract, once

Bold header → blank line → real `- ` list items. `**bold**` for emphasis (single `*` is *italic* in both). Blocks separated by a blank line. Never a literal `•` — Telegram's converter only rewrites the `- ` marker, so a hand-typed bullet passes there and stays inert prose in the app.

Stated in `docs/architecture/GATEWAY.md` § Reply formatting, and — where a new command author actually looks — in the `handlers.py` module docstring, with signatures and a worked `@command` example. `gateway/commands/format.py` owns it:

```python
section("Available commands", items)   # **header**, blank line, "- item" each
kv_section("Jarvis status", pairs)     # same, rendered "- **key**: value"
document("HEARTBEAT.md", body)         # a header above raw file content
join(block_a, block_b)                 # blank-line-separated blocks
```

## Handlers converted

**Certain defects** (two plain lines joined by a bare newline): `_USAGE_USAGE`, `/usage`'s invalid-date reply, `/skills`' `(none)` under its header, `/heartbeat`'s `**HEARTBEAT.md:**\n{body}` running into the file's first line.

**The rows flagged as needing an on-device check** (header + list, no blank line) are converted too, and the check turned out to be moot: the helpers emit the blank line unconditionally, which is correct in CommonMark whether or not a list may interrupt a paragraph there, and inert in Telegram's converter. `/logs`' own invalid-date reply follows `/usage`'s shape.

Three spellings of the same field-list idea (`- key: value`, `- ns: desc`, `- **bold** — …`) collapse to `kv_section`'s `- **key**: value`.

`format_usage_table` keeps its hand-built layout — it already conforms, and importing gateway helpers into `observability` would invert the layering. Its docstring points at the contract instead of restating it; the guard validates its output through `/usage`.

## Regression gate

`scripts/ci/check_command_replies.py` runs every registered command against a seeded scratch `JARVIS_ROOT` and validates the reply with `format.check_reply`. A command registered without a case in `CASES` fails the guard, so a new command can't land without an explicit layout decision. Verbatim-file replies (`/memory <file>`, `/logs`, `/heartbeat <task>`) are exempt — the handler doesn't own that layout — and are **printed as skipped**, not silently passed.

CI job only, not the pre-commit hook: it boots the whole app to render each reply (~1.5s), a poor fit for a commit-time guard.

## Verification

- All three guards green locally.
- `check_reply` flags every defect the issue lists — both the certain ones and the three "likely ok, needs verification" rows — when fed the pre-fix strings, and passes every new shape.
- Reintroduced the `/heartbeat` defect on purpose → guard failed with the right message; restored.
- Printed each reply as source markdown *and* converted Telegram HTML: bullets, bold, nesting and code spans all render correctly. Nested `/skills` (active parent) checked separately, since a cold scratch root has no active skills.
- **On-device pass through the running service is pending a staging restart** — Telegram *and* app, since the app is where a collapse would show.

## Adjacent, not fixed here

The jarvis-app channel has **no message-length cap**; Telegram truncates the source markdown at 3800/900 chars. `/heartbeat`, `/memory <file>` and `/logs` return whole files and can exceed either. That belongs on #23 (paginate rather than truncate), whose framing is incomplete — one channel truncates, the other doesn't.

This PR also corrects a stale cross-reference: the truncation comment in `gateway/channels/telegram/channel.py` cited **#52** (the Stage C app-channel issue) for paragraph-aware pagination. That's **#23**.