### PR TITLE
Travel tile: DTO-safe payload, and archive the travel plans

### DIFF
--- a/docs/plans/TRAVEL_APP_HANDOFF.md
+++ b/docs/plans/TRAVEL_APP_HANDOFF.md
@@ -91,6 +91,50 @@ A real response, trimmed to the populated days plus one empty one.
 }
 ```
 
+### Nullability — every field, so a DTO can be written from this
+
+Anything not listed as nullable is **always present and non-null**. Arrays are always present and
+may be empty.
+
+| Always present | Nullable |
+|---|---|
+| `trip.trip_id` · `destination` · `destination_name` · `timezone` · `status` · `is_current` · `today` · `position` | `trip.country` · `notes` · `start_date` · `end_date` |
+| `days[].date` · `outside_window` · `is_today` · `items` | `days[].day_number` |
+| item `entry_id` · `item_type` · `title` · `start_date` · `crosses_midnight` · `role` | item `end_date` · `start_time` · `end_time` · `from_location` · `to_location` · `confirmation_code` · `notes` · `place` |
+| `place.place_id` · `title` | `place.address` · `maps_url` · `lat` · `lng` · `category` · `type_label` |
+| wishlist group `category` · `items`; item `wishlist_id` · `title` · `priority` | wishlist item `place_id` · `city` · `address` · `maps_url` · `lat` · `lng` · `type_label` · `notes` |
+
+Two that look nullable and are not:
+
+- **`trip.destination` is never null.** It is the trip's own title when it has one and the
+  destination's name otherwise, and a destination's name cannot be null. The comment in the sample
+  says where the value comes from, not that it can be absent.
+- **`role` is on `lodging` entries too**, as `"stay"`. Both arrays carry the same item shape, so one
+  type reads both. A stay is never placed inside a day, which is what `"stay"` says.
+
+### `position: "undated"` — a real state, and what it looks like
+
+A trip exists before its dates do; that is the "someday bucket" the wishlist is for. The payload:
+
+```json
+{ "trip": { "trip_id": "someday", "destination": "Somewhere",
+            "start_date": null, "end_date": null,
+            "timezone": "Asia/Tokyo", "position": "undated", "…": "…" },
+  "days": [], "lodging": [], "wishlist": [ … ] }
+```
+
+So: **no date range to draw, no strip, no day to open on.** The itinerary tab has nothing to show
+and cannot have — scheduling into an undated trip is refused agent-side.
+
+Suggested rendering, though this is the client's call:
+
+- Header shows the destination with "no dates yet" in place of the range.
+- **Open on the wishlist tab**, since it is the only one with content.
+- The itinerary tab, if reachable, says the trip needs dates and that they can be set in chat.
+
+The "pick the day to open on" rule in the notes below therefore applies only to `before`, `during`
+and `after`.
+
 ### Field notes that matter for rendering
 
 - **`trip` may be `null`** — no trip is pinned. A legitimate empty state, not an error.

--- a/docs/plans/archive/TRAVEL_APP_HANDOFF.md
+++ b/docs/plans/archive/TRAVEL_APP_HANDOFF.md
@@ -1,7 +1,8 @@
 # Handoff — Travel app screen (`roiguri/jarvis-app`)
 
-**For:** the Android client. **Agent side is shipped**: `travel` is declared in the manifest and
-`GET tile` answers today.
+**For:** the Android client. **Agent side is shipped and merged** (#77): `travel` is declared in
+the manifest and `GET tile` answers today. This document is archived alongside the plan it came
+from, but it is **live for the client work** — it describes an endpoint that is running.
 **Written from the payload that actually ships**, not from a design sketch — sample below is a real
 response, trimmed to two populated days plus one empty one.
 **Source of truth for the data:** `gateway/apps/travel.py` in `roiguri/jarvis-agent`. If this

--- a/docs/plans/archive/TRAVEL_PLAN.md
+++ b/docs/plans/archive/TRAVEL_PLAN.md
@@ -1,6 +1,7 @@
 # Travel — trip planning skill, and the app tile derived from it
 
-**Status:** designed, not started.
+**Status:** SHIPPED — merged to main in #77 (2026-08-06). Archived; kept for the reasoning behind
+the decisions, not as a live plan. Multi-destination is deferred and tracked in issue #76.
 **Date:** 2026-08-05.
 **Goal:** let the owner plan and run a trip through conversation — save places, keep a per-trip
 wishlist, build a dated itinerary — and render the result as a tile in the jarvis-app. Jarvis's

--- a/docs/plans/archive/TRAVEL_TARGET_STATE.md
+++ b/docs/plans/archive/TRAVEL_TARGET_STATE.md
@@ -1,8 +1,8 @@
 # Travel — target state
 
-**Status:** specification. The current build is Phases 1–3 plus Stage 0; this describes where the
-next work lands. Rationale lives in `TRAVEL_PLAN.md`, which also carries the staged route from one
-to the other.
+**Status:** SHIPPED — this describes what was built, not what was planned. Merged in #77
+(2026-08-06) and archived. The code is the source of truth; where this and the code disagree, the
+code is right. Rationale lives in `TRAVEL_PLAN.md` alongside it.
 
 **Scope:** one destination per trip. A destination may be a city or a country, and carries the
 trip's timezone. A country is **preferred where it applies** — it holds every city's places under

--- a/gateway/apps/travel.py
+++ b/gateway/apps/travel.py
@@ -154,7 +154,10 @@ def _tile_sync(trip_id: str) -> dict[str, Any]:
             (tid,),
         ).fetchall()
 
-        lodging = [_entry(r) for r in rows if r["item_type"] == "lodging"]
+        # `role` on every item, including these, so one client type reads both
+        # arrays. A stay is not placed in a day at all, which is what "stay"
+        # says — the other roles all describe a position within one.
+        lodging = [dict(_entry(r), role="stay") for r in rows if r["item_type"] == "lodging"]
 
         # Every day of the trip, plus every day any item touches — so an empty
         # middle day still gets a chip, and a day an item merely arrives on is

--- a/scripts/test_travel.py
+++ b/scripts/test_travel.py
@@ -1071,12 +1071,34 @@ def test_tile() -> None:
           str(d["wishlist"][1]["items"][0]),
           contains=["go at dawn", "Coffee Shop"])
 
+    section("travel tile — the shapes a client parses against")
+
+    check("lodging carries a role too, so one type reads both arrays",
+          str([x["role"] for x in d["lodging"]]), contains="stay")
+
+    check("every item everywhere has a role",
+          "ok" if all("role" in i for day in d["days"] for i in day["items"])
+          and all("role" in x for x in d["lodging"]) else "missing", contains="ok")
+
+    check("and a title, so nothing renders blank",
+          "ok" if all(i["title"] for day in d["days"] for i in day["items"]) else "missing",
+          contains="ok")
+
     section("travel tile — empty states are not errors")
 
     d0 = tile(trip_id="it0")
     check("an undated trip returns a trip with no days, not an error",
           f"{d0['trip']['trip_id']} days={len(d0['days'])} pos={d0['trip']['position']}",
           contains=["it0", "days=0", "undated"])
+
+    # The client has to render this, so its shape is pinned: no range to draw,
+    # no strip, and a timezone that is present regardless.
+    check("its dates are null rather than absent, and the timezone still resolves",
+          f"{d0['trip']['start_date']} {d0['trip']['end_date']} {d0['trip']['timezone']}",
+          contains=["None None", "Europe/Lisbon"])
+
+    check("the trip's display name is never null, even with no title",
+          "ok" if d0["trip"]["destination"] else "null", contains="ok")
 
 
 def test_crossing_timezones() -> None:


### PR DESCRIPTION
Follow-up to #77, from questions the app developers raised while writing the
client.

## The payload fix

**`role` was missing from `lodging[]`.** Every item in `days[]` carries it; the
banner entries did not. A client sharing one type across both arrays fails to
parse the banner — in Kotlin a missing non-nullable field throws and the whole
payload is lost, so the screen reads "Jarvis sent something this app could not
read" rather than showing a trip with one detail absent. Lodging now carries
`role: "stay"`, which is also the honest value: every other role describes a
position within a day, and a stay is never placed in one.

**A nullability table**, covering every field. That distinction is exactly what
a DTO encodes and the document had left it to inference. Two fields that read
as nullable and are not are called out — `trip.destination` is the trip's title
or the destination's name, and neither can be null.

**`position: "undated"` is specified.** A trip exists before its dates do; that
is what the wishlist is for. It renders into a screen nobody had described: no
range in the header, no strip, no day to open on, and an itinerary tab that
cannot have content because scheduling into an undated trip is refused
agent-side. The "which day to open on" rule is now scoped to the other three
values.

Three tests pin the shapes a client parses against. 211 checks.

## The archiving

The agent side is complete, so the plan, the target state and the handoff move
to `docs/plans/archive/`. Each carries a status line saying what it now is —
the plan is kept for the reasoning rather than the checklist, and the target
state says the code wins where they disagree.

The handoff is archived **but not finished**: it describes a running endpoint
and the Android client has not been written. Its header says so, since a
document in an archive folder otherwise reads as superseded. Its URL moves as a
result, which matters — the old path was shared with the app developers today:

`docs/plans/archive/TRAVEL_APP_HANDOFF.md`

https://claude.ai/code/session_01RdXUG9jwvgS2yu4VPjiNer