### PR TITLE
feat(app-channel): add AppConfirmationUI (C5/B2)

### DIFF
--- a/docs/architecture/GATEWAY.md
+++ b/docs/architecture/GATEWAY.md
@@ -146,9 +146,9 @@ sequenceDiagram
     UI->>Store: resolve(callback_id, outcome)
     alt confirmed
         Store->>Store: await action_fn()
-        Store->>UI: edit_outcome(success/fail text)
+        Store->>UI: apply_outcome(CONFIRMED/FAILED, success/fail text)
     else cancelled or expired
-        Store->>UI: edit_outcome(cancellation text)
+        Store->>UI: apply_outcome(CANCELLED/EXPIRED, cancellation text)
     end
     Store-)User: on_outcome(...) or outbox.notify_owner(...)
 ```
@@ -347,18 +347,33 @@ The store implementation (`InMemoryConfirmationStore`) handles bookkeeping, TTL 
 ### `ConfirmationUI` ABC (`gateway/confirmation/base.py`)
 
 ```python
+class ConfirmationOutcome(str, Enum):
+    CONFIRMED = "confirmed"
+    CANCELLED = "cancelled"
+    FAILED = "failed"           # confirmed, but the action itself raised
+    EXPIRED = "expired"
+    ALREADY_HANDLED = "already_handled"
+
 class ConfirmationUI(ABC):
     @abstractmethod
     async def send_prompt(self, callback_id: str, description: str) -> None: ...
 
     @abstractmethod
-    async def edit_outcome(self, callback_id: str, outcome_text: str) -> None: ...
+    async def apply_outcome(
+        self, callback_id: str, outcome: ConfirmationOutcome, outcome_text: str
+    ) -> None:
+        """Deliver the final state. `outcome` is the structured result (fixed
+        vocabulary); `outcome_text` is the human-readable prose. Implementations
+        read whichever fits their wire — most read exactly one. Must not raise;
+        the store isolates each call so a failure here can't skip what follows."""
 
     # Channels may also expose a channel-native callback handler
     # (e.g. PTB CallbackQueryHandler) that calls store.resolve(callback_id, outcome).
 ```
 
 `InMemoryConfirmationStore.__init__(ui: ConfirmationUI, outbox: Outbox, owner_thread_id: str, on_outcome=None)` — one store **per channel**, carrying that channel's `owner_thread_id` and `outbox` so a resolved confirmation acks on the channel the turn came from. The store delegates rendering to `ui` and delivers the final outcome via the injected `on_outcome(system_text, owner_thread_id, outbox)` domain callback (conversational acknowledgement) or `outbox.notify_owner(...)` verbatim as fallback. Stores register per channel name; `get_confirmation()` resolves the **origin** channel's store from the running turn's `CURRENT_THREAD_ID` (falling back to the default channel for origin-less turns).
+
+`apply_outcome` is one method carrying both a structured `outcome` and rendered `outcome_text`, rather than two parallel methods. `TelegramConfirmationUI` reads only `outcome_text` (it edits the prompt message to that string) — the jarvis-app hub has no such free-text edit at all, only `PATCH {state}` on the block, so `AppConfirmationUI` reads only `outcome`, mapping it to the hub's `confirmed|cancelled|expired` vocabulary. An earlier draft split this into two independently-overridable methods (one abstract but often vestigial, one optional but load-bearing for the second channel) — collapsed into one abstract method after review, since both facts describe the same event and a channel is expected to just ignore whichever field it doesn't need. `InMemoryConfirmationStore._apply_outcome` wraps every call in a try/except so a channel's delivery failure can never skip the conversational follow-up after it.
 
 ---
 
@@ -474,7 +489,7 @@ Concrete steps to add an `email` (or `whatsapp`, etc.) channel after Phase 1 lan
    - `confirmation.py` — `EmailConfirmationUI(ConfirmationUI)` (e.g. magic-link confirm/cancel URLs).
 2. **Implement the `Channel` ABC** in `channel.py`. Constructor takes `allowed_email: str` (or whatever owner-config makes sense). Implement `send` (SMTP), `send_media` (SMTP attachment), `send_to_owner` (fixed recipient), `authorize` (compare sender), `owner_thread_id` (e.g. `email_<sanitized_address>` — single-source the format in `channel.py` and reuse it from the router).
 3. **Define an owner-config env** (e.g. `ALLOWED_EMAIL`) and add it to `/app/secrets/.env`. Add channel-specific config (`SMTP_HOST`, `SMTP_USER`, `IMAP_HOST`, etc.). The **factory** reads all of it — `main.py` never sees channel config.
-4. **Implement `ConfirmationUI`** if your channel needs a confirmation flow. The store interface is fixed — only `send_prompt` and `edit_outcome` are channel-specific.
+4. **Implement `ConfirmationUI`** if your channel needs a confirmation flow. The store interface is fixed — `send_prompt` and `apply_outcome` are the two required, channel-specific methods. `apply_outcome` carries both a structured `outcome` and rendered `outcome_text`; read whichever fits your wire and ignore the other (see `TelegramConfirmationUI` for text-only, `AppConfirmationUI` for structured-state-only).
 5. **Register in `gateway/factory.py`** — add a `build_email_stack(...)` factory that reads the config env, constructs channel + outbox + router + confirmation store/UI + host, wires the router to `process_inbound_message`, registers the defaults (outbox, confirmation, default channel), and returns a stack with `start()`/`stop()`.
 6. **Wire startup in `main.py`** — call the factory and `await stack.start()`. That's the whole host-side footprint.
 7. **Update `thread_id` convention** — use `email_<sanitized_address>` (or whatever format suits the channel's identifier domain).

--- a/docs/plans/app-plans/EXECUTION_PLAN.md
+++ b/docs/plans/app-plans/EXECUTION_PLAN.md
@@ -1,15 +1,17 @@
 # App channel — execution plan
 
-**Status (2026-07-29):** Stage C on branch `feat/stage-c-app-channel`. **Landed & committed:** C1
-(text round-trip, verified live), C2 (slash commands), C6 (channel identity — #50 Phase 1), `/help`
-list fix, **C3 (outbound media), C4 (inbound media)** + its review follow-ups, and **§4 (image upload
-metadata — width/height + blur-up placeholder)**. The hub **upgraded to the pinned
-`3b3a48f330f09a39`** (skew resolved), and an independent audit confirmed we are **in sync with
-`roiguri/jarvis-app-v2@main`** (no re-pin). **Remaining:** restart staging → on-device verify pass →
-Telegram regression + `code-review` → PR to main. **Deferred:** C5 → B2; real `file`-kind ingestion
-(PDF/video) → **#51**, shipped; see [../archive/MEDIA_INGESTION_PLAN.md](../archive/MEDIA_INGESTION_PLAN.md)
-(interim: an honest "can't read yet" note, never a silent drop). Stages A + B
-merged (#47, #49).
+**Status (2026-07-31):** Stage C merged to main (PR #52) — C1–C4, C6, `/help` fix, and the neutral
+media-kind resolution follow-up all landed. Real `file`-kind ingestion (PDF/video, #51) also shipped
+separately; see [../archive/MEDIA_INGESTION_PLAN.md](../archive/MEDIA_INGESTION_PLAN.md). Stages A + B
+merged (#47, #49). **C5/B2 — `AppConfirmationUI`** now implemented: the hub shipped the missing wire
+piece (`contract_version` `3b3a48f330f09a39` → **`f605f1ced7bdb356`** — new `POST /v1/actions`, the
+`{kind, summary, state, payload}` block envelope, and a state-only `PATCH`), so the app channel now has
+its own real confirm/cancel flow instead of falling back to Telegram. Implementation details in the
+**C5/B2** entry below and in `docs/architecture/GATEWAY.md`'s Plane 3 section (`ConfirmationUI`'s
+`edit_outcome` was replaced with a single `apply_outcome(callback_id, outcome, outcome_text)` —
+an earlier two-method split was reviewed and collapsed after landing). **Remaining:** restart staging
+→ on-device confirm/cancel verify pass (see *Verification* under C5/B2) → Telegram regression +
+`code-review` → commit → PR.
 **Single source of truth.** Absorbs and replaces the former `APP_CHANNEL_PLAN.md` (index),
 `02_MULTI_CHANNEL_SUPPORT.md`, and `03_APP_CHANNEL.md` (now in `archive/`). The only other live
 material is the app author's pinned handover under `jarvis-app/` — **imported verbatim, not ours
@@ -67,8 +69,24 @@ stay in Stage D (still no phone renderer).
 - [x] C4 review follow-ups (commit `bee778c`): reject malformed `att_` ids before a filesystem path + basename guard; `media_cache.save` inside the per-attachment try; retrieval note instead of an empty turn when every download fails
 - [x] §4 — image upload metadata (commit `0783aeb`): `upload_attachment` sends optional `width`/`height`/`blur_preview`; the channel computes them for images via Pillow (`Pillow==12.3.0` added, import guarded). App reserves aspect ratio (no reflow) + shows a blur-up placeholder. `duration_ms` omitted (no outbound-audio producer). *Verified* the hub stored `w/h/blur_preview`
 - [x] `file`-kind honest fallback (commit `23c347d`): the agent surfaces any unreadable kind as text rather than silently dropping it; real PDF/video ingestion tracked in **#51**, planned in [../archive/MEDIA_INGESTION_PLAN.md](../archive/MEDIA_INGESTION_PLAN.md)
-- [ ] C5 — **DEFERRED → B2** (decided 2026-07-24). An interim `UnsupportedConfirmation` is throwaway: the real `AppConfirmationUI` (upstream B2) replaces it, and its registration seam already exists. Interim behavior is **safe** — app-origin destructive tools fall back to the default channel's (Telegram) confirmation; nothing fires silently. Build the real UI when the app ships confirmation; don't build the placeholder.
-- [ ] **Restart staging** + Telegram regression + `code-review` skill, then PR `feat/stage-c-app-channel` → main
+- [x] C5/B2 — **`AppConfirmationUI` landed (2026-07-31)**, once the hub shipped `POST /v1/actions` +
+  the `{kind, summary, state, payload}` block envelope + a state-only `PATCH` (see the hub-skew note
+  below for the new pin). No throwaway placeholder was built — the deferral held until the app's real
+  confirm/cancel mechanism existed, then this went straight in against it. `send_prompt` posts a
+  `confirmation` block (`payload.callback_id`/`body` = the store's own callback id / description);
+  resolution flows back via an `ActionUpdate` (`type: "action"`) on the same long-poll, dispatched by
+  the router to `AppConfirmationUI.handle_action` (a `block_kind` switch — only `"confirmation"` is
+  handled; `buttons`/`card`/`form` still fall through to Stage D, no consumer yet). Outcome delivery
+  goes through `ConfirmationUI.apply_outcome(callback_id, outcome, outcome_text)` — one method
+  carrying both a structured `ConfirmationOutcome` and rendered prose; `AppConfirmationUI` reads only
+  `outcome` (PATCHes the hub's wire state, since there's no free-text edit) and `TelegramConfirmationUI`
+  reads only `outcome_text` (unchanged edit-message-text behavior). An initial split into two
+  independently-overridable methods (`edit_outcome` + an additive `sync_outcome_state`) was reviewed
+  post-implementation and collapsed into this single method — the split made the mandatory method
+  sometimes vestigial and the load-bearing one easy for a future channel author to forget entirely.
+  *Pending:* staging restart + on-device confirm/cancel/expiry verify.
+- [ ] **Restart staging** + on-device confirm/cancel/expiry verify (C5/B2) + Telegram regression +
+  `code-review` skill, then commit + PR to main
 
 > **Hub-skew note — RESOLVED (2026-07-29):** the hub now serves `contract_version =
 > 3b3a48f330f09a39`, the pinned version (`GET /v1/health`), so the warn-on-mismatch no longer fires
@@ -76,12 +94,21 @@ stay in Stage D (still no phone renderer).
 > contract has not advanced past the pin (verified against its CI drift test) — **no re-pin needed.**
 > One low-impact upstream note it surfaced, now closed: our upload omitted the optional
 > `width/height/blur_preview` metadata → landed as §4.
+>
+> **Contract bump — `f605f1ced7bdb356` (2026-07-31):** re-pulled the hub's live `docs/CONTRACT.md`
+> and route source (`gh api repos/roiguri/jarvis-app/...`) for the C5/B2 work. Every block gained a
+> common `{kind, summary, state, payload}` envelope (`summary` is a required plain-text fallback);
+> `ConfirmationPayload` now carries `body`/`title` (the question lives in the block, not just message
+> `text`); `PATCH` shrank to `{"state": ...}` only, hub-enforced terminal (idempotent same-value,
+> 422 `already_resolved` on a different one); and a new `POST /v1/actions` + `ActionUpdate` (`type:
+> "action"`) is the phone-tap round trip this whole feature depends on. `contract.md` re-synced
+> verbatim; `PINNED_CONTRACT_VERSION` bumped in `client.py`.
 
 **Stage D — rich rendering / blocks** (design deliberately OPEN — decide when a consumer exists)
 - [ ] Design the outbound seam against the real app renderer (`OutboundReply` is *one candidate*, not committed)
 - [ ] 4b — sibling-thread chat injection (needs a second live user thread)
 - [ ] 4c — durable cross-channel context (open question — not app-specific)
-- [ ] Upstream deferrals: B2 app `AppConfirmationUI` — the app's real confirm/cancel UI (this is the successor to the deferred C5; until it lands, app-origin confirmations fall back to Telegram — safe) · B5 chips · B6 apps
+- [ ] Upstream deferrals: B5 streaming chips · B6 apps. (B2 `AppConfirmationUI` — the successor to the deferred C5 — landed 2026-07-31; see the Stage C checklist above.)
 
 ---
 
@@ -289,13 +316,16 @@ replaces it the moment the app can render a confirm/cancel widget, and the per-c
 seam it would plug into (`register_confirmation` / `_confirmation_stores` in the factory) already
 exists. So we skip the placeholder and build the real UI when the app ships confirmation.
 
-**Interim behavior (safe, documented).** Until B2, no confirmation store is registered for the app,
-so `get_confirmation()` on an app-origin turn falls back to the **default channel's store
-(Telegram)**: a destructive tool triggered from the app renders its confirm/cancel prompt on
-Telegram, and the action fires **only** if the owner taps Confirm there — nothing destructive
-happens silently. It is a cross-device wrinkle (a dead-end if the owner isn't on Telegram), not a
-hazard. The general principle still stands and is realized by B2: a channel that can't render a rich
-interaction has the gap surfaced to the agent, which phrases the human explanation.
+**Interim behavior (safe, documented) — superseded 2026-07-31.** Until B2, no confirmation store was
+registered for the app, so `get_confirmation()` on an app-origin turn fell back to the **default
+channel's store (Telegram)**: a destructive tool triggered from the app rendered its confirm/cancel
+prompt on Telegram, and the action fired **only** if the owner tapped Confirm there — nothing
+destructive happened silently. It was a cross-device wrinkle (a dead-end if the owner wasn't on
+Telegram), not a hazard. **B2 landed 2026-07-31** once the hub shipped `POST /v1/actions` + the new
+block envelope — see the C5/B2 checklist entry above and `docs/architecture/GATEWAY.md`'s Plane 3
+section for `AppConfirmationUI`'s shape. The Telegram-fallback path still exists structurally
+(`get_confirmation()`'s default-channel fallback is unconditional, for any origin-less thread), but
+app-origin turns now resolve their own store and never reach it.
 
 **Owner prereq (done).** `APP_HUB_URL`, `APP_HUB_BOT_TOKEN`, `APP_OWNER_USER_ID` are in staging's
 `secrets/.env` with a **staging-specific hub bot token** — the hub is one-bot-one-user, so a
@@ -350,10 +380,11 @@ now" gate:
   sibling chat; beyond that, continuity depends on the daily log or a memory write. Not
   app-specific — the same time-bound governs heartbeat↔user today — so treat it on its own terms,
   alongside `../CONTEXT_HANDLING_PLAN.md` (a wider window costs tokens).
-- **Upstream honest-boundary deferrals:** B2 app `AppConfirmationUI` (the confirm/cancel UI; the
-  successor to the deferred C5), B5 streaming chips, B6 apps. Each is real and specified in
-  `jarvis-app/original_app_plan.md`; none is end-to-end testable today. (B1.6 media inbound
-  graduated to **Stage C4** — the phone sends attachments now.)
+- **Upstream honest-boundary deferrals:** B5 streaming chips, B6 apps. Each is real and specified in
+  `jarvis-app/original_app_plan.md`; neither is end-to-end testable today. (B1.6 media inbound
+  graduated to **Stage C4** — the phone sends attachments now. B2 `AppConfirmationUI` — the
+  confirm/cancel UI, successor to the deferred C5 — graduated out of Stage D and landed 2026-07-31;
+  see the Stage C checklist.)
 
 *Verify:* per slice, when each acquires its consumer.
 
@@ -418,7 +449,7 @@ channels. **Deferred cleanups** (tracked, not blocking): loop-bridge misfiled in
 
 | File | What it is |
 |---|---|
-| `contract.md` | The wire contract, **generated from the hub's Pydantic models** — the single source of truth for payload *shape*. Pinned at `contract_version = 3b3a48f330f09a39` (bumped 2026-07-24, adds the attachments model), which the live hub reports on `GET /v1/health`. B0 records the pin; `HubClient` warns (not hard-fail) on mismatch |
+| `contract.md` | The wire contract, **generated from the hub's Pydantic models** — the single source of truth for payload *shape*. Pinned at `contract_version = f605f1ced7bdb356` (bumped 2026-07-31 for the C5/B2 action/block-envelope rework; previously `3b3a48f330f09a39`, bumped 2026-07-24 for the attachments model), which the live hub reports on `GET /v1/health`. B0 records the pin; `HubClient` warns (not hard-fail) on mismatch |
 | `fake_agent.py` | A fake **agent** (not a fake hub) — it long-polls a *running* hub. Its value is as the reference poll loop B1 must write (`:366-417`) |
 | `original_app_plan.md` | The approved Track B plan (2026-07-12), phases B0–B6. Upstream's *capability* sequencing |
 

--- a/docs/plans/app-plans/jarvis-app/contract.md
+++ b/docs/plans/app-plans/jarvis-app/contract.md
@@ -6,7 +6,7 @@
 JSON Schema plus the endpoint list, generated from the Pydantic models and
 the mounted routes under `backend/jarvis_app_backend`.
 
-`contract_version`: `3b3a48f330f09a39`
+`contract_version`: `f605f1ced7bdb356`
 
 ## Endpoints
 
@@ -22,12 +22,90 @@ the mounted routes under `backend/jarvis_app_backend`.
 - `POST /bot/v1/commands` — Declare Commands
 - `POST /bot/v1/events` — Bot Event
 - `POST /bot/v1/messages` — Bot Send
+- `POST /v1/actions` — Post Action
 - `POST /v1/attachments` — Upload Attachment
 - `POST /v1/auth/login` — Login
 - `POST /v1/auth/logout` — Logout
 - `POST /v1/messages` — Send Message
 
 ## Models
+
+### ActionRequest
+
+```json
+{
+  "additionalProperties": false,
+  "description": "`POST /v1/actions`'s body \u2014 a tap on a live block. `action_id` names\none of the block's declared affordances, or, for `confirmation` (which\ndeclares none of its own \u2014 it has exactly two outcomes), the reserved\n`\"confirm\"`/`\"cancel\"` (architecture \u00a75). No `values` field here: it\nexists for submitted form data, and nothing reads it until a `form`\nrenderer exists.",
+  "properties": {
+    "action_id": {
+      "title": "Action Id",
+      "type": "string"
+    },
+    "message_id": {
+      "title": "Message Id",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "message_id",
+    "action_id"
+  ],
+  "title": "ActionRequest",
+  "type": "object"
+}
+```
+
+### ActionUpdate
+
+```json
+{
+  "description": "A tap the hub already validated against the block it names. `callback_id`\nis `None` when the block that was tapped carries none of its own.",
+  "properties": {
+    "action_id": {
+      "title": "Action Id",
+      "type": "string"
+    },
+    "block_kind": {
+      "title": "Block Kind",
+      "type": "string"
+    },
+    "callback_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Callback Id"
+    },
+    "message_id": {
+      "title": "Message Id",
+      "type": "integer"
+    },
+    "type": {
+      "const": "action",
+      "title": "Type",
+      "type": "string"
+    },
+    "update_id": {
+      "title": "Update Id",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "update_id",
+    "type",
+    "message_id",
+    "action_id",
+    "block_kind"
+  ],
+  "title": "ActionUpdate",
+  "type": "object"
+}
+```
 
 ### ApiError
 
@@ -254,271 +332,16 @@ the mounted routes under `backend/jarvis_app_backend`.
 
 ```json
 {
-  "$defs": {
-    "Action": {
-      "additionalProperties": false,
-      "description": "A tappable option: `card.actions` and `buttons.options` both use this\nshape, so a card's own buttons and a bare `buttons` block behave the same\nway once tapped.",
-      "properties": {
-        "action_id": {
-          "title": "Action Id",
-          "type": "string"
-        },
-        "label": {
-          "title": "Label",
-          "type": "string"
-        }
-      },
-      "required": [
-        "action_id",
-        "label"
-      ],
-      "title": "Action",
-      "type": "object"
-    },
-    "ButtonsBlock": {
-      "additionalProperties": false,
-      "description": "No prose field exists here \u2014 see the module docstring. `options`\nabsorbs what a separate `choice` kind would otherwise do; `state` is the\nselected `action_id` once resolved, or `None` while the block is still\nlive.",
-      "properties": {
-        "kind": {
-          "const": "buttons",
-          "default": "buttons",
-          "title": "Kind",
-          "type": "string"
-        },
-        "options": {
-          "items": {
-            "$ref": "#/$defs/Action"
-          },
-          "title": "Options",
-          "type": "array"
-        },
-        "state": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "State"
-        }
-      },
-      "required": [
-        "options"
-      ],
-      "title": "ButtonsBlock",
-      "type": "object"
-    },
-    "CardBlock": {
-      "additionalProperties": false,
-      "properties": {
-        "actions": {
-          "items": {
-            "$ref": "#/$defs/Action"
-          },
-          "title": "Actions",
-          "type": "array"
-        },
-        "body": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Body"
-        },
-        "image": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Image"
-        },
-        "kind": {
-          "const": "card",
-          "default": "card",
-          "title": "Kind",
-          "type": "string"
-        },
-        "subtitle": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Subtitle"
-        },
-        "title": {
-          "title": "Title",
-          "type": "string"
-        }
-      },
-      "required": [
-        "title"
-      ],
-      "title": "CardBlock",
-      "type": "object"
-    },
-    "ConfirmationBlock": {
-      "additionalProperties": false,
-      "description": "No prose field exists here either \u2014 the question this block asks\nlives in the message's own `text`, never in the block.",
-      "properties": {
-        "callback_id": {
-          "title": "Callback Id",
-          "type": "string"
-        },
-        "cancel_label": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Cancel Label"
-        },
-        "confirm_label": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Confirm Label"
-        },
-        "kind": {
-          "const": "confirmation",
-          "default": "confirmation",
-          "title": "Kind",
-          "type": "string"
-        },
-        "state": {
-          "anyOf": [
-            {
-              "enum": [
-                "confirmed",
-                "cancelled",
-                "expired"
-              ],
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "State"
-        }
-      },
-      "required": [
-        "callback_id"
-      ],
-      "title": "ConfirmationBlock",
-      "type": "object"
-    },
-    "FormBlock": {
-      "additionalProperties": false,
-      "properties": {
-        "fields": {
-          "items": {
-            "$ref": "#/$defs/FormField"
-          },
-          "title": "Fields",
-          "type": "array"
-        },
-        "kind": {
-          "const": "form",
-          "default": "form",
-          "title": "Kind",
-          "type": "string"
-        },
-        "submit_label": {
-          "default": "Submit",
-          "title": "Submit Label",
-          "type": "string"
-        }
-      },
-      "required": [
-        "fields"
-      ],
-      "title": "FormBlock",
-      "type": "object"
-    },
-    "FormField": {
-      "additionalProperties": false,
-      "properties": {
-        "field_id": {
-          "title": "Field Id",
-          "type": "string"
-        },
-        "label": {
-          "title": "Label",
-          "type": "string"
-        }
-      },
-      "required": [
-        "field_id",
-        "label"
-      ],
-      "title": "FormField",
-      "type": "object"
-    }
-  },
   "additionalProperties": false,
-  "description": "Replaces a message's blocks \u2014 how the agent resolves a live one (a\n`confirmation` to `confirmed`/`cancelled`/`expired`, a `buttons` `state`).\nBlocks are validated strict, same as a send.",
+  "description": "Resolves a message's one block by setting its `state` alone \u2014 how the\nagent answers a `confirmation` (`confirmed`/`cancelled`/`expired`) or\nnames a `buttons` selection. The body carries no block: `message_id` in\nthe URL plus \"at most one interactive block per message\" (architecture\n\u00a75) is already an unambiguous address, and there is no content for the\nagent to send even if it wanted to \u2014 an action update carries none, and\nthe Bot API has no read.\n\nThis model cannot enforce the terminal-state rule itself \u2014 it has no way\nto see what is already stored, only what was sent. That guard, and the\nper-kind check on `state`'s own vocabulary, both live in\n`messages.db.update_message_blocks`, the only place that holds the\nstored block to check against: once a stored block's `state` is\nnon-null, a PATCH may change it only to the same value again.",
   "properties": {
-    "blocks": {
-      "items": {
-        "discriminator": {
-          "mapping": {
-            "buttons": "#/$defs/ButtonsBlock",
-            "card": "#/$defs/CardBlock",
-            "confirmation": "#/$defs/ConfirmationBlock",
-            "form": "#/$defs/FormBlock"
-          },
-          "propertyName": "kind"
-        },
-        "oneOf": [
-          {
-            "$ref": "#/$defs/CardBlock"
-          },
-          {
-            "$ref": "#/$defs/FormBlock"
-          },
-          {
-            "$ref": "#/$defs/ButtonsBlock"
-          },
-          {
-            "$ref": "#/$defs/ConfirmationBlock"
-          }
-        ]
-      },
-      "title": "Blocks",
-      "type": "array"
+    "state": {
+      "title": "State",
+      "type": "string"
     }
   },
   "required": [
-    "blocks"
+    "state"
   ],
   "title": "BotPatchRequest",
   "type": "object"
@@ -571,7 +394,7 @@ the mounted routes under `backend/jarvis_app_backend`.
     },
     "ButtonsBlock": {
       "additionalProperties": false,
-      "description": "No prose field exists here \u2014 see the module docstring. `options`\nabsorbs what a separate `choice` kind would otherwise do; `state` is the\nselected `action_id` once resolved, or `None` while the block is still\nlive.",
+      "description": "`state` is the selected `action_id` once resolved \u2014 an open string\nrather than an enum, because the values are whatever the author of this\nblock's `options` chose.",
       "properties": {
         "kind": {
           "const": "buttons",
@@ -579,12 +402,8 @@ the mounted routes under `backend/jarvis_app_backend`.
           "title": "Kind",
           "type": "string"
         },
-        "options": {
-          "items": {
-            "$ref": "#/$defs/Action"
-          },
-          "title": "Options",
-          "type": "array"
+        "payload": {
+          "$ref": "#/$defs/ButtonsPayload"
         },
         "state": {
           "anyOf": [
@@ -597,15 +416,74 @@ the mounted routes under `backend/jarvis_app_backend`.
           ],
           "default": null,
           "title": "State"
+        },
+        "summary": {
+          "title": "Summary",
+          "type": "string"
+        }
+      },
+      "required": [
+        "summary",
+        "payload"
+      ],
+      "title": "ButtonsBlock",
+      "type": "object"
+    },
+    "ButtonsPayload": {
+      "additionalProperties": false,
+      "description": "No prose field exists here \u2014 see the module docstring. `options`\nabsorbs what a separate `choice` kind would otherwise do.",
+      "properties": {
+        "options": {
+          "items": {
+            "$ref": "#/$defs/Action"
+          },
+          "title": "Options",
+          "type": "array"
         }
       },
       "required": [
         "options"
       ],
-      "title": "ButtonsBlock",
+      "title": "ButtonsPayload",
       "type": "object"
     },
     "CardBlock": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "const": "card",
+          "default": "card",
+          "title": "Kind",
+          "type": "string"
+        },
+        "payload": {
+          "$ref": "#/$defs/CardPayload"
+        },
+        "state": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "State"
+        },
+        "summary": {
+          "title": "Summary",
+          "type": "string"
+        }
+      },
+      "required": [
+        "summary",
+        "payload"
+      ],
+      "title": "CardBlock",
+      "type": "object"
+    },
+    "CardPayload": {
       "additionalProperties": false,
       "properties": {
         "actions": {
@@ -627,24 +505,6 @@ the mounted routes under `backend/jarvis_app_backend`.
           "default": null,
           "title": "Body"
         },
-        "image": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Image"
-        },
-        "kind": {
-          "const": "card",
-          "default": "card",
-          "title": "Kind",
-          "type": "string"
-        },
         "subtitle": {
           "anyOf": [
             {
@@ -665,13 +525,58 @@ the mounted routes under `backend/jarvis_app_backend`.
       "required": [
         "title"
       ],
-      "title": "CardBlock",
+      "title": "CardPayload",
       "type": "object"
     },
     "ConfirmationBlock": {
       "additionalProperties": false,
-      "description": "No prose field exists here either \u2014 the question this block asks\nlives in the message's own `text`, never in the block.",
       "properties": {
+        "kind": {
+          "const": "confirmation",
+          "default": "confirmation",
+          "title": "Kind",
+          "type": "string"
+        },
+        "payload": {
+          "$ref": "#/$defs/ConfirmationPayload"
+        },
+        "state": {
+          "anyOf": [
+            {
+              "enum": [
+                "confirmed",
+                "cancelled",
+                "expired"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "State"
+        },
+        "summary": {
+          "title": "Summary",
+          "type": "string"
+        }
+      },
+      "required": [
+        "summary",
+        "payload"
+      ],
+      "title": "ConfirmationBlock",
+      "type": "object"
+    },
+    "ConfirmationPayload": {
+      "additionalProperties": false,
+      "description": "`body` carries the question this block asks \u2014 required, since nothing\nelse on the block carries it. `title` is optional and renders no row at\nall when absent; it exists for the rarer confirmation whose question\nneeds a heading above detail. The two labels are what vary the button\nwording between one confirmation and another.",
+      "properties": {
+        "body": {
+          "title": "Body",
+          "type": "string"
+        },
         "callback_id": {
           "title": "Callback Id",
           "type": "string"
@@ -700,20 +605,41 @@ the mounted routes under `backend/jarvis_app_backend`.
           "default": null,
           "title": "Confirm Label"
         },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Title"
+        }
+      },
+      "required": [
+        "callback_id",
+        "body"
+      ],
+      "title": "ConfirmationPayload",
+      "type": "object"
+    },
+    "FormBlock": {
+      "additionalProperties": false,
+      "properties": {
         "kind": {
-          "const": "confirmation",
-          "default": "confirmation",
+          "const": "form",
+          "default": "form",
           "title": "Kind",
           "type": "string"
+        },
+        "payload": {
+          "$ref": "#/$defs/FormPayload"
         },
         "state": {
           "anyOf": [
             {
-              "enum": [
-                "confirmed",
-                "cancelled",
-                "expired"
-              ],
               "type": "string"
             },
             {
@@ -722,38 +648,15 @@ the mounted routes under `backend/jarvis_app_backend`.
           ],
           "default": null,
           "title": "State"
-        }
-      },
-      "required": [
-        "callback_id"
-      ],
-      "title": "ConfirmationBlock",
-      "type": "object"
-    },
-    "FormBlock": {
-      "additionalProperties": false,
-      "properties": {
-        "fields": {
-          "items": {
-            "$ref": "#/$defs/FormField"
-          },
-          "title": "Fields",
-          "type": "array"
         },
-        "kind": {
-          "const": "form",
-          "default": "form",
-          "title": "Kind",
-          "type": "string"
-        },
-        "submit_label": {
-          "default": "Submit",
-          "title": "Submit Label",
+        "summary": {
+          "title": "Summary",
           "type": "string"
         }
       },
       "required": [
-        "fields"
+        "summary",
+        "payload"
       ],
       "title": "FormBlock",
       "type": "object"
@@ -775,6 +678,29 @@ the mounted routes under `backend/jarvis_app_backend`.
         "label"
       ],
       "title": "FormField",
+      "type": "object"
+    },
+    "FormPayload": {
+      "additionalProperties": false,
+      "description": "`fields` carries a label and an id and nothing else \u2014 there is no field\n*type*, no required flag, no default. That is the whole taxonomy, and it\nstays this small until a renderer forces the question: a type nothing can\ndraw is a promise the system cannot keep.",
+      "properties": {
+        "fields": {
+          "items": {
+            "$ref": "#/$defs/FormField"
+          },
+          "title": "Fields",
+          "type": "array"
+        },
+        "submit_label": {
+          "default": "Submit",
+          "title": "Submit Label",
+          "type": "string"
+        }
+      },
+      "required": [
+        "fields"
+      ],
+      "title": "FormPayload",
       "type": "object"
     }
   },
@@ -846,512 +772,6 @@ the mounted routes under `backend/jarvis_app_backend`.
 }
 ```
 
-### BotUpdate
-
-```json
-{
-  "$defs": {
-    "Action": {
-      "additionalProperties": false,
-      "description": "A tappable option: `card.actions` and `buttons.options` both use this\nshape, so a card's own buttons and a bare `buttons` block behave the same\nway once tapped.",
-      "properties": {
-        "action_id": {
-          "title": "Action Id",
-          "type": "string"
-        },
-        "label": {
-          "title": "Label",
-          "type": "string"
-        }
-      },
-      "required": [
-        "action_id",
-        "label"
-      ],
-      "title": "Action",
-      "type": "object"
-    },
-    "Attachment": {
-      "additionalProperties": false,
-      "description": "One uploaded blob, as it rides `attachments[]` on a `Message` or the\nresponse of `POST /v1/attachments`.",
-      "properties": {
-        "blur_preview": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Blur Preview"
-        },
-        "duration_ms": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Duration Ms"
-        },
-        "filename": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Filename"
-        },
-        "height": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Height"
-        },
-        "id": {
-          "pattern": "^att_[0-9A-HJKMNP-TV-Z]{26}$",
-          "title": "Id",
-          "type": "string"
-        },
-        "kind": {
-          "enum": [
-            "image",
-            "audio",
-            "file"
-          ],
-          "title": "Kind",
-          "type": "string"
-        },
-        "mime_type": {
-          "title": "Mime Type",
-          "type": "string"
-        },
-        "size": {
-          "title": "Size",
-          "type": "integer"
-        },
-        "width": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Width"
-        }
-      },
-      "required": [
-        "id",
-        "kind",
-        "mime_type",
-        "size"
-      ],
-      "title": "Attachment",
-      "type": "object"
-    },
-    "ButtonsBlock": {
-      "additionalProperties": false,
-      "description": "No prose field exists here \u2014 see the module docstring. `options`\nabsorbs what a separate `choice` kind would otherwise do; `state` is the\nselected `action_id` once resolved, or `None` while the block is still\nlive.",
-      "properties": {
-        "kind": {
-          "const": "buttons",
-          "default": "buttons",
-          "title": "Kind",
-          "type": "string"
-        },
-        "options": {
-          "items": {
-            "$ref": "#/$defs/Action"
-          },
-          "title": "Options",
-          "type": "array"
-        },
-        "state": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "State"
-        }
-      },
-      "required": [
-        "options"
-      ],
-      "title": "ButtonsBlock",
-      "type": "object"
-    },
-    "CardBlock": {
-      "additionalProperties": false,
-      "properties": {
-        "actions": {
-          "items": {
-            "$ref": "#/$defs/Action"
-          },
-          "title": "Actions",
-          "type": "array"
-        },
-        "body": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Body"
-        },
-        "image": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Image"
-        },
-        "kind": {
-          "const": "card",
-          "default": "card",
-          "title": "Kind",
-          "type": "string"
-        },
-        "subtitle": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Subtitle"
-        },
-        "title": {
-          "title": "Title",
-          "type": "string"
-        }
-      },
-      "required": [
-        "title"
-      ],
-      "title": "CardBlock",
-      "type": "object"
-    },
-    "ConfirmationBlock": {
-      "additionalProperties": false,
-      "description": "No prose field exists here either \u2014 the question this block asks\nlives in the message's own `text`, never in the block.",
-      "properties": {
-        "callback_id": {
-          "title": "Callback Id",
-          "type": "string"
-        },
-        "cancel_label": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Cancel Label"
-        },
-        "confirm_label": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Confirm Label"
-        },
-        "kind": {
-          "const": "confirmation",
-          "default": "confirmation",
-          "title": "Kind",
-          "type": "string"
-        },
-        "state": {
-          "anyOf": [
-            {
-              "enum": [
-                "confirmed",
-                "cancelled",
-                "expired"
-              ],
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "State"
-        }
-      },
-      "required": [
-        "callback_id"
-      ],
-      "title": "ConfirmationBlock",
-      "type": "object"
-    },
-    "FormBlock": {
-      "additionalProperties": false,
-      "properties": {
-        "fields": {
-          "items": {
-            "$ref": "#/$defs/FormField"
-          },
-          "title": "Fields",
-          "type": "array"
-        },
-        "kind": {
-          "const": "form",
-          "default": "form",
-          "title": "Kind",
-          "type": "string"
-        },
-        "submit_label": {
-          "default": "Submit",
-          "title": "Submit Label",
-          "type": "string"
-        }
-      },
-      "required": [
-        "fields"
-      ],
-      "title": "FormBlock",
-      "type": "object"
-    },
-    "FormField": {
-      "additionalProperties": false,
-      "properties": {
-        "field_id": {
-          "title": "Field Id",
-          "type": "string"
-        },
-        "label": {
-          "title": "Label",
-          "type": "string"
-        }
-      },
-      "required": [
-        "field_id",
-        "label"
-      ],
-      "title": "FormField",
-      "type": "object"
-    },
-    "Message": {
-      "description": "The persistent unit; `id` is the sync cursor (architecture \u00a75).",
-      "properties": {
-        "attachments": {
-          "items": {
-            "$ref": "#/$defs/Attachment"
-          },
-          "title": "Attachments",
-          "type": "array"
-        },
-        "blocks": {
-          "anyOf": [
-            {
-              "items": {
-                "discriminator": {
-                  "mapping": {
-                    "buttons": "#/$defs/ButtonsBlock",
-                    "card": "#/$defs/CardBlock",
-                    "confirmation": "#/$defs/ConfirmationBlock",
-                    "form": "#/$defs/FormBlock"
-                  },
-                  "propertyName": "kind"
-                },
-                "oneOf": [
-                  {
-                    "$ref": "#/$defs/CardBlock"
-                  },
-                  {
-                    "$ref": "#/$defs/FormBlock"
-                  },
-                  {
-                    "$ref": "#/$defs/ButtonsBlock"
-                  },
-                  {
-                    "$ref": "#/$defs/ConfirmationBlock"
-                  }
-                ]
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "title": "Blocks"
-        },
-        "client_msg_id": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "title": "Client Msg Id"
-        },
-        "client_ts": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "title": "Client Ts"
-        },
-        "created_at": {
-          "title": "Created At",
-          "type": "string"
-        },
-        "delivered_at": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "title": "Delivered At"
-        },
-        "id": {
-          "title": "Id",
-          "type": "integer"
-        },
-        "meta": {
-          "$ref": "#/$defs/MessageMeta"
-        },
-        "role": {
-          "enum": [
-            "user",
-            "assistant"
-          ],
-          "title": "Role",
-          "type": "string"
-        },
-        "text": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "title": "Text"
-        },
-        "updated_at": {
-          "title": "Updated At",
-          "type": "string"
-        }
-      },
-      "required": [
-        "id",
-        "client_msg_id",
-        "role",
-        "text",
-        "blocks",
-        "attachments",
-        "meta",
-        "client_ts",
-        "delivered_at",
-        "created_at",
-        "updated_at"
-      ],
-      "title": "Message",
-      "type": "object"
-    },
-    "MessageMeta": {
-      "additionalProperties": false,
-      "description": "`source` is informational only \u2014 the client must not branch on it\n(architecture \u00a74: `heartbeat`/`reminder`/`notifier` are this agent's\nconcepts, not universal ones).",
-      "properties": {
-        "source": {
-          "enum": [
-            "user",
-            "agent",
-            "heartbeat",
-            "reminder",
-            "notifier"
-          ],
-          "title": "Source",
-          "type": "string"
-        }
-      },
-      "required": [
-        "source"
-      ],
-      "title": "MessageMeta",
-      "type": "object"
-    }
-  },
-  "properties": {
-    "message": {
-      "$ref": "#/$defs/Message"
-    },
-    "type": {
-      "const": "message",
-      "title": "Type",
-      "type": "string"
-    },
-    "update_id": {
-      "title": "Update Id",
-      "type": "integer"
-    }
-  },
-  "required": [
-    "update_id",
-    "type",
-    "message"
-  ],
-  "title": "BotUpdate",
-  "type": "object"
-}
-```
-
 ### ButtonsBlock
 
 ```json
@@ -1376,10 +796,28 @@ the mounted routes under `backend/jarvis_app_backend`.
       ],
       "title": "Action",
       "type": "object"
+    },
+    "ButtonsPayload": {
+      "additionalProperties": false,
+      "description": "No prose field exists here \u2014 see the module docstring. `options`\nabsorbs what a separate `choice` kind would otherwise do.",
+      "properties": {
+        "options": {
+          "items": {
+            "$ref": "#/$defs/Action"
+          },
+          "title": "Options",
+          "type": "array"
+        }
+      },
+      "required": [
+        "options"
+      ],
+      "title": "ButtonsPayload",
+      "type": "object"
     }
   },
   "additionalProperties": false,
-  "description": "No prose field exists here \u2014 see the module docstring. `options`\nabsorbs what a separate `choice` kind would otherwise do; `state` is the\nselected `action_id` once resolved, or `None` while the block is still\nlive.",
+  "description": "`state` is the selected `action_id` once resolved \u2014 an open string\nrather than an enum, because the values are whatever the author of this\nblock's `options` chose.",
   "properties": {
     "kind": {
       "const": "buttons",
@@ -1387,12 +825,8 @@ the mounted routes under `backend/jarvis_app_backend`.
       "title": "Kind",
       "type": "string"
     },
-    "options": {
-      "items": {
-        "$ref": "#/$defs/Action"
-      },
-      "title": "Options",
-      "type": "array"
+    "payload": {
+      "$ref": "#/$defs/ButtonsPayload"
     },
     "state": {
       "anyOf": [
@@ -1405,10 +839,15 @@ the mounted routes under `backend/jarvis_app_backend`.
       ],
       "default": null,
       "title": "State"
+    },
+    "summary": {
+      "title": "Summary",
+      "type": "string"
     }
   },
   "required": [
-    "options"
+    "summary",
+    "payload"
   ],
   "title": "ButtonsBlock",
   "type": "object"
@@ -1439,48 +878,65 @@ the mounted routes under `backend/jarvis_app_backend`.
       ],
       "title": "Action",
       "type": "object"
+    },
+    "CardPayload": {
+      "additionalProperties": false,
+      "properties": {
+        "actions": {
+          "items": {
+            "$ref": "#/$defs/Action"
+          },
+          "title": "Actions",
+          "type": "array"
+        },
+        "body": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Body"
+        },
+        "subtitle": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Subtitle"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        }
+      },
+      "required": [
+        "title"
+      ],
+      "title": "CardPayload",
+      "type": "object"
     }
   },
   "additionalProperties": false,
   "properties": {
-    "actions": {
-      "items": {
-        "$ref": "#/$defs/Action"
-      },
-      "title": "Actions",
-      "type": "array"
-    },
-    "body": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "title": "Body"
-    },
-    "image": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "title": "Image"
-    },
     "kind": {
       "const": "card",
       "default": "card",
       "title": "Kind",
       "type": "string"
     },
-    "subtitle": {
+    "payload": {
+      "$ref": "#/$defs/CardPayload"
+    },
+    "state": {
       "anyOf": [
         {
           "type": "string"
@@ -1490,15 +946,16 @@ the mounted routes under `backend/jarvis_app_backend`.
         }
       ],
       "default": null,
-      "title": "Subtitle"
+      "title": "State"
     },
-    "title": {
-      "title": "Title",
+    "summary": {
+      "title": "Summary",
       "type": "string"
     }
   },
   "required": [
-    "title"
+    "summary",
+    "payload"
   ],
   "title": "CardBlock",
   "type": "object"
@@ -1533,42 +990,74 @@ the mounted routes under `backend/jarvis_app_backend`.
 
 ```json
 {
+  "$defs": {
+    "ConfirmationPayload": {
+      "additionalProperties": false,
+      "description": "`body` carries the question this block asks \u2014 required, since nothing\nelse on the block carries it. `title` is optional and renders no row at\nall when absent; it exists for the rarer confirmation whose question\nneeds a heading above detail. The two labels are what vary the button\nwording between one confirmation and another.",
+      "properties": {
+        "body": {
+          "title": "Body",
+          "type": "string"
+        },
+        "callback_id": {
+          "title": "Callback Id",
+          "type": "string"
+        },
+        "cancel_label": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Cancel Label"
+        },
+        "confirm_label": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Confirm Label"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Title"
+        }
+      },
+      "required": [
+        "callback_id",
+        "body"
+      ],
+      "title": "ConfirmationPayload",
+      "type": "object"
+    }
+  },
   "additionalProperties": false,
-  "description": "No prose field exists here either \u2014 the question this block asks\nlives in the message's own `text`, never in the block.",
   "properties": {
-    "callback_id": {
-      "title": "Callback Id",
-      "type": "string"
-    },
-    "cancel_label": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "title": "Cancel Label"
-    },
-    "confirm_label": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "title": "Confirm Label"
-    },
     "kind": {
       "const": "confirmation",
       "default": "confirmation",
       "title": "Kind",
       "type": "string"
+    },
+    "payload": {
+      "$ref": "#/$defs/ConfirmationPayload"
     },
     "state": {
       "anyOf": [
@@ -1586,10 +1075,15 @@ the mounted routes under `backend/jarvis_app_backend`.
       ],
       "default": null,
       "title": "State"
+    },
+    "summary": {
+      "title": "Summary",
+      "type": "string"
     }
   },
   "required": [
-    "callback_id"
+    "summary",
+    "payload"
   ],
   "title": "ConfirmationBlock",
   "type": "object"
@@ -1619,31 +1113,62 @@ the mounted routes under `backend/jarvis_app_backend`.
       ],
       "title": "FormField",
       "type": "object"
+    },
+    "FormPayload": {
+      "additionalProperties": false,
+      "description": "`fields` carries a label and an id and nothing else \u2014 there is no field\n*type*, no required flag, no default. That is the whole taxonomy, and it\nstays this small until a renderer forces the question: a type nothing can\ndraw is a promise the system cannot keep.",
+      "properties": {
+        "fields": {
+          "items": {
+            "$ref": "#/$defs/FormField"
+          },
+          "title": "Fields",
+          "type": "array"
+        },
+        "submit_label": {
+          "default": "Submit",
+          "title": "Submit Label",
+          "type": "string"
+        }
+      },
+      "required": [
+        "fields"
+      ],
+      "title": "FormPayload",
+      "type": "object"
     }
   },
   "additionalProperties": false,
   "properties": {
-    "fields": {
-      "items": {
-        "$ref": "#/$defs/FormField"
-      },
-      "title": "Fields",
-      "type": "array"
-    },
     "kind": {
       "const": "form",
       "default": "form",
       "title": "Kind",
       "type": "string"
     },
-    "submit_label": {
-      "default": "Submit",
-      "title": "Submit Label",
+    "payload": {
+      "$ref": "#/$defs/FormPayload"
+    },
+    "state": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "State"
+    },
+    "summary": {
+      "title": "Summary",
       "type": "string"
     }
   },
   "required": [
-    "fields"
+    "summary",
+    "payload"
   ],
   "title": "FormBlock",
   "type": "object"
@@ -1874,7 +1399,7 @@ the mounted routes under `backend/jarvis_app_backend`.
     },
     "ButtonsBlock": {
       "additionalProperties": false,
-      "description": "No prose field exists here \u2014 see the module docstring. `options`\nabsorbs what a separate `choice` kind would otherwise do; `state` is the\nselected `action_id` once resolved, or `None` while the block is still\nlive.",
+      "description": "`state` is the selected `action_id` once resolved \u2014 an open string\nrather than an enum, because the values are whatever the author of this\nblock's `options` chose.",
       "properties": {
         "kind": {
           "const": "buttons",
@@ -1882,12 +1407,8 @@ the mounted routes under `backend/jarvis_app_backend`.
           "title": "Kind",
           "type": "string"
         },
-        "options": {
-          "items": {
-            "$ref": "#/$defs/Action"
-          },
-          "title": "Options",
-          "type": "array"
+        "payload": {
+          "$ref": "#/$defs/ButtonsPayload"
         },
         "state": {
           "anyOf": [
@@ -1900,15 +1421,74 @@ the mounted routes under `backend/jarvis_app_backend`.
           ],
           "default": null,
           "title": "State"
+        },
+        "summary": {
+          "title": "Summary",
+          "type": "string"
+        }
+      },
+      "required": [
+        "summary",
+        "payload"
+      ],
+      "title": "ButtonsBlock",
+      "type": "object"
+    },
+    "ButtonsPayload": {
+      "additionalProperties": false,
+      "description": "No prose field exists here \u2014 see the module docstring. `options`\nabsorbs what a separate `choice` kind would otherwise do.",
+      "properties": {
+        "options": {
+          "items": {
+            "$ref": "#/$defs/Action"
+          },
+          "title": "Options",
+          "type": "array"
         }
       },
       "required": [
         "options"
       ],
-      "title": "ButtonsBlock",
+      "title": "ButtonsPayload",
       "type": "object"
     },
     "CardBlock": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "const": "card",
+          "default": "card",
+          "title": "Kind",
+          "type": "string"
+        },
+        "payload": {
+          "$ref": "#/$defs/CardPayload"
+        },
+        "state": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "State"
+        },
+        "summary": {
+          "title": "Summary",
+          "type": "string"
+        }
+      },
+      "required": [
+        "summary",
+        "payload"
+      ],
+      "title": "CardBlock",
+      "type": "object"
+    },
+    "CardPayload": {
       "additionalProperties": false,
       "properties": {
         "actions": {
@@ -1930,24 +1510,6 @@ the mounted routes under `backend/jarvis_app_backend`.
           "default": null,
           "title": "Body"
         },
-        "image": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Image"
-        },
-        "kind": {
-          "const": "card",
-          "default": "card",
-          "title": "Kind",
-          "type": "string"
-        },
         "subtitle": {
           "anyOf": [
             {
@@ -1968,13 +1530,58 @@ the mounted routes under `backend/jarvis_app_backend`.
       "required": [
         "title"
       ],
-      "title": "CardBlock",
+      "title": "CardPayload",
       "type": "object"
     },
     "ConfirmationBlock": {
       "additionalProperties": false,
-      "description": "No prose field exists here either \u2014 the question this block asks\nlives in the message's own `text`, never in the block.",
       "properties": {
+        "kind": {
+          "const": "confirmation",
+          "default": "confirmation",
+          "title": "Kind",
+          "type": "string"
+        },
+        "payload": {
+          "$ref": "#/$defs/ConfirmationPayload"
+        },
+        "state": {
+          "anyOf": [
+            {
+              "enum": [
+                "confirmed",
+                "cancelled",
+                "expired"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "State"
+        },
+        "summary": {
+          "title": "Summary",
+          "type": "string"
+        }
+      },
+      "required": [
+        "summary",
+        "payload"
+      ],
+      "title": "ConfirmationBlock",
+      "type": "object"
+    },
+    "ConfirmationPayload": {
+      "additionalProperties": false,
+      "description": "`body` carries the question this block asks \u2014 required, since nothing\nelse on the block carries it. `title` is optional and renders no row at\nall when absent; it exists for the rarer confirmation whose question\nneeds a heading above detail. The two labels are what vary the button\nwording between one confirmation and another.",
+      "properties": {
+        "body": {
+          "title": "Body",
+          "type": "string"
+        },
         "callback_id": {
           "title": "Callback Id",
           "type": "string"
@@ -2003,20 +1610,41 @@ the mounted routes under `backend/jarvis_app_backend`.
           "default": null,
           "title": "Confirm Label"
         },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Title"
+        }
+      },
+      "required": [
+        "callback_id",
+        "body"
+      ],
+      "title": "ConfirmationPayload",
+      "type": "object"
+    },
+    "FormBlock": {
+      "additionalProperties": false,
+      "properties": {
         "kind": {
-          "const": "confirmation",
-          "default": "confirmation",
+          "const": "form",
+          "default": "form",
           "title": "Kind",
           "type": "string"
+        },
+        "payload": {
+          "$ref": "#/$defs/FormPayload"
         },
         "state": {
           "anyOf": [
             {
-              "enum": [
-                "confirmed",
-                "cancelled",
-                "expired"
-              ],
               "type": "string"
             },
             {
@@ -2025,38 +1653,15 @@ the mounted routes under `backend/jarvis_app_backend`.
           ],
           "default": null,
           "title": "State"
-        }
-      },
-      "required": [
-        "callback_id"
-      ],
-      "title": "ConfirmationBlock",
-      "type": "object"
-    },
-    "FormBlock": {
-      "additionalProperties": false,
-      "properties": {
-        "fields": {
-          "items": {
-            "$ref": "#/$defs/FormField"
-          },
-          "title": "Fields",
-          "type": "array"
         },
-        "kind": {
-          "const": "form",
-          "default": "form",
-          "title": "Kind",
-          "type": "string"
-        },
-        "submit_label": {
-          "default": "Submit",
-          "title": "Submit Label",
+        "summary": {
+          "title": "Summary",
           "type": "string"
         }
       },
       "required": [
-        "fields"
+        "summary",
+        "payload"
       ],
       "title": "FormBlock",
       "type": "object"
@@ -2078,6 +1683,29 @@ the mounted routes under `backend/jarvis_app_backend`.
         "label"
       ],
       "title": "FormField",
+      "type": "object"
+    },
+    "FormPayload": {
+      "additionalProperties": false,
+      "description": "`fields` carries a label and an id and nothing else \u2014 there is no field\n*type*, no required flag, no default. That is the whole taxonomy, and it\nstays this small until a renderer forces the question: a type nothing can\ndraw is a promise the system cannot keep.",
+      "properties": {
+        "fields": {
+          "items": {
+            "$ref": "#/$defs/FormField"
+          },
+          "title": "Fields",
+          "type": "array"
+        },
+        "submit_label": {
+          "default": "Submit",
+          "title": "Submit Label",
+          "type": "string"
+        }
+      },
+      "required": [
+        "fields"
+      ],
+      "title": "FormPayload",
       "type": "object"
     },
     "MessageMeta": {
@@ -2261,6 +1889,615 @@ the mounted routes under `backend/jarvis_app_backend`.
 }
 ```
 
+### MessageUpdate
+
+```json
+{
+  "$defs": {
+    "Action": {
+      "additionalProperties": false,
+      "description": "A tappable option: `card.actions` and `buttons.options` both use this\nshape, so a card's own buttons and a bare `buttons` block behave the same\nway once tapped.",
+      "properties": {
+        "action_id": {
+          "title": "Action Id",
+          "type": "string"
+        },
+        "label": {
+          "title": "Label",
+          "type": "string"
+        }
+      },
+      "required": [
+        "action_id",
+        "label"
+      ],
+      "title": "Action",
+      "type": "object"
+    },
+    "Attachment": {
+      "additionalProperties": false,
+      "description": "One uploaded blob, as it rides `attachments[]` on a `Message` or the\nresponse of `POST /v1/attachments`.",
+      "properties": {
+        "blur_preview": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Blur Preview"
+        },
+        "duration_ms": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Duration Ms"
+        },
+        "filename": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Filename"
+        },
+        "height": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Height"
+        },
+        "id": {
+          "pattern": "^att_[0-9A-HJKMNP-TV-Z]{26}$",
+          "title": "Id",
+          "type": "string"
+        },
+        "kind": {
+          "enum": [
+            "image",
+            "audio",
+            "file"
+          ],
+          "title": "Kind",
+          "type": "string"
+        },
+        "mime_type": {
+          "title": "Mime Type",
+          "type": "string"
+        },
+        "size": {
+          "title": "Size",
+          "type": "integer"
+        },
+        "width": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Width"
+        }
+      },
+      "required": [
+        "id",
+        "kind",
+        "mime_type",
+        "size"
+      ],
+      "title": "Attachment",
+      "type": "object"
+    },
+    "ButtonsBlock": {
+      "additionalProperties": false,
+      "description": "`state` is the selected `action_id` once resolved \u2014 an open string\nrather than an enum, because the values are whatever the author of this\nblock's `options` chose.",
+      "properties": {
+        "kind": {
+          "const": "buttons",
+          "default": "buttons",
+          "title": "Kind",
+          "type": "string"
+        },
+        "payload": {
+          "$ref": "#/$defs/ButtonsPayload"
+        },
+        "state": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "State"
+        },
+        "summary": {
+          "title": "Summary",
+          "type": "string"
+        }
+      },
+      "required": [
+        "summary",
+        "payload"
+      ],
+      "title": "ButtonsBlock",
+      "type": "object"
+    },
+    "ButtonsPayload": {
+      "additionalProperties": false,
+      "description": "No prose field exists here \u2014 see the module docstring. `options`\nabsorbs what a separate `choice` kind would otherwise do.",
+      "properties": {
+        "options": {
+          "items": {
+            "$ref": "#/$defs/Action"
+          },
+          "title": "Options",
+          "type": "array"
+        }
+      },
+      "required": [
+        "options"
+      ],
+      "title": "ButtonsPayload",
+      "type": "object"
+    },
+    "CardBlock": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "const": "card",
+          "default": "card",
+          "title": "Kind",
+          "type": "string"
+        },
+        "payload": {
+          "$ref": "#/$defs/CardPayload"
+        },
+        "state": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "State"
+        },
+        "summary": {
+          "title": "Summary",
+          "type": "string"
+        }
+      },
+      "required": [
+        "summary",
+        "payload"
+      ],
+      "title": "CardBlock",
+      "type": "object"
+    },
+    "CardPayload": {
+      "additionalProperties": false,
+      "properties": {
+        "actions": {
+          "items": {
+            "$ref": "#/$defs/Action"
+          },
+          "title": "Actions",
+          "type": "array"
+        },
+        "body": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Body"
+        },
+        "subtitle": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Subtitle"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        }
+      },
+      "required": [
+        "title"
+      ],
+      "title": "CardPayload",
+      "type": "object"
+    },
+    "ConfirmationBlock": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "const": "confirmation",
+          "default": "confirmation",
+          "title": "Kind",
+          "type": "string"
+        },
+        "payload": {
+          "$ref": "#/$defs/ConfirmationPayload"
+        },
+        "state": {
+          "anyOf": [
+            {
+              "enum": [
+                "confirmed",
+                "cancelled",
+                "expired"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "State"
+        },
+        "summary": {
+          "title": "Summary",
+          "type": "string"
+        }
+      },
+      "required": [
+        "summary",
+        "payload"
+      ],
+      "title": "ConfirmationBlock",
+      "type": "object"
+    },
+    "ConfirmationPayload": {
+      "additionalProperties": false,
+      "description": "`body` carries the question this block asks \u2014 required, since nothing\nelse on the block carries it. `title` is optional and renders no row at\nall when absent; it exists for the rarer confirmation whose question\nneeds a heading above detail. The two labels are what vary the button\nwording between one confirmation and another.",
+      "properties": {
+        "body": {
+          "title": "Body",
+          "type": "string"
+        },
+        "callback_id": {
+          "title": "Callback Id",
+          "type": "string"
+        },
+        "cancel_label": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Cancel Label"
+        },
+        "confirm_label": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Confirm Label"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Title"
+        }
+      },
+      "required": [
+        "callback_id",
+        "body"
+      ],
+      "title": "ConfirmationPayload",
+      "type": "object"
+    },
+    "FormBlock": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "const": "form",
+          "default": "form",
+          "title": "Kind",
+          "type": "string"
+        },
+        "payload": {
+          "$ref": "#/$defs/FormPayload"
+        },
+        "state": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "State"
+        },
+        "summary": {
+          "title": "Summary",
+          "type": "string"
+        }
+      },
+      "required": [
+        "summary",
+        "payload"
+      ],
+      "title": "FormBlock",
+      "type": "object"
+    },
+    "FormField": {
+      "additionalProperties": false,
+      "properties": {
+        "field_id": {
+          "title": "Field Id",
+          "type": "string"
+        },
+        "label": {
+          "title": "Label",
+          "type": "string"
+        }
+      },
+      "required": [
+        "field_id",
+        "label"
+      ],
+      "title": "FormField",
+      "type": "object"
+    },
+    "FormPayload": {
+      "additionalProperties": false,
+      "description": "`fields` carries a label and an id and nothing else \u2014 there is no field\n*type*, no required flag, no default. That is the whole taxonomy, and it\nstays this small until a renderer forces the question: a type nothing can\ndraw is a promise the system cannot keep.",
+      "properties": {
+        "fields": {
+          "items": {
+            "$ref": "#/$defs/FormField"
+          },
+          "title": "Fields",
+          "type": "array"
+        },
+        "submit_label": {
+          "default": "Submit",
+          "title": "Submit Label",
+          "type": "string"
+        }
+      },
+      "required": [
+        "fields"
+      ],
+      "title": "FormPayload",
+      "type": "object"
+    },
+    "Message": {
+      "description": "The persistent unit; `id` is the sync cursor (architecture \u00a75).",
+      "properties": {
+        "attachments": {
+          "items": {
+            "$ref": "#/$defs/Attachment"
+          },
+          "title": "Attachments",
+          "type": "array"
+        },
+        "blocks": {
+          "anyOf": [
+            {
+              "items": {
+                "discriminator": {
+                  "mapping": {
+                    "buttons": "#/$defs/ButtonsBlock",
+                    "card": "#/$defs/CardBlock",
+                    "confirmation": "#/$defs/ConfirmationBlock",
+                    "form": "#/$defs/FormBlock"
+                  },
+                  "propertyName": "kind"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/$defs/CardBlock"
+                  },
+                  {
+                    "$ref": "#/$defs/FormBlock"
+                  },
+                  {
+                    "$ref": "#/$defs/ButtonsBlock"
+                  },
+                  {
+                    "$ref": "#/$defs/ConfirmationBlock"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Blocks"
+        },
+        "client_msg_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Client Msg Id"
+        },
+        "client_ts": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Client Ts"
+        },
+        "created_at": {
+          "title": "Created At",
+          "type": "string"
+        },
+        "delivered_at": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Delivered At"
+        },
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        },
+        "meta": {
+          "$ref": "#/$defs/MessageMeta"
+        },
+        "role": {
+          "enum": [
+            "user",
+            "assistant"
+          ],
+          "title": "Role",
+          "type": "string"
+        },
+        "text": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Text"
+        },
+        "updated_at": {
+          "title": "Updated At",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "client_msg_id",
+        "role",
+        "text",
+        "blocks",
+        "attachments",
+        "meta",
+        "client_ts",
+        "delivered_at",
+        "created_at",
+        "updated_at"
+      ],
+      "title": "Message",
+      "type": "object"
+    },
+    "MessageMeta": {
+      "additionalProperties": false,
+      "description": "`source` is informational only \u2014 the client must not branch on it\n(architecture \u00a74: `heartbeat`/`reminder`/`notifier` are this agent's\nconcepts, not universal ones).",
+      "properties": {
+        "source": {
+          "enum": [
+            "user",
+            "agent",
+            "heartbeat",
+            "reminder",
+            "notifier"
+          ],
+          "title": "Source",
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ],
+      "title": "MessageMeta",
+      "type": "object"
+    }
+  },
+  "properties": {
+    "message": {
+      "$ref": "#/$defs/Message"
+    },
+    "type": {
+      "const": "message",
+      "title": "Type",
+      "type": "string"
+    },
+    "update_id": {
+      "title": "Update Id",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "update_id",
+    "type",
+    "message"
+  ],
+  "title": "MessageUpdate",
+  "type": "object"
+}
+```
+
 ### MessagesPage
 
 ```json
@@ -2384,7 +2621,7 @@ the mounted routes under `backend/jarvis_app_backend`.
     },
     "ButtonsBlock": {
       "additionalProperties": false,
-      "description": "No prose field exists here \u2014 see the module docstring. `options`\nabsorbs what a separate `choice` kind would otherwise do; `state` is the\nselected `action_id` once resolved, or `None` while the block is still\nlive.",
+      "description": "`state` is the selected `action_id` once resolved \u2014 an open string\nrather than an enum, because the values are whatever the author of this\nblock's `options` chose.",
       "properties": {
         "kind": {
           "const": "buttons",
@@ -2392,12 +2629,8 @@ the mounted routes under `backend/jarvis_app_backend`.
           "title": "Kind",
           "type": "string"
         },
-        "options": {
-          "items": {
-            "$ref": "#/$defs/Action"
-          },
-          "title": "Options",
-          "type": "array"
+        "payload": {
+          "$ref": "#/$defs/ButtonsPayload"
         },
         "state": {
           "anyOf": [
@@ -2410,15 +2643,74 @@ the mounted routes under `backend/jarvis_app_backend`.
           ],
           "default": null,
           "title": "State"
+        },
+        "summary": {
+          "title": "Summary",
+          "type": "string"
+        }
+      },
+      "required": [
+        "summary",
+        "payload"
+      ],
+      "title": "ButtonsBlock",
+      "type": "object"
+    },
+    "ButtonsPayload": {
+      "additionalProperties": false,
+      "description": "No prose field exists here \u2014 see the module docstring. `options`\nabsorbs what a separate `choice` kind would otherwise do.",
+      "properties": {
+        "options": {
+          "items": {
+            "$ref": "#/$defs/Action"
+          },
+          "title": "Options",
+          "type": "array"
         }
       },
       "required": [
         "options"
       ],
-      "title": "ButtonsBlock",
+      "title": "ButtonsPayload",
       "type": "object"
     },
     "CardBlock": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "const": "card",
+          "default": "card",
+          "title": "Kind",
+          "type": "string"
+        },
+        "payload": {
+          "$ref": "#/$defs/CardPayload"
+        },
+        "state": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "State"
+        },
+        "summary": {
+          "title": "Summary",
+          "type": "string"
+        }
+      },
+      "required": [
+        "summary",
+        "payload"
+      ],
+      "title": "CardBlock",
+      "type": "object"
+    },
+    "CardPayload": {
       "additionalProperties": false,
       "properties": {
         "actions": {
@@ -2440,24 +2732,6 @@ the mounted routes under `backend/jarvis_app_backend`.
           "default": null,
           "title": "Body"
         },
-        "image": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Image"
-        },
-        "kind": {
-          "const": "card",
-          "default": "card",
-          "title": "Kind",
-          "type": "string"
-        },
         "subtitle": {
           "anyOf": [
             {
@@ -2478,13 +2752,58 @@ the mounted routes under `backend/jarvis_app_backend`.
       "required": [
         "title"
       ],
-      "title": "CardBlock",
+      "title": "CardPayload",
       "type": "object"
     },
     "ConfirmationBlock": {
       "additionalProperties": false,
-      "description": "No prose field exists here either \u2014 the question this block asks\nlives in the message's own `text`, never in the block.",
       "properties": {
+        "kind": {
+          "const": "confirmation",
+          "default": "confirmation",
+          "title": "Kind",
+          "type": "string"
+        },
+        "payload": {
+          "$ref": "#/$defs/ConfirmationPayload"
+        },
+        "state": {
+          "anyOf": [
+            {
+              "enum": [
+                "confirmed",
+                "cancelled",
+                "expired"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "State"
+        },
+        "summary": {
+          "title": "Summary",
+          "type": "string"
+        }
+      },
+      "required": [
+        "summary",
+        "payload"
+      ],
+      "title": "ConfirmationBlock",
+      "type": "object"
+    },
+    "ConfirmationPayload": {
+      "additionalProperties": false,
+      "description": "`body` carries the question this block asks \u2014 required, since nothing\nelse on the block carries it. `title` is optional and renders no row at\nall when absent; it exists for the rarer confirmation whose question\nneeds a heading above detail. The two labels are what vary the button\nwording between one confirmation and another.",
+      "properties": {
+        "body": {
+          "title": "Body",
+          "type": "string"
+        },
         "callback_id": {
           "title": "Callback Id",
           "type": "string"
@@ -2513,20 +2832,41 @@ the mounted routes under `backend/jarvis_app_backend`.
           "default": null,
           "title": "Confirm Label"
         },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Title"
+        }
+      },
+      "required": [
+        "callback_id",
+        "body"
+      ],
+      "title": "ConfirmationPayload",
+      "type": "object"
+    },
+    "FormBlock": {
+      "additionalProperties": false,
+      "properties": {
         "kind": {
-          "const": "confirmation",
-          "default": "confirmation",
+          "const": "form",
+          "default": "form",
           "title": "Kind",
           "type": "string"
+        },
+        "payload": {
+          "$ref": "#/$defs/FormPayload"
         },
         "state": {
           "anyOf": [
             {
-              "enum": [
-                "confirmed",
-                "cancelled",
-                "expired"
-              ],
               "type": "string"
             },
             {
@@ -2535,38 +2875,15 @@ the mounted routes under `backend/jarvis_app_backend`.
           ],
           "default": null,
           "title": "State"
-        }
-      },
-      "required": [
-        "callback_id"
-      ],
-      "title": "ConfirmationBlock",
-      "type": "object"
-    },
-    "FormBlock": {
-      "additionalProperties": false,
-      "properties": {
-        "fields": {
-          "items": {
-            "$ref": "#/$defs/FormField"
-          },
-          "title": "Fields",
-          "type": "array"
         },
-        "kind": {
-          "const": "form",
-          "default": "form",
-          "title": "Kind",
-          "type": "string"
-        },
-        "submit_label": {
-          "default": "Submit",
-          "title": "Submit Label",
+        "summary": {
+          "title": "Summary",
           "type": "string"
         }
       },
       "required": [
-        "fields"
+        "summary",
+        "payload"
       ],
       "title": "FormBlock",
       "type": "object"
@@ -2588,6 +2905,29 @@ the mounted routes under `backend/jarvis_app_backend`.
         "label"
       ],
       "title": "FormField",
+      "type": "object"
+    },
+    "FormPayload": {
+      "additionalProperties": false,
+      "description": "`fields` carries a label and an id and nothing else \u2014 there is no field\n*type*, no required flag, no default. That is the whole taxonomy, and it\nstays this small until a renderer forces the question: a type nothing can\ndraw is a promise the system cannot keep.",
+      "properties": {
+        "fields": {
+          "items": {
+            "$ref": "#/$defs/FormField"
+          },
+          "title": "Fields",
+          "type": "array"
+        },
+        "submit_label": {
+          "default": "Submit",
+          "title": "Submit Label",
+          "type": "string"
+        }
+      },
+      "required": [
+        "fields"
+      ],
+      "title": "FormPayload",
       "type": "object"
     },
     "Message": {
@@ -2793,7 +3133,7 @@ the mounted routes under `backend/jarvis_app_backend`.
     },
     "ButtonsBlock": {
       "additionalProperties": false,
-      "description": "No prose field exists here \u2014 see the module docstring. `options`\nabsorbs what a separate `choice` kind would otherwise do; `state` is the\nselected `action_id` once resolved, or `None` while the block is still\nlive.",
+      "description": "`state` is the selected `action_id` once resolved \u2014 an open string\nrather than an enum, because the values are whatever the author of this\nblock's `options` chose.",
       "properties": {
         "kind": {
           "const": "buttons",
@@ -2801,12 +3141,8 @@ the mounted routes under `backend/jarvis_app_backend`.
           "title": "Kind",
           "type": "string"
         },
-        "options": {
-          "items": {
-            "$ref": "#/$defs/Action"
-          },
-          "title": "Options",
-          "type": "array"
+        "payload": {
+          "$ref": "#/$defs/ButtonsPayload"
         },
         "state": {
           "anyOf": [
@@ -2819,15 +3155,74 @@ the mounted routes under `backend/jarvis_app_backend`.
           ],
           "default": null,
           "title": "State"
+        },
+        "summary": {
+          "title": "Summary",
+          "type": "string"
+        }
+      },
+      "required": [
+        "summary",
+        "payload"
+      ],
+      "title": "ButtonsBlock",
+      "type": "object"
+    },
+    "ButtonsPayload": {
+      "additionalProperties": false,
+      "description": "No prose field exists here \u2014 see the module docstring. `options`\nabsorbs what a separate `choice` kind would otherwise do.",
+      "properties": {
+        "options": {
+          "items": {
+            "$ref": "#/$defs/Action"
+          },
+          "title": "Options",
+          "type": "array"
         }
       },
       "required": [
         "options"
       ],
-      "title": "ButtonsBlock",
+      "title": "ButtonsPayload",
       "type": "object"
     },
     "CardBlock": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "const": "card",
+          "default": "card",
+          "title": "Kind",
+          "type": "string"
+        },
+        "payload": {
+          "$ref": "#/$defs/CardPayload"
+        },
+        "state": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "State"
+        },
+        "summary": {
+          "title": "Summary",
+          "type": "string"
+        }
+      },
+      "required": [
+        "summary",
+        "payload"
+      ],
+      "title": "CardBlock",
+      "type": "object"
+    },
+    "CardPayload": {
       "additionalProperties": false,
       "properties": {
         "actions": {
@@ -2849,24 +3244,6 @@ the mounted routes under `backend/jarvis_app_backend`.
           "default": null,
           "title": "Body"
         },
-        "image": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Image"
-        },
-        "kind": {
-          "const": "card",
-          "default": "card",
-          "title": "Kind",
-          "type": "string"
-        },
         "subtitle": {
           "anyOf": [
             {
@@ -2887,13 +3264,58 @@ the mounted routes under `backend/jarvis_app_backend`.
       "required": [
         "title"
       ],
-      "title": "CardBlock",
+      "title": "CardPayload",
       "type": "object"
     },
     "ConfirmationBlock": {
       "additionalProperties": false,
-      "description": "No prose field exists here either \u2014 the question this block asks\nlives in the message's own `text`, never in the block.",
       "properties": {
+        "kind": {
+          "const": "confirmation",
+          "default": "confirmation",
+          "title": "Kind",
+          "type": "string"
+        },
+        "payload": {
+          "$ref": "#/$defs/ConfirmationPayload"
+        },
+        "state": {
+          "anyOf": [
+            {
+              "enum": [
+                "confirmed",
+                "cancelled",
+                "expired"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "State"
+        },
+        "summary": {
+          "title": "Summary",
+          "type": "string"
+        }
+      },
+      "required": [
+        "summary",
+        "payload"
+      ],
+      "title": "ConfirmationBlock",
+      "type": "object"
+    },
+    "ConfirmationPayload": {
+      "additionalProperties": false,
+      "description": "`body` carries the question this block asks \u2014 required, since nothing\nelse on the block carries it. `title` is optional and renders no row at\nall when absent; it exists for the rarer confirmation whose question\nneeds a heading above detail. The two labels are what vary the button\nwording between one confirmation and another.",
+      "properties": {
+        "body": {
+          "title": "Body",
+          "type": "string"
+        },
         "callback_id": {
           "title": "Callback Id",
           "type": "string"
@@ -2922,20 +3344,41 @@ the mounted routes under `backend/jarvis_app_backend`.
           "default": null,
           "title": "Confirm Label"
         },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Title"
+        }
+      },
+      "required": [
+        "callback_id",
+        "body"
+      ],
+      "title": "ConfirmationPayload",
+      "type": "object"
+    },
+    "FormBlock": {
+      "additionalProperties": false,
+      "properties": {
         "kind": {
-          "const": "confirmation",
-          "default": "confirmation",
+          "const": "form",
+          "default": "form",
           "title": "Kind",
           "type": "string"
+        },
+        "payload": {
+          "$ref": "#/$defs/FormPayload"
         },
         "state": {
           "anyOf": [
             {
-              "enum": [
-                "confirmed",
-                "cancelled",
-                "expired"
-              ],
               "type": "string"
             },
             {
@@ -2944,38 +3387,15 @@ the mounted routes under `backend/jarvis_app_backend`.
           ],
           "default": null,
           "title": "State"
-        }
-      },
-      "required": [
-        "callback_id"
-      ],
-      "title": "ConfirmationBlock",
-      "type": "object"
-    },
-    "FormBlock": {
-      "additionalProperties": false,
-      "properties": {
-        "fields": {
-          "items": {
-            "$ref": "#/$defs/FormField"
-          },
-          "title": "Fields",
-          "type": "array"
         },
-        "kind": {
-          "const": "form",
-          "default": "form",
-          "title": "Kind",
-          "type": "string"
-        },
-        "submit_label": {
-          "default": "Submit",
-          "title": "Submit Label",
+        "summary": {
+          "title": "Summary",
           "type": "string"
         }
       },
       "required": [
-        "fields"
+        "summary",
+        "payload"
       ],
       "title": "FormBlock",
       "type": "object"
@@ -2998,10 +3418,33 @@ the mounted routes under `backend/jarvis_app_backend`.
       ],
       "title": "FormField",
       "type": "object"
+    },
+    "FormPayload": {
+      "additionalProperties": false,
+      "description": "`fields` carries a label and an id and nothing else \u2014 there is no field\n*type*, no required flag, no default. That is the whole taxonomy, and it\nstays this small until a renderer forces the question: a type nothing can\ndraw is a promise the system cannot keep.",
+      "properties": {
+        "fields": {
+          "items": {
+            "$ref": "#/$defs/FormField"
+          },
+          "title": "Fields",
+          "type": "array"
+        },
+        "submit_label": {
+          "default": "Submit",
+          "title": "Submit Label",
+          "type": "string"
+        }
+      },
+      "required": [
+        "fields"
+      ],
+      "title": "FormPayload",
+      "type": "object"
     }
   },
   "additionalProperties": false,
-  "description": "`POST /v1/messages`'s body. `client_msg_id` is the idempotency key \u2014\na replay returns the row it already produced rather than a new one.",
+  "description": "`POST /v1/messages`'s body. `client_msg_id` is the idempotency key \u2014\na replay returns the row it already produced rather than a new one.\n\n`blocks` carries at most one entry \u2014 every kind is interactive\n(architecture \u00a75), and `{message_id, action_id}` is only an unambiguous\naddress for a tap when a message carries at most one block. A second\nblock goes out as a second message.",
   "properties": {
     "attachment_ids": {
       "items": {

--- a/gateway/channels/jarvis_app/client.py
+++ b/gateway/channels/jarvis_app/client.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 # The version the adapter was written against. The hub reports its own
 # contract_version on GET /v1/health; a mismatch is logged, never fatal — the hub
 # already 422s a malformed payload, so this only gives a *silent* skew a voice.
-PINNED_CONTRACT_VERSION = "3b3a48f330f09a39"
+PINNED_CONTRACT_VERSION = "f605f1ced7bdb356"
 
 # The hanging poll's server-side wait. The client read timeout sits a little above
 # it so a genuinely dead connection eventually errors instead of hanging forever.
@@ -28,6 +28,17 @@ POLL_TIMEOUT_S = 25.0
 class HubUnavailable(Exception):
     """The hub could not be reached or returned a server error — raised so the
     router enters degraded mode instead of the fetch loop dying."""
+
+
+class MessageAlreadyResolved(Exception):
+    """A PATCH tried to move a block's state to a value that differs from what
+    the hub already has stored — the terminal-state guard refused it (wire
+    error code "already_resolved"). Carries the state that actually stands, so
+    the caller can log the settled value instead of a bare failure."""
+
+    def __init__(self, state: str) -> None:
+        self.state = state
+        super().__init__(f"block already resolved to {state!r}")
 
 
 class HubClient:
@@ -70,11 +81,40 @@ class HubClient:
             raise HubUnavailable(str(e)) from e
         return r.json()
 
-    async def send_message(self, body: dict) -> None:
-        """POST an assistant message to the hub. `body` carries any of text /
-        attachment_ids (the hub requires at least one)."""
+    async def send_message(self, body: dict) -> dict:
+        """POST an assistant message to the hub and return the created Message
+        (in particular its `id`, needed to later PATCH a block's state). `body`
+        carries any of text / attachment_ids / blocks (the hub requires at
+        least one)."""
         r = await self._client.post("/bot/v1/messages", json=body)
         r.raise_for_status()
+        return r.json()
+
+    async def patch_message_state(self, message_id: int, state: str) -> None:
+        """PATCH a sent message's sole interactive block to `state` (e.g.
+        confirmed/cancelled/expired for a confirmation). The hub's terminal-state
+        guard makes re-sending the value already stored a harmless no-op; a
+        PATCH to a *different* value than what is stored raises
+        MessageAlreadyResolved carrying the value that stands. Raises
+        HubUnavailable on a server error or transport failure."""
+        try:
+            r = await self._client.patch(
+                f"/bot/v1/messages/{message_id}", json={"state": state}
+            )
+            r.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code >= 500:
+                raise HubUnavailable(f"hub returned {e.response.status_code}") from e
+            if e.response.status_code == 422:
+                try:
+                    error = e.response.json()["error"]
+                except (ValueError, KeyError):
+                    error = {}
+                if error.get("code") == "already_resolved":
+                    raise MessageAlreadyResolved(error["detail"]["state"]) from e
+            raise
+        except httpx.HTTPError as e:
+            raise HubUnavailable(str(e)) from e
 
     async def upload_attachment(
         self,

--- a/gateway/channels/jarvis_app/confirmation.py
+++ b/gateway/channels/jarvis_app/confirmation.py
@@ -1,0 +1,98 @@
+"""
+AppConfirmationUI — the jarvis-app half of Plane 3: send a confirmation block,
+and keep the hub's wire-level state in sync with what the store decided.
+
+Unlike Telegram, this channel has no way to rewrite a message's free-form text
+after the fact — its only lever is PATCHing the block's `state` to one of
+confirmed/cancelled/expired. apply_outcome reads only `outcome` (the structured
+result) and ignores `outcome_text`, the prose half a text-rendering channel
+would use instead. Resolution flows the other way through handle_action, the
+router's entry point for an ActionUpdate.
+"""
+
+import logging
+
+from gateway.confirmation.base import ConfirmationOutcome, ConfirmationUI
+from gateway.channels.jarvis_app.client import HubClient, MessageAlreadyResolved
+
+logger = logging.getLogger(__name__)
+
+# Maps a resolved confirmation to the hub's wire vocabulary for a confirmation
+# block's `state`. FAILED still means the tap itself was honored (the owner
+# confirmed) — the wire has no separate "the action then failed" state, only
+# what the human decided. ALREADY_HANDLED maps to None: this process no longer
+# knows which value it originally intended, and the hub's own terminal-state
+# guard is what actually protects the stored value either way.
+_WIRE_STATE: dict[ConfirmationOutcome, str | None] = {
+    ConfirmationOutcome.CONFIRMED: "confirmed",
+    ConfirmationOutcome.FAILED: "confirmed",
+    ConfirmationOutcome.CANCELLED: "cancelled",
+    ConfirmationOutcome.EXPIRED: "expired",
+    ConfirmationOutcome.ALREADY_HANDLED: None,
+}
+
+
+class AppConfirmationUI(ConfirmationUI):
+    def __init__(self, client: HubClient) -> None:
+        self._client = client
+        self._store = None  # set via bind_store() to break the construction cycle
+        self._message_ids: dict[str, int] = {}  # callback_id -> prompt message_id
+
+    def bind_store(self, store) -> None:
+        self._store = store
+
+    async def send_prompt(self, callback_id: str, description: str) -> None:
+        # summary == payload.body verbatim: the architecture's own canonical
+        # example does the same — the confirmation's question has one source
+        # of truth, restated only where the wire's block envelope requires it.
+        message = await self._client.send_message({
+            "blocks": [{
+                "kind": "confirmation",
+                "summary": description,
+                "payload": {"callback_id": callback_id, "body": description},
+            }]
+        })
+        self._message_ids[callback_id] = message["id"]
+
+    async def apply_outcome(
+        self, callback_id: str, outcome: ConfirmationOutcome, outcome_text: str
+    ) -> None:
+        message_id = self._message_ids.pop(callback_id, None)
+        if message_id is None:
+            return  # prompt was never successfully sent — nothing to PATCH
+        wire_state = _WIRE_STATE[outcome]
+        if wire_state is None:
+            return
+        try:
+            await self._client.patch_message_state(message_id, wire_state)
+        except MessageAlreadyResolved as e:
+            logger.warning(
+                "jarvis-app PATCH state=%s for callback %s lost to already-settled state=%s",
+                wire_state, callback_id, e.state,
+            )
+        except Exception:
+            logger.exception("jarvis-app PATCH state failed for callback %s", callback_id)
+
+    async def handle_action(
+        self, *, action_id: str, message_id: int, block_kind: str, callback_id: str | None
+    ) -> None:
+        """Router entry point for an ActionUpdate — mirrors
+        TelegramConfirmationUI.handle_callback. Confirmation is the only kind
+        with a registered below-LLM resolution today; any other block_kind
+        (buttons/card/form) is Stage D territory and falls through."""
+        if block_kind != "confirmation":
+            logger.info(
+                "jarvis-app ignoring action for block_kind=%r (no handler yet)", block_kind
+            )
+            return
+        if callback_id is None:
+            logger.warning(
+                "jarvis-app confirmation action with no callback_id (message_id=%s) — "
+                "contract violation, ignoring",
+                message_id,
+            )
+            return
+        if self._store is None:
+            logger.error("Confirmation store not bound; cannot resolve %s", callback_id)
+            return
+        await self._store.resolve(callback_id, confirmed=(action_id == "confirm"))

--- a/gateway/channels/jarvis_app/router.py
+++ b/gateway/channels/jarvis_app/router.py
@@ -25,6 +25,7 @@ from gateway.channels.jarvis_app.client import (
     HubClient,
     PINNED_CONTRACT_VERSION,
 )
+from gateway.channels.jarvis_app.confirmation import AppConfirmationUI
 
 logger = logging.getLogger(__name__)
 
@@ -59,11 +60,16 @@ def _neutral_kind(hub_kind: str, mime_type: str) -> str:
 
 class JarvisAppInboundRouter:
     def __init__(
-        self, channel: JarvisAppChannel, client: HubClient, on_message: OnMessage
+        self,
+        channel: JarvisAppChannel,
+        client: HubClient,
+        on_message: OnMessage,
+        confirmation_ui: AppConfirmationUI,
     ) -> None:
         self._channel = channel
         self._client = client
         self._on_message = on_message
+        self._confirmation_ui = confirmation_ui
         self._queue: asyncio.Queue = asyncio.Queue()
         self._stop = asyncio.Event()
         self._degraded = False  # True while the hub is unreachable — for log-once
@@ -158,8 +164,16 @@ class JarvisAppInboundRouter:
                 self._queue.task_done()
 
     async def _handle(self, update: dict) -> None:
+        if update.get("type") == "action":
+            await self._confirmation_ui.handle_action(
+                action_id=update.get("action_id"),
+                message_id=update.get("message_id"),
+                block_kind=update.get("block_kind"),
+                callback_id=update.get("callback_id"),
+            )
+            return
         if update.get("type") != "message":
-            return  # non-message updates carry no turn; the poll already acked them
+            return  # neither message nor action; the poll already acked it
         message = update.get("message") or {}
         # Only the owner's own messages drive a turn — never the agent's own sends
         # echoed back, which would loop.

--- a/gateway/channels/telegram/confirmation.py
+++ b/gateway/channels/telegram/confirmation.py
@@ -9,7 +9,7 @@ import logging
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.error import BadRequest
 
-from gateway.confirmation.base import ConfirmationUI
+from gateway.confirmation.base import ConfirmationOutcome, ConfirmationUI
 from gateway.channels.telegram.channel import TelegramChannel
 from gateway.channels.telegram._render import render_fences_only
 
@@ -61,7 +61,11 @@ class TelegramConfirmationUI(ConfirmationUI):
             )
         self._message_ids[callback_id] = message.message_id
 
-    async def edit_outcome(self, callback_id: str, outcome_text: str) -> None:
+    async def apply_outcome(
+        self, callback_id: str, outcome: ConfirmationOutcome, outcome_text: str
+    ) -> None:
+        # This wire has no structured resolution state of its own — outcome_text
+        # is the entire signal, so `outcome` goes unused here.
         message_id = self._message_ids.pop(callback_id, None)
         try:
             if message_id is not None:
@@ -74,9 +78,6 @@ class TelegramConfirmationUI(ConfirmationUI):
                 await self._channel.send_to_owner(outcome_text)
         except Exception:
             logger.exception("Failed to edit confirmation outcome")
-
-    async def expire(self, callback_id: str) -> None:
-        await self.edit_outcome(callback_id, "⌛ Confirmation expired.")
 
     async def handle_callback(self, update: Update, context) -> None:
         """PTB CallbackQueryHandler entry point."""

--- a/gateway/confirmation/base.py
+++ b/gateway/confirmation/base.py
@@ -11,7 +11,21 @@ delivered out-of-band.
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
+from enum import Enum
 from typing import Awaitable, Callable
+
+
+class ConfirmationOutcome(str, Enum):
+    """What a resolved confirmation turned out to be, independent of any
+    channel's rendered text — a channel whose native protocol tracks
+    resolution state (rather than free-form prose) needs this instead of
+    parsing outcome_text."""
+
+    CONFIRMED = "confirmed"
+    CANCELLED = "cancelled"
+    FAILED = "failed"  # confirmed, but the action itself raised
+    EXPIRED = "expired"
+    ALREADY_HANDLED = "already_handled"
 
 
 @dataclass
@@ -58,13 +72,22 @@ class ConfirmationUI(ABC):
         """Render the confirm/cancel prompt to the owner."""
 
     @abstractmethod
-    async def edit_outcome(self, callback_id: str, outcome_text: str) -> None:
-        """Replace the prompt with the final outcome text."""
+    async def apply_outcome(
+        self, callback_id: str, outcome: ConfirmationOutcome, outcome_text: str
+    ) -> None:
+        """Deliver the final state of a resolved or expired confirmation.
+        `outcome` is the structured result (fixed vocabulary); `outcome_text`
+        is the human-readable prose. Implementations read whichever fits their
+        channel's wire — most read exactly one, and ignore the other. Must not
+        raise: the store treats this as best-effort delivery and isolates each
+        call so a failure here can never skip the conversational follow-up."""
 
     async def expire(self, callback_id: str) -> None:
         """Retire a prompt whose pending action was TTL-evicted before resolution.
 
-        Default: delegate to edit_outcome with a generic expiry message. Channels
-        with cheaper cleanup paths may override.
+        Default: deliver a generic expiry outcome. Channels with cheaper
+        cleanup paths may override.
         """
-        await self.edit_outcome(callback_id, "⌛ Confirmation expired.")
+        await self.apply_outcome(
+            callback_id, ConfirmationOutcome.EXPIRED, "⌛ Confirmation expired."
+        )

--- a/gateway/confirmation/store.py
+++ b/gateway/confirmation/store.py
@@ -16,7 +16,12 @@ import uuid
 from typing import Awaitable, Callable
 
 from gateway import outbox as outbox_mod
-from gateway.confirmation.base import Confirmation, ConfirmationUI, PendingAction
+from gateway.confirmation.base import (
+    Confirmation,
+    ConfirmationOutcome,
+    ConfirmationUI,
+    PendingAction,
+)
 from gateway.outbox import Outbox
 
 logger = logging.getLogger(__name__)
@@ -132,15 +137,18 @@ class InMemoryConfirmationStore(Confirmation):
             action = self._pending.pop(callback_id, None)
 
         if action is None:
-            await self._ui.edit_outcome(
+            await self._apply_outcome(
                 callback_id,
+                ConfirmationOutcome.ALREADY_HANDLED,
                 "⚠️ This confirmation has already been handled or has expired.",
             )
             return
 
         desc = action.description
         if not confirmed:
-            await self._ui.edit_outcome(callback_id, f"❌ {action.result_cancel_text}")
+            await self._apply_outcome(
+                callback_id, ConfirmationOutcome.CANCELLED, f"❌ {action.result_cancel_text}"
+            )
             await self._deliver_outcome(
                 f"[System: The user cancelled the requested action. Task: {desc}]"
             )
@@ -148,8 +156,10 @@ class InMemoryConfirmationStore(Confirmation):
 
         try:
             result = await action.action_fn()
-            await self._ui.edit_outcome(
-                callback_id, f"✅ {action.result_ok_text}\n{result}"
+            await self._apply_outcome(
+                callback_id,
+                ConfirmationOutcome.CONFIRMED,
+                f"✅ {action.result_ok_text}\n{result}",
             )
             feedback = (
                 f"[System: The user confirmed the requested action. "
@@ -157,13 +167,26 @@ class InMemoryConfirmationStore(Confirmation):
             )
         except Exception as e:
             logger.exception("Confirmed action raised")
-            await self._ui.edit_outcome(callback_id, f"❌ Action failed: {e}")
+            await self._apply_outcome(
+                callback_id, ConfirmationOutcome.FAILED, f"❌ Action failed: {e}"
+            )
             feedback = (
                 f"[System: The confirmed action failed. "
                 f"Task: {desc}. Error: {e}]"
             )
 
         await self._deliver_outcome(feedback)
+
+    async def _apply_outcome(
+        self, callback_id: str, outcome: ConfirmationOutcome, outcome_text: str
+    ) -> None:
+        """Best-effort dispatch to the UI, isolated from the rest of resolve()'s
+        control flow — a channel's outcome delivery failing must never skip the
+        conversational follow-up that comes after it."""
+        try:
+            await self._ui.apply_outcome(callback_id, outcome, outcome_text)
+        except Exception:
+            logger.exception("UI.apply_outcome failed for %s", callback_id)
 
     async def _deliver_outcome(self, system_text: str) -> None:
         """Hand the neutral outcome to the domain for a conversational

--- a/gateway/factory.py
+++ b/gateway/factory.py
@@ -21,6 +21,7 @@ from typing import Awaitable, Callable, Protocol
 
 import turn_context
 
+from gateway import outbox as outbox_mod
 from gateway.base import Channel, OnMessage
 from gateway.confirmation.base import Confirmation
 from gateway.confirmation.store import InMemoryConfirmationStore
@@ -31,6 +32,7 @@ from gateway.channels.telegram.host import TelegramHost
 from gateway.channels.telegram.router import TelegramInboundRouter
 from gateway.channels.jarvis_app.channel import JarvisAppChannel
 from gateway.channels.jarvis_app.client import HubClient
+from gateway.channels.jarvis_app.confirmation import AppConfirmationUI
 from gateway.channels.jarvis_app.router import JarvisAppInboundRouter
 
 logger = logging.getLogger(__name__)
@@ -69,11 +71,22 @@ class JarvisAppStack:
     channel: JarvisAppChannel
     client: HubClient
     router: JarvisAppInboundRouter
+    store: InMemoryConfirmationStore
+    confirmation_ui: AppConfirmationUI
     outbox: Outbox
     _task: "asyncio.Task | None" = field(default=None, init=False)
 
     async def start(self) -> None:
-        """Launch the poll-loop router as a background task; returns immediately."""
+        """Bind the thread->loop bridge, start the confirmation TTL sweeper, then
+        launch the poll-loop router as a background task; returns immediately.
+
+        Telegram's host binds the bridge in its own start(); there is no
+        equivalent host object here, and this stack may build and start before
+        or without Telegram's, so bind explicitly rather than assume it already
+        happened — bind_loop() to the same running loop is a no-op if it did.
+        """
+        outbox_mod.bind_loop(asyncio.get_running_loop())
+        self.store.start_sweeper()
         self._task = asyncio.create_task(self.router.run())
 
     async def stop(self) -> None:
@@ -221,14 +234,16 @@ def _build_jarvis_app_stack(
     on_confirmation_outcome: Callable[[str, str, Outbox], Awaitable[None]] | None = None,
     log_sink: LogSink | None = None,
 ) -> JarvisAppStack:
-    """Construct and wire the jarvis-app channel — HubClient, channel, outbox, and
-    the poll-loop router — and register the channel for proactive routing. Reads
+    """Construct and wire the jarvis-app channel — HubClient, channel, confirmation
+    store/UI, outbox, and the poll-loop router — and register the channel for
+    proactive routing and the confirmation backend for destructive tools. Reads
     APP_HUB_URL / APP_HUB_BOT_TOKEN / APP_OWNER_USER_ID from the environment.
 
-    No confirmation store is registered yet: a destructive tool on an app-origin
-    turn currently falls back to the default channel's store (a later step gives
-    the app its own handling), so on_confirmation_outcome is accepted for
-    signature parity but unused here."""
+    on_confirmation_outcome: domain callback that turns a confirmation outcome
+    into a conversational acknowledgement (keeps the agent out of the gateway) —
+    same callback the Telegram stack uses, so a resolved confirmation acks on
+    whichever channel's thread it originated from.
+    """
     base_url = os.getenv("APP_HUB_URL")
     if not base_url:
         raise ValueError("APP_HUB_URL not set in the environment")
@@ -242,11 +257,20 @@ def _build_jarvis_app_stack(
     client = HubClient(base_url, token)
     channel = JarvisAppChannel(client, owner)
     outbox = Outbox(channel, log_sink)
-    router = JarvisAppInboundRouter(channel, client, on_message)
+    confirmation_ui = AppConfirmationUI(client)
+    store = InMemoryConfirmationStore(
+        confirmation_ui, outbox, channel.owner_thread_id, on_confirmation_outcome
+    )
+    confirmation_ui.bind_store(store)
+    router = JarvisAppInboundRouter(channel, client, on_message, confirmation_ui)
 
     register_channel(channel, outbox)
+    register_confirmation(channel.name, store)
     logger.info("jarvis-app stack built (owner=%s)", owner)
-    return JarvisAppStack(channel=channel, client=client, router=router, outbox=outbox)
+    return JarvisAppStack(
+        channel=channel, client=client, router=router,
+        store=store, confirmation_ui=confirmation_ui, outbox=outbox,
+    )
 
 
 _STACK_BUILDERS: dict[str, Callable[..., Stack]] = {


### PR DESCRIPTION
## Summary
- The jarvis-app hub shipped `POST /v1/actions` plus a PATCH-only block-state model (contract `f605f1ced7bdb356`, up from `3b3a48f330f09a39`), so the app channel can now resolve its own confirm/cancel taps instead of falling back to Telegram's confirmation store.
- `ConfirmationUI`'s `edit_outcome` was replaced with a single `apply_outcome(callback_id, outcome, outcome_text)` — one method carrying both a structured `ConfirmationOutcome` and rendered prose, rather than two parallel methods. An initial two-method split (`edit_outcome` + an additive `sync_outcome_state`) was reviewed after landing and collapsed into this shape: the mandatory method was often vestigial for a structured-state channel, and the optional one carried the real logic in a way a future channel author could easily miss.
- `InMemoryConfirmationStore` now isolates every `apply_outcome` call in its own try/except, so a channel's outcome-delivery failure can no longer skip the conversational follow-up after it.
- `contract.md` re-synced verbatim from the hub; `PINNED_CONTRACT_VERSION` bumped in `client.py`.

## Review notes (code-review skill, pre-merge)
Ran clean — 0 blockers, 3 warnings, all disclosed rather than fixed:
- The ABC change is channel-neutral but did require touching both channel implementations (Telegram: mechanical rename only, zero behavior change).
- Pre-existing (not introduced here): the "already handled" resolve() branch never calls `_deliver_outcome` — no conversational feedback for that case, on either channel.
- A PATCH failure in `AppConfirmationUI.apply_outcome` is logged, not surfaced — the owner's conversational follow-up ("confirmed"/"cancelled") isn't currently conditioned on the wire PATCH actually succeeding. Known trade-off, not fixed in this PR.

## Test plan
- [ ] Restart staging
- [ ] On-device: trigger a destructive tool from the app, confirm — tool runs, phone shows resolved state, app-thread follow-up (not Telegram)
- [ ] On-device: trigger again, cancel — tool does not run, state resolves to `cancelled`
- [ ] On-device: let one sit past TTL — sweep PATCHes `expired`
- [ ] Double-tap quickly — hub's own 422 `already_resolved` fires before a duplicate `ActionUpdate` reaches the bot
- [ ] Telegram regression — confirmation flow unchanged

https://claude.ai/code/session_01TcKHUrthfLzuzdFDBm5N1s