### PR TITLE
feat(jarvis-app): emit the thinking heartbeat while a turn runs

### DIFF
--- a/docs/architecture/channels/jarvis-app/contract.md
+++ b/docs/architecture/channels/jarvis-app/contract.md
@@ -6,7 +6,7 @@
 JSON Schema plus the endpoint list, generated from the Pydantic models and
 the mounted routes under `backend/jarvis_app_backend`.
 
-`contract_version`: `b124f103398748df`
+`contract_version`: `45e79b46aed20391`
 
 ## Endpoints
 
@@ -522,7 +522,7 @@ the mounted routes under `backend/jarvis_app_backend`.
 ```json
 {
   "additionalProperties": false,
-  "description": "An ephemeral event the agent relays to the client's stream \u2014 a tool chip\nor a stream delta (architecture \u00a75 SSE catalog). Never persisted and carries\nno cursor, so the stream frames it without an `id:` line.\n\n`type` is strict: an unknown one is a 422, not a mystery event relayed to the\nphone. It admits the whole catalog, not only the two tool-chip kinds a first\nagent sends \u2014 the agent, not the hub, chooses which to emit, and each is a\nworking relay end to end. `data` is opaque: the hub carries the chip's shape,\nit does not interpret it.",
+  "description": "An ephemeral event the agent relays to the client's stream \u2014 a tool chip,\na stream delta, or the \"thinking\" heartbeat (architecture \u00a75 SSE catalog).\nNever persisted and carries no cursor, so the stream frames it without an\n`id:` line.\n\n`type` is strict: an unknown one is a 422, not a mystery event relayed to the\nphone. It admits the whole catalog, not only the two tool-chip kinds a first\nagent sends \u2014 the agent, not the hub, chooses which to emit, and each is a\nworking relay end to end. `data` is opaque: the hub carries the chip's shape,\nit does not interpret it \u2014 `agent_thinking`'s own `ttl_ms` included.",
   "properties": {
     "data": {
       "additionalProperties": true,
@@ -534,7 +534,8 @@ the mounted routes under `backend/jarvis_app_backend`.
         "tool_call_started",
         "tool_call_result",
         "agent_stream_delta",
-        "agent_message_final"
+        "agent_message_final",
+        "agent_thinking"
       ],
       "title": "Type",
       "type": "string"

--- a/gateway/channels/jarvis_app/client.py
+++ b/gateway/channels/jarvis_app/client.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 # The version the adapter was written against. The hub reports its own
 # contract_version on GET /v1/health; a mismatch is logged, never fatal — the hub
 # already 422s a malformed payload, so this only gives a *silent* skew a voice.
-PINNED_CONTRACT_VERSION = "b124f103398748df"
+PINNED_CONTRACT_VERSION = "45e79b46aed20391"
 
 # The hanging poll's server-side wait. The client read timeout sits a little above
 # it so a genuinely dead connection eventually errors instead of hanging forever.
@@ -207,6 +207,16 @@ class HubClient:
         except httpx.HTTPError as e:
             raise HubUnavailable(str(e)) from e
         return True
+
+    async def post_event(self, event_type: str, data: dict) -> None:
+        """Relay one ephemeral event to the client's stream. Never persisted and
+        carries no cursor, so nothing comes back to correlate — hence no
+        HubUnavailable translation and no 404 handling: there is no parked state
+        to miss and no retry question, the caller's next event is the retry."""
+        r = await self._client.post(
+            "/bot/v1/events", json={"type": event_type, "data": data}
+        )
+        r.raise_for_status()
 
     async def declare_apps(self, apps: list[dict]) -> None:
         """Publish the app manifest to the hub so the app can draw its Apps

--- a/gateway/channels/jarvis_app/router.py
+++ b/gateway/channels/jarvis_app/router.py
@@ -35,6 +35,21 @@ logger = logging.getLogger(__name__)
 _BACKOFF_START_S = 1.0
 _BACKOFF_MAX_S = 60.0
 
+# The "Jarvis is thinking" indicator is driven entirely by these beats: the
+# client draws the row while they keep arriving and retires it once `ttl_ms` has
+# passed since the last one. Nothing on the wire says "done" — a turn's end is
+# left to speak for itself, so an agent killed mid-turn is discovered exactly the
+# way a healthy one's silence is.
+#
+# The TTL is ~2.5x the cadence, and the ratio is the point: at 1x a single slow
+# or dropped beat would hide the row mid-turn, so the indicator would flicker on
+# ordinary jitter rather than only on a genuinely dead turn. `ttl_ms` rides on
+# every beat instead of being a value the client also hardcodes — the two sides
+# share no code, so a duplicated constant would drift silently. Change the
+# cadence and the TTL together, keeping the ratio.
+_THINKING_INTERVAL_S = 4.0
+_THINKING_TTL_MS = 10_000
+
 # The hub pins attachment ids to this shape. The id names the cache file, so a
 # value that doesn't match is rejected before it can reach a filesystem path.
 _ATT_ID_RE = re.compile(r"^att_[0-9A-HJKMNP-TV-Z]{26}$")
@@ -313,9 +328,36 @@ class JarvisAppInboundRouter:
             user_text=text,
             attachments=attachments,
         )
-        reply = await self._on_message(inbound)
-        if reply:
-            await self._channel.send(self._channel.owner_thread_id, reply)
+        beat = asyncio.create_task(self._thinking_beat())
+        try:
+            reply = await self._on_message(inbound)
+            if reply:
+                await self._channel.send(self._channel.owner_thread_id, reply)
+        finally:
+            # The beat exists only for the life of the turn — including the one
+            # that raised, where a surviving task would report a dead agent as
+            # still thinking.
+            beat.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await beat
+
+    async def _thinking_beat(self) -> None:
+        """Beat while a turn runs, so the app can show its thinking indicator.
+
+        Beats before the first sleep: the client learns a turn started right
+        away rather than one cadence in. Each failure is caught and the loop
+        continues — a beat that stops is precisely how the client reports *the
+        agent died*, so letting one transient POST failure end the loop would
+        make a healthy agent look dead. The next cadence is the retry.
+        """
+        while True:
+            try:
+                await self._client.post_event(
+                    "agent_thinking", {"ttl_ms": _THINKING_TTL_MS}
+                )
+            except Exception as exc:
+                logger.warning("jarvis-app thinking beat failed: %s", exc)
+            await asyncio.sleep(_THINKING_INTERVAL_S)
 
     async def _download_attachments(self, raw: list[dict]) -> list[dict]:
         """Download each inbound attachment to the channel-owned cache and return


### PR DESCRIPTION
Agent-side half of the app's "Jarvis is thinking" indicator. The client draws the row while beats keep arriving and retires it once `ttl_ms` has passed since the last one; until now the app channel emitted no beat, so against the real agent the indicator never appeared — every client slice was built against the app repo's `fake_agent`.

**Additive on both sides.** An agent that never sends `agent_thinking` keeps working exactly as before, so this is not a breaking co-deploy.

## Changes

- `HubClient.post_event` — modelled on `declare_commands`/`declare_apps`: plain `post` + `raise_for_status`. Deliberately skips `post_app_result`'s 404 handling; there is no parked state to miss and no retry question.
- The beat in `JarvisAppInboundRouter._handle` — a task around `_on_message`, cancelled in `finally`.
- Contract mirror + `PINNED_CONTRACT_VERSION` refreshed to `45e79b46aed20391` for the hub's new `BotEvent.type` value.

## Two deliberate divergences from `keep_typing`

The Telegram router's `keep_typing` is the right shape and the wrong error policy — it has no `try`/`except`, so a failed action kills the task and the turn survives by task *isolation*, not swallowing.

1. **Catch per iteration, keep going.** A stopped beat is precisely how the client reports *the agent died*. Copied faithfully, one transient POST failure would make a healthy agent look dead for the rest of the turn.
2. **Beat before the first sleep**, so the client learns a turn started right away rather than one cadence in.

## Why no "done" event

Nothing on the wire says done. The beat self-retires by stopping, so an agent killed mid-turn is discovered exactly the way a healthy one's silence is — no timeout to guess, nothing hub-side that has to notice a death. An end event would create a state the client must reconcile against the reply it already handles.

`ttl_ms` rides on every beat rather than being a constant the client also hardcodes: the two repos share no code and no CI, so a duplicate would drift silently. It is ~2.5x the 4s cadence so ordinary jitter can't flicker the row — change one and change the other.

## Verification

Against fakes (this repo has no test suite):

| case | result |
|---|---|
| healthy turn | beats at cadence, payload `("agent_thinking", {"ttl_ms": 10000})`, reply sent, no task left behind |
| **every beat POST fails** | still beats to the end, turn still replies normally |
| turn raises | propagates, `finally` still cancels |
| non-message update | no beats — none outside a turn |

All three `scripts/ci/` guards pass; `import main` clean.

**Not yet proven on staging.** The app repo's `phase/thinking` runs `jarvis-deploy-stage` once this lands; the staging agent needs updating before that prove.