### PR TITLE
Add fetch_url and move web_search into a shared `web` skill

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -56,9 +56,12 @@ GOOGLE_HEALTH_REFRESH_TOKEN=...    # minted once — see tools/google_health/SET
 
 Sonarr/Radarr/Prowlarr API keys: **Settings → General → API Key** in each web UI.
 Jellyseerr: **Settings → General → API Key**. Tavily: sign up at
-https://app.tavily.com — free "Researcher" plan, 1,000 credits/month, 1 credit per
-search, no card. On quota exhaustion `web_search` returns a graceful error telling
-Jarvis to fall back to training knowledge rather than failing.
+https://app.tavily.com — free "Researcher" plan, no card. One shared 1,000-credit
+monthly balance across all endpoints: 1 credit per `web_search`, and 1 credit per
+*five* URLs for `fetch_url` (both `web` skill tools use the same key). On quota
+exhaustion each returns a graceful error — `web_search` tells Jarvis to fall back to
+training knowledge; `fetch_url` tells it to say it could not read the page, never to
+guess the content.
 
 GitHub: generate a **classic** Personal Access Token at GitHub → Settings →
 Developer settings → Tokens (classic), with the **repo** scope. Without

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ list below is the set that exists **today**, not a fixed ceiling:
 
 | Tool group | What it does |
 |------------|--------------|
-| **Core** (always on) | Long-term memory, web search, reminders/scheduling, chat history |
+| **Core** (always on) | Long-term memory, reminders/scheduling, chat history |
+| **Web** (skill) | Search the web; read the page at a URL |
 | **Media** (skill) | Search, request, and manage TV/movies across Sonarr, Radarr, Prowlarr, Jellyseerr; aggregated download-ready notifications from webhooks |
 | **Fitness** (skill) | Gym class schedule/booking (Arbox), workout & running logging |
 | **Health** (skill) | Sleep, workouts, resting HR, and HRV from a Pixel Watch (Google Health) |

--- a/docs/architecture/RUNTIME.md
+++ b/docs/architecture/RUNTIME.md
@@ -38,7 +38,6 @@ A small set (~9 tools) used in nearly every conversation. Full JSON schemas are 
 | Module (`tools/core/`) | Tools | Notes |
 |---|---|---|
 | `memory.py` | `read_memory`, `write_memory`, `list_memory`, `delete_memory` | `delete_memory` is `destructive` → confirmation. |
-| `search.py` | `web_search` | |
 | `history.py` | `get_chat_history`, `get_notification_history` | Read-only recall. See "The notification question" below. |
 | `scheduling.py` | `manage_reminder` | create / list / delete reminders. |
 | `activate_skill.py` | `activate_skill`, `deactivate_skill` | The meta-tools that expose Tier 2. |
@@ -55,6 +54,7 @@ Tools grouped by **namespace**. A namespace is a skill — and a namespace may b
 | `media/prowlarr` | `tools/media/prowlarr/` | Indexer search: `search_prowlarr`. |
 | `media/jellyseerr` | `tools/media/jellyseerr/` | Requests: `search_jellyseerr`, `get_jellyseerr_requests`, `request_media`. |
 | `media/system` | `tools/media/system/` | Stack health / overview: `get_library_overview`, `get_media_system_health`. |
+| `web` | `tools/web/` | `web_search`, `fetch_url`. Grouped deliberately: search bound without fetch is what made a turn search 14 times for a URL it could not look up (#7). |
 | `fitness` | `tools/fitness/` | Arbox + training: `manage_fitness_plan`, `fetch_upcoming_arbox_classes`, `fetch_weekly_gym_schedule`, `sync_arbox_attendance`, `log_exercise_stats`, `log_running_session`, `log_wod_result`, `query_exercise_history`, `get_today_workout_id`, `get_weekly_fitness_summary`, `get_adherence_report`, `query_fitness_db` (read-only ad-hoc SQL). |
 
 ⚠ = `destructive`. **No `home` placeholder** — namespaces are added when their tools exist, not before. The registry is extensible: a new top-level skill is a new directory plus `namespace="<name>"` on its tools; a new sub-skill is a `tools/<parent>/<child>/` subpackage plus `namespace="<parent>/<child>"`. Nothing else.

--- a/docs/plans/URL_FETCH_PLAN.md
+++ b/docs/plans/URL_FETCH_PLAN.md
@@ -1,0 +1,486 @@
+# URL fetch — give Jarvis a way to read a link
+
+**Status:** planned, not started.
+**Date:** 2026-08-06.
+**Goal:** add a `fetch_url` core tool so a URL handed to Jarvis is *dereferenced* rather than
+guessed at, and close the loop that let a single unreadable link cost 4m44s and ~$0.36 in one turn.
+
+---
+
+## Context
+
+On 2026-08-06 the owner sent a bare `x.com` status URL with "add this as well". Turn
+`b068e543` ran **283.7 s**, made **16 LLM calls** and **14 consecutive `web_search` calls**, burned
+**494,962 input / 65,994 output tokens** (64,321 of them reasoning) — ~10× the median user turn
+(~59k total) and the 3rd most expensive user turn in two weeks. It then wrote a **fabricated**
+description into `reading_list.md` and reported success confidently. The owner corrected it in the
+next turn.
+
+The root cause is not prompt tuning. `tools/core/search.py` exposes `web_search(query: str)` —
+Tavily *search* — and it is the only web capability in the tree. There is no way to read a URL.
+Given an address, the only available move is to invent a query, and for a numeric status ID that
+is structurally hopeless.
+
+Two properties made it expensive rather than merely wrong:
+
+1. **`web_search` cannot fail.** Every path in `search.py` returns a string; a search that finds
+   nothing relevant still returns `status: ok` and five plausible results. Nothing tells the model
+   to stop, so it reformulated 14 times, each result adding tokens and plausibility-noise.
+2. **Nothing bounded the retry.** The 14 searches took ~60 s; the remaining **3m39s** was a single
+   LLM call thinking in circles after the searches produced nothing usable.
+
+Then it anchored: the previous link in the thread was a Matt Pocock tweet, so the unknown tweet
+became "another one from Matt Pocock."
+
+### Audit of what this already cost in stored memory
+
+All three `x.com` entries in `reading_list.md`, resolved for real during planning:
+
+| ID | Actual | What Jarvis stored |
+|---|---|---|
+| `…286118` | **Norvex** (@norvex1029) — "Anthropic just published the official guide to building a knowledge graph with Claude…" | "Matt Pocock, /writing-for-agents deep dive" → corrected by the owner to "Anthropic — Graph Engineering" |
+| `…012992` | **Matt Pocock** — skills v1.2 (`/wait-what`, `/writing-for-agents`, `/grill-me`) | correct |
+| `…296679` | **Lunar** (@LunarResearcher) — summarizing Karpathy's "5 shifts turning LLMs into agentic systems" | "Andrej Karpathy on LLMs vs Agents" — wrong author |
+
+Two of three are misattributed, and even the owner's correction is off (that tweet is *about* an
+Anthropic guide, not *by* Anthropic). The one it got right is the one whose text
+("mattpocock/skills v1.2") happens to be a searchable string — which is the tell: search succeeded
+exactly where the content was guessable. **Fixing these entries is part of this work, not a
+follow-up.**
+
+---
+
+## Evidence gathered during planning
+
+Measured directly against live hosts (plain `httpx` GET with a Chrome-like UA; Tavily `extract`
+via the existing client and key):
+
+| Host | plain GET | readable text | `og:description` | Tavily `extract` |
+|---|---|---|---|---|
+| `x.com/i/status/…` | 200, 168 KB | **0 KB** (JS shell) | yes | **3,012 chars — full tweet + author** |
+| `openai.com/index/…` | **403** | — | — | **24,002 chars** |
+| `reddit.com/r/LocalLLaMA` | 200, 8 KB | **0 KB** | no | 8,860 chars, mostly nav |
+| `youtube.com/watch?v=…` | 200, 1.3 MB | **0 KB** | yes | not tested |
+| `github.com/…/langgraph` | 200, 292 KB | 7 KB | yes | not tested |
+| `arxiv.org/abs/…` | 200, 43 KB | 4 KB | yes | 1,946 chars |
+| `internet-israel.com` | 200, 125 KB | 5 KB | yes | not tested |
+
+Three conclusions:
+
+- **A plain GET is not enough.** It fails on x.com, openai.com (403 — a URL *already in the reading
+  list*), reddit, and youtube. Bot-blocking and JS rendering are the norm, not the exception.
+- **Tavily `extract` rescues every failing case tested**, including the exact URL from the incident.
+  It returns the tweet body and the author handle. Same client, same `TAVILY_API_KEY` — **no new
+  dependency and no new secret.**
+- **Therefore no per-host adapter is required.** An earlier sketch in discussion proposed an
+  x.com/Twitter oEmbed special case. `publish.twitter.com/oembed` does work unauthenticated and
+  resolved all three tweets cleanly, but Tavily `extract` already covers x.com, so oEmbed was only
+  ever an optimization — and once Q1 removed local fetching altogether it stopped making sense at
+  all. Dropped; see Phase 3 for the reasoning, kept so it is not re-proposed.
+
+A caution about all Tavily measurements here: **Tavily caches server-side** (measured: 1.31 s →
+0.47 s → 0.18 s on repeat calls, byte-identical). Any A/B probe against a URL fetched earlier in
+the session will silently compare two cache hits. The depth comparison under N1 controls for this;
+naive re-measurement will not.
+
+---
+
+## References — OpenClaw and hermes-agent
+
+Both references solve this problem, and they converge. Following the comparison format of
+[CONTEXT_HANDLING_PLAN.md §Mechanisms](CONTEXT_HANDLING_PLAN.md):
+
+| Mechanism | OpenClaw | hermes-agent | Jarvis today |
+|---|---|---|---|
+| Search / fetch split | `web_search` + `web_fetch`, **two tools** | `web_search` + `web_extract`, **two tools** | `web_search` only — **no way to read a URL** |
+| Grouping | web tools together | **`web` toolset**, gated on credentials | `web_search` in always-on `core` |
+| Extraction | Readability (Mozilla) on HTML → markdown/text | Provider-side extraction, markdown, **no LLM summarization** | n/a |
+| Provider fallback | Readability → **Firecrawl** bot-circumvention mode | Backend chain: **Tavily → Exa → Parallel → Firecrawl → SearXNG → Brave → DDGS**; Firecrawl default | n/a |
+| Truncation | `maxChars` default **20,000**, cap 50,000; body cap 750 KB | `web.extract_char_limit` default **15,000**; head+tail **~75/25** with `[TRUNCATED]` footer pointing at the full file on disk; absolute cap 2 MB | n/a |
+| JS pages | explicitly **not** executed — punted to a separate headless browser tool | provider's problem (Firecrawl renders) | n/a |
+| Per-host special cases | **none** | **none documented** | n/a |
+| URLs per call | 1 | **max 5** | n/a |
+| Caching | 15 min, configurable | not documented | n/a |
+| SSRF | private/internal hostnames blocked by default; headers redacted from debug captures | not documented | n/a |
+
+**The two answers that matter most for the open questions below:**
+
+1. **Neither has per-host special cases.** Both tier by *capability* — plain fetch → extraction →
+   bot-circumvention provider → (OpenClaw only) headless browser. Any host lands in whichever tier
+   can read it. That generalizes; an adapter list does not. This is the direct answer to "do we
+   only need a special case for x?" — no, and neither reference has *any*.
+2. **Hermes groups them in a `web` toolset**, which independently confirms the scope decision taken
+   in this plan. Its `web_extract` also takes **up to 5 URLs per call**, which Jarvis should not
+   copy yet (see Open Questions).
+
+Note also the internal precedent: `CONTEXT_HANDLING_PLAN.md` WS4 already adopts Hermes's head/tail
+truncation marker (`[... truncated N chars — file intact on disk ...]`) for injected files. The
+same marker shape should be reused here rather than inventing a second one.
+
+Sources: [Web fetch · OpenClaw](https://docs.openclaw.ai/tools/web-fetch),
+[Web Tools | OpenClaw Docs](https://openclaw-ai.com/en/docs/tools/web),
+[Web Search & Extract | Hermes Agent](https://hermes-agent.nousresearch.com/docs/user-guide/features/web-search),
+[hermes-agent tools reference](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/reference/tools-reference.md)
+
+**What this plan takes from them:** the two-tool split, the `web` grouping, capability tiering with
+no per-host adapters, and mandatory truncation. **What it does not take:** OpenClaw's headless
+browser (capability-surface expansion, ruled out under the sandbox constraint) and Hermes's
+provider-abstraction layer (seven backends is infrastructure for a distributed user base; Jarvis
+has one Tavily key and one owner).
+
+---
+
+## Decisions carried in from discussion
+
+- **`web_search` and `fetch_url` share one activatable skill — `tools/web/`.** They are two halves
+  of one capability (find a page / read a page) and belong to the same namespace. This *reverses*
+  an earlier draft decision that `fetch_url` should be a core tool; see "Tool scope" below for the
+  argument and the measurement that made the reversal safe.
+- **[Q1 — decided] Provider-only extraction, the hermes-agent way.** `fetch_url` never makes an
+  outbound HTTP request of its own; it hands the URL to Tavily `extract` and returns the markdown.
+  This *reverses* the draft's local-fetch-then-fallback design (OpenClaw's shape). Rationale:
+  - Measured, a plain GET returns **zero readable text** on x.com, reddit and youtube and a **403**
+    on openai.com. The "free path" only pays off on the well-behaved minority, so local-first buys
+    much less than it appears to.
+  - It removes the SSRF guard — the single most security-sensitive piece of the plan — because a
+    URL naming `192.168.x.x` is fetched from Tavily's infrastructure, which cannot reach the home
+    LAN. Phase 1 drops from ~150 lines to ~40.
+  - No new dependency, and no HTML parsing in-process.
+  - **Confirmed cheaper than the status quo** — see the credit arithmetic below.
+- **No per-host adapters in Phase 1.** Justified by the measurement above, not by taste, and
+  matching both references (neither has any).
+- **The error path matters more than the happy path.** A clean "could not read this" is the whole
+  point; it is what bounds the loop. Phase 4 exists to make the model *act* on it.
+- **Truncation is mandatory, not a nicety.** An uncapped fetch of that x.com page is 168 KB — one
+  call would cost more context than the 14 searches did.
+- **Accepted trade-off:** reading a link now depends on Tavily being reachable. A Tavily outage
+  costs Jarvis both search *and* fetch. Judged acceptable for a single-owner assistant; it is also
+  the failure mode Hermes accepts by default.
+
+### Tavily credit arithmetic (resolves the draft's biggest unknown)
+
+| Operation | Credits | Per single URL/query |
+|---|---|---|
+| Search, basic | 1 per request | **1.0** |
+| Search, advanced | 2 per request | 2.0 |
+| **Extract, basic** | **1 per 5 successful URLs** | **0.2** |
+| Extract, advanced | 2 per 5 successful URLs | 0.4 |
+
+Failed extractions are **never charged**. Free tier: **1,000 credits/month**.
+
+**A basic extract is 5× cheaper than a single search.** The incident turn spent **14 credits**
+searching and still got the answer wrong; one `fetch_url` would have spent **0.2** and got it
+right — **70× cheaper**, before counting the ~$0.36 of model tokens it also burned. Current usage
+(53 searches in ~17 days ≈ 95 credits/month) sits far inside the free tier, and adding fetches at
+0.2 each does not threaten it. The draft's worry that provider-only fetching would be expensive was
+backwards: **it is the cheapest option on the table.**
+
+Sources: [Credits & Pricing — Tavily Docs](https://docs.tavily.com/documentation/api-credits)
+
+---
+
+## Tool scope — one `web` skill holding both tools
+
+`web_search` lives in `tools/core/` today (always bound). It moves into a new `tools/web/` skill
+alongside `fetch_url`, so the pair is activated and deactivated together.
+
+**Why together, rather than `fetch_url` in core:** the incident was caused by an *asymmetry* — the
+model had search available and fetch unavailable, so when it needed to read a URL it reached for
+the only web-shaped tool in reach and searched 14 times. Binding the two into one namespace makes
+that state unreachable: either both are available or neither is. There is no configuration in
+which the model can substitute search for a fetch it cannot perform.
+
+**Measurement that makes this safe** (`tool_calls.jsonl` joined to `turns.jsonl`, since 2026-07-20):
+
+- `web_search`: **53 calls across 20 turns, 100% in `user` scope — zero in `heartbeat`.**
+  So gating it behind activation costs the heartbeat nothing. This was the main risk and it is
+  empirically absent.
+- Activation is **sticky per thread** (`active_skills` persists in thread state — the incident turn
+  itself ran with `active_skills: ["fitness"]` carried in). So the cost is one extra `activate_skill`
+  round-trip on the first web-shaped request in a thread, not per turn. Against 14 wasted searches,
+  that trade is not close.
+- `compact_skill_list` always renders every top-level skill's one-line description, so the model
+  can always *see* that a `web` skill exists — activation is discoverable, not hidden.
+
+**Naming:** `web` rather than `search`, since the skill contains a reader as well as a searcher and
+the namespace is what the model reads in the skill list. Flat namespace, no sub-skills — two tools
+does not justify the two-step discovery machinery.
+
+**Residual risk to watch in staging:** a turn where the model answers from training knowledge
+instead of activating `web`. AGENTS.md line 6 currently leans on search being always-on ("Use web
+search proactively…"); that line has to be rewritten to say *activate `web` and search* or the
+nudge points at a tool that is not bound. Phase 2 covers it.
+
+## Phase 1 — the `web` skill
+
+**New directory `tools/web/`** containing:
+
+- `__init__.py` — imports both modules, running the `@tool_register` side-effects
+- `SKILL.md` — YAML frontmatter (`name: web`, `description:`) plus a short rules body: *use
+  `fetch_url` for any URL; never try to identify a link by searching for it; if a fetch fails, say
+  so rather than guessing*
+- `search.py` — **moved** from `tools/core/search.py`, `namespace="core"` → `namespace="web"`,
+  otherwise unchanged
+- `fetch.py` — new
+
+Per CLAUDE.md that is the entire wiring — the registry auto-discovers the namespace from the
+directory. No registry, agent, or prompt-assembly edits.
+
+**Callers/docs to update in the same change** (all references to search being always-on):
+`prompts/AGENTS.md` lines 4 and 6, `README.md:78`, `docs/architecture/RUNTIME.md:41`,
+and the CLAUDE.md core-tools description.
+
+Pipeline (Q1 = provider-only):
+
+```
+fetch_url(url, max_chars=8000) →
+  1. validate   scheme in (http, https); reject everything else
+  2. extract    TavilyClient.extract(urls=[url], format="markdown")   # basic depth
+  3. empty?     no results → return a plain, unambiguous failure string
+  4. truncate   to max_chars, reusing the CONTEXT_HANDLING_PLAN marker shape
+  → returns: final URL, title, text  |  or a clear "could not read" string
+```
+
+No `httpx` call, no HTML parsing, **no SSRF guard** — Jarvis never dereferences the URL itself.
+Scheme validation stays so that `file://` and friends fail fast and locally rather than being
+handed to a third party.
+
+House pattern to follow: `tools/core/search.py` — one `try`, a typed-exception ladder
+(`UsageLimitExceededError`, `InvalidAPIKeyError`, `MissingAPIKeyError`), and a helpful string on
+every failure rather than a raise. `fetch.py` should mirror it almost line-for-line, since the two
+tools now sit in the same skill and share a client and a key.
+
+**Dependencies:** none. `tavily-python==0.7.24` is already in `requirements.txt` and already ships
+`extract()`.
+
+Estimate: **~40 lines.**
+
+## Phase 2 — bound the failure
+
+Three changes that matter even after Phase 1, because a fetch that fails will otherwise send the
+model straight back to `web_search` for another 14 rounds.
+
+- **[Q5 — decided] Input-shape guard in `web_search`.** Detect a query that is a URL or a bare long
+  digit string and return, without searching:
+  *"That looks like a URL or an ID, not a search query. Use `fetch_url` to read it directly."*
+  Deterministic, nothing to tune, and it catches the incident's exact shape. See "Routing" below
+  for why this is a *code* guard rather than a prompt rule.
+- **Repeat-call cap in `tools/registry.py`.** Cap identical-tool calls per turn (~5), then return a
+  hard stop: *"you have called `web_search` 5 times without success; stop and report what you could
+  not determine."* Uses the existing per-turn context (`turn_context.py`). This is the single
+  highest-leverage change in the plan — it bounds cost for *every* tool, not just this one.
+  The guard stops the *first* wrong search; the cap stops the *fourteenth*.
+- **A URL rule in `prompts/AGENTS.md`** (currently 26 lines, zero mentions of links/URLs), plus the
+  rewrite of line 4 and line 6 that the `web` skill move forces anyway.
+
+### Rejected: a relevance-score threshold on `web_search`
+
+Recorded so it is not re-proposed. The idea was to return "no relevant results" when Tavily's
+scores are all low. **Measured, it fails on exactly the case it was meant to catch:**
+
+| Query | Top score | What came back |
+|---|---|---|
+| `2084703057267286118` — **the incident's exact query shape** | **1.0** | "ASCII Codes", "ASCII Character Chart" |
+| `https://x.com/i/status/2084703057267286118` | 0.29 | unrelated tweet URLs |
+| `qwzx plarn vetch dooble` (nonsense control) | 0.27 | plastic-bag-yarn craft pages |
+| `Anthropic knowledge graph guide Claude` | 0.76 | the actual Anthropic cookbook |
+| `mattpocock skills v1.2 release` | 0.83 | the actual release page |
+
+Tavily's score measures match-to-query, not usefulness — and a bare numeric ID matches numeric
+tables *perfectly*. A threshold would have caught the nonsense control and let the real incident
+through at a maximal 1.0. Guard the **input shape**, not the output score.
+
+### Routing — how the references steer search vs fetch
+
+Checked directly, because `tools/web/SKILL.md` has to encode this:
+
+- **Tavily's own published skill** states the rule most plainly: use extract *"when the user has one
+  or more URLs and wants their content"*, and defer to the search skill *"when you don't have a
+  URL."* Have a URL → read it. No URL → search. It also notes: if search results already carry the
+  content, skip the extract step.
+- **OpenClaw's `AGENTS.default.md` contains no web-routing guidance at all** — routing is left
+  entirely to the tool descriptions.
+- **Hermes likewise** ships pure capability descriptions (`web_search`: "Search the web…";
+  `web_extract`: "Extract content from web page URLs…") with no routing prose.
+
+**Conclusion: every reference routes through tool descriptions, not prompt rules** — which matches
+this repo's own stated position that "tool usage is driven by tool docstrings, not prompt prose"
+(CLAUDE.md). So the primary routing mechanism here should be a sharp `fetch_url` docstring plus the
+`web` SKILL.md body, and `AGENTS.md` should stay thin.
+
+**But Jarvis goes one step further than any reference, deliberately.** None of them *enforce* the
+rule in code; all three trust the model to route correctly. Jarvis has a logged incident proving
+that trust can fail expensively, so the input-shape guard encodes in code what the references leave
+to judgment. That divergence is intentional and should be noted in the SKILL.md rules body rather
+than silently added.
+
+## Phase 3 — dropped: x.com oEmbed tier-0
+
+**Dropped 2026-08-06.** The draft proposed `publish.twitter.com/oembed` as a free, no-auth tier-0
+for x.com. Tavily `extract` is now measured as covering x.com fully (tweet body + author), and the
+Q1 decision removed local fetching entirely — an oEmbed tier would reintroduce exactly the
+outbound-HTTP path that decision deleted, for one host, to save 0.2 credits. Recorded here so the
+idea is not re-proposed; the general principle (no per-host adapters, matching both references)
+stands.
+
+Guard rail: **resist a second special case.** Past one, the answer is the generic fallback. If a
+host list starts growing, that is the signal to reconsider a Firecrawl-class provider, as OpenClaw
+did — not to accumulate adapters.
+
+## Phase 4 — repair the corrupted entries
+
+Re-fetch and rewrite the three `x.com` entries in `reading_list.md` from real content, including
+the one the owner already corrected (still wrong on authorship). Worth spot-checking the rest of
+the file for other entries written from search guesses rather than fetches.
+
+---
+
+## Open questions
+
+**Disposition rule.** Questions still open when the plan is otherwise settled get one of three
+outcomes at end-of-plan review, decided together rather than one at a time: **adopt** (fold into a
+phase), **drop** (record the decision not to do it, with the reason), or **escalate** (file a
+GitHub issue and let it live outside this plan — the precedent being #32/#33 from the outbox work).
+Nothing stays "open" past the plan's close.
+
+1. ~~**Extraction library.**~~ **RESOLVED 2026-08-06 → provider-only (hermes-agent shape).** No
+   extraction library, no local fetch. See "Decisions carried in" above. The alternatives
+   considered (trafilatura, readability-lxml, hand-rolled `og:`+regex) are all moot once Jarvis
+   stops fetching HTML itself.
+
+2. ~~**`max_chars` default.**~~ **RESOLVED 2026-08-06 → 8,000 chars, 70/20 head+tail**, reusing the
+   `[... truncated N chars ...]` marker shape already committed to by
+   [CONTEXT_HANDLING_PLAN](CONTEXT_HANDLING_PLAN.md) WS4 rather than inventing a second one.
+
+   Deliberately below both references (OpenClaw 20,000; Hermes 15,000/75-25) for two
+   Jarvis-specific reasons they do not share:
+
+   - **Tool results are re-sent verbatim.** `_add_and_trim` (`agent.py:133`) keeps a 50-message
+     window, and `_strip_media_blobs` strips media blobs from history but **not text**. A fetched
+     page is therefore re-sent on every following turn in the thread until it falls out. Both
+     references compact or summarize history; Jarvis does not, so their numbers do not transfer.
+   - **Truncation here is terminal.** Both references truncate with a pointer to the full content
+     on disk. Jarvis's memory tools are sandboxed to `/app/jarvis_memory/` and `/app/jarvis_data/`
+     is explicitly never in the memory tool surface, so there is no read-the-rest path. (This one
+     cuts the *other* way — it argues for a larger cap — and is why 8,000 rather than something
+     smaller.)
+
+   Head+tail rather than head-only because an article's conclusions and a thread's replies both
+   live at the end. Measured coverage: arxiv (1,946), x.com (3,612) and HN (3,709) fit whole;
+   openai.com (24,002) and Wikipedia (242,293–600,274) truncate.
+
+   **Related follow-up, deferred to next steps:** strip fetched text from history after its turn,
+   exactly as `_strip_media_blobs` already does for images — the model has consumed the content by
+   the time the turn ends. That would let the cap be generous *and* cheap.
+
+3. ~~**Should `web_search` also learn to fail?**~~ **RESOLVED 2026-08-06 → yes, via an input-shape
+   guard**, folded into Phase 2. The score-threshold approach was tested and rejected; the
+   measurements are recorded under "Rejected: a relevance-score threshold" so it is not
+   re-proposed.
+
+**All five drafting questions are now closed.** What remains open is the two deferred next steps
+(N1, N2) plus the history-stripping follow-up noted under question 2.
+
+---
+
+## Possible next steps — deferred, not in Phase 1
+
+Both are enhancements to a shipped `fetch_url`, deliberately held back so Phase 1 stays minimal.
+Disposition (adopt / drop / escalate to a GitHub issue) happens at end-of-plan review, together.
+
+**Consequence of deferring, stated plainly:** Phase 1 therefore ships **basic depth and no cache** —
+the Tavily client defaults. If the advanced-depth evidence below is judged compelling, that is an
+argument for pulling it into Phase 1 rather than deferring it.
+
+### N1 — `extract_depth="advanced"`
+
+   **Credits are not the constraint.** The 1,000/month free tier is a *single shared balance*
+   across all Tavily endpoints, not per-endpoint. Current usage is ~95 credits/month. At 100
+   fetches/month, advanced depth adds ~40 credits — a combined ~13.5% of the free tier. Cost
+   should carry almost no weight in this decision.
+
+   **Measured, basic vs advanced** (fresh URLs never previously fetched; advanced deliberately run
+   *first* on half the cases, because a first comparison on already-fetched URLs returned
+   byte-identical results in 0.2s — Tavily serves its own cache, which silently confounds naive
+   A/B probes):
+
+   | URL | basic | advanced | delta |
+   |---|---|---|---|
+   | x.com tweet *(advanced first)* | 1,111 chars | **3,612** | advanced **3.3×** |
+   | news.ycombinator.com *(advanced first)* | 1,577 chars | **3,709** | advanced **2.4×** |
+   | Wikipedia comparison table | 600,274 chars | **153,021** | advanced — 4× *less* boilerplate |
+   | nasdaq.com (JS app) | 7,335, content absent | 7,335, content absent | tie, both failed |
+
+   Advanced won even where it ran first, so this is not a cache artifact. Tavily's docs recommend
+   advanced specifically for **JS-rendered SPAs** — which is what x.com is, and what caused the
+   incident. Note also that advanced *reduces* the truncation burden on Wikipedia rather than
+   adding to it.
+
+   **Against advanced:** latency. ~7 s typical vs ~1 s, and Tavily's default timeout rises from
+   10 s to 30 s. Against a 283-second incident that is noise, but it is a real per-turn cost on
+   every link the owner sends.
+
+   **Sub-question, also open:** whether a quota guard is needed at all. `web_search` already
+   surfaces `UsageLimitExceededError` gracefully, so mirroring that ladder in `fetch.py` may be
+   sufficient without any counter or state.
+
+   *(A third option exists — basic with escalation to advanced when the result looks thin — but it
+   adds a retry path to the one code path whose purpose is to fail cleanly, and the measurements
+   suggest it would fire on most social/SPA content anyway.)*
+
+### N2 — local caching
+
+**Measured: Tavily already caches server-side.** Same URL, same depth, three calls in a row:
+**1.31 s → 0.47 s → 0.18 s**, byte-identical output. A local cache would duplicate a cache we
+already inherit for free.
+
+**The references split, and the split maps onto the Q1 decision.** OpenClaw caches for 15 minutes
+(`cacheTtlMinutes`) — but *because it fetches locally*: it bears the full round-trip and HTML parse
+itself and has no provider cache to lean on. Hermes documents no cache at all, consistent with its
+provider-only design. Having taken the Hermes shape in Q1, OpenClaw's rationale does not transfer.
+
+**What a local cache would still buy:** credits only. Tavily bills per successful extraction, cache
+hit or not, so three repeats cost 0.6 rather than 0.2 credits. Against ~95 used of 1,000/month,
+that is not a reason.
+
+**Options if adopted:**
+
+| | State | Buys | Costs |
+|---|---|---|---|
+| in-turn memo | dict, dies with the turn | dedupes within one turn | ~nil; staleness impossible |
+| TTL cache (OpenClaw) | 15-min store, needs a home in `/app/jarvis_data/` per the placement principle | dedupes across turns | staleness, eviction, a new state owner |
+
+**Caveat on the evidence:** Tavily's caching is inferred from timings, not a published guarantee.
+If they change it we lose the latency win silently — though no worse off than never having cached.
+
+**Overlap to keep in mind:** the failure mode a cache would blunt (the model hammering one URL) is
+addressed more directly by the Phase 2 repeat-call cap, which *stops* the loop rather than making
+it cheap. Adopting both means two mechanisms half-solving one problem.
+
+### N3 — strip fetched text from history after its turn
+
+`_strip_media_blobs` (`agent.py:137`) already removes media blobs from messages the LLM has
+previously seen, keeping them only for the turn that needs them. Fetched page text has the same
+profile: large, consumed once, then dead weight re-sent on every following turn inside the
+50-message window.
+
+Applying the same treatment would decouple `max_chars` from the re-send multiplier entirely — the
+cap could be generous (Hermes's 15,000, or OpenClaw's 20,000) without a per-turn tax, since the
+text would survive only the turn that fetched it.
+
+**Against:** a follow-up question about the same page in a later turn would need a re-fetch (~0.2
+credits, and Tavily's cache makes it fast). Also a slightly surprising asymmetry — the model can
+see a page it read two turns ago in its *reply*, but no longer in its *context*.
+
+Sequencing note: N3 and the Q4 decision interact. If N3 is adopted, revisit the 8,000-char cap —
+its main justification disappears.
+
+---
+
+## Non-goals
+
+- **No headless browser / JS execution.** That is a capability-surface expansion; the sandbox
+  constraint from `docs/plans/archive/ARCHITECTURE_PLAN.md` stands.
+- **No authenticated fetching**, no cookie jar, no login-walled content.
+- **No crawling.** Single URL per call; Tavily's `crawl` is not used.
+- **No new secrets.** If a tier needs a new API key, it does not belong in Phase 1.

--- a/docs/plans/URL_FETCH_PLAN.md
+++ b/docs/plans/URL_FETCH_PLAN.md
@@ -9,7 +9,8 @@ guessed at, and close the loop that let a single unreadable link cost 4m44s and 
 
 ## Context
 
-On 2026-08-06 the owner sent a bare `x.com` status URL with "add this as well". Turn
+On 2026-08-06 the owner sent a bare `x.com` status URL with "add this as well" — the same request
+shape that had already failed at least twice before (see "This is a recurrence" below). Turn
 `b068e543` ran **283.7 s**, made **16 LLM calls** and **14 consecutive `web_search` calls**, burned
 **494,962 input / 65,994 output tokens** (64,321 of them reasoning) — ~10× the median user turn
 (~59k total) and the 3rd most expensive user turn in two weeks. It then wrote a **fabricated**
@@ -49,6 +50,47 @@ exactly where the content was guessable. **Fixing these entries is part of this 
 follow-up.**
 
 ---
+
+## This is a recurrence, and it is already filed
+
+**The 2026-08-06 incident is at least the third occurrence of the same failure.** Discovered while
+reviewing open issues *after* the plan was drafted:
+
+- **[#7 — Add a URL fetch & summarize tool](../../../../issues/7)** (enhancement, priority: medium,
+  filed 2026-07-04) is this plan's Phase 1, already specified. Its acceptance criteria — "fetches a
+  given URL and returns a usable summary" and "handles timeouts, blocked, and non-HTML fetches
+  gracefully" — anticipated both halves of what this plan builds.
+- **[#36 — Turns are unbounded, terminate abnormally, and leave no legible trace](../../../../issues/36)**
+  (bug, priority: **high**) records incident 2 on **2026-07-30**: the same x.com-link request, the
+  same **14 consecutive `web_search` calls**, then a single LLM call burning **65,668 output tokens
+  over 6m48s**, ending in `MALFORMED_FUNCTION_CALL`. 7m43s, ~$0.31, `error: null`, and
+  `reading_list.md` never updated. #7's comment notes the same 14-search flail had already run
+  *the previous evening* and happened to recover.
+
+**The failure mode has been getting worse, not better.** On 2026-07-30 the turn died and delivered
+nothing — loud, visible, no memory written. On 2026-08-06 the turn *succeeded*: it completed
+normally, reported confidently, and wrote a fabrication into `reading_list.md` that survived until
+the owner happened to catch it. A silent corruption of stored memory is the worse outcome of the
+two, and it is what the same root cause produces once the model gets slightly luckier with its
+token budget.
+
+**One premise in #7 needs correcting.** Its comment states that *"x.com blocks unauthenticated
+fetches, so this exact URL will still fail"*, and therefore treats failing cleanly as the criterion
+that prevents recurrence. Measured, that is no longer true: Tavily `extract` reads that exact URL
+in full, tweet body and author handle included. The acceptance criteria can be strengthened from
+"fails cleanly on x.com" to "**succeeds** on x.com" — with clean failure still required for the
+genuinely unreadable cases (nasdaq.com was measured as failing on both extract depths).
+
+**Relationship to the other open issues:**
+
+| Issue | Relationship |
+|---|---|
+| [#7](../../../../issues/7) | **Closed by this plan's Phase 1.** Should be linked from the PR. |
+| [#36](../../../../issues/36) | **Partially addressed** by Phase 2's repeat-call cap, which bounds the 14-search flail. #36 is broader — unbounded turns in *both* scopes, `GraphRecursionError`, and no legible trace — so it stays open. |
+| [#59](../../../../issues/59) | Split out of #36: non-STOP finish reasons collapsing to an empty reply. Adjacent, not addressed here. The 08-06 turn terminated *normally*, so #59's path did not fire — same head, different tail. |
+| [#17](../../../../issues/17) | Load-time tool gating by required env vars. More attractive once `web` is a skill: with no `TAVILY_API_KEY`, the whole skill could be skipped at registration rather than failing per-call. Still low priority; current deploys always have the key. |
+| [#67](../../../../issues/67) | Staging shares prod's real external services, **explicitly including web search**. `fetch_url` adds a second consumer of the same 1,000-credit Tavily pool from staging. Minor, but it makes the shared-quota point slightly sharper. |
+| [#18](../../../../issues/18) | Reduce token spend. The `max_chars` decision and the N3 history-stripping follow-up both feed it. |
 
 ## Evidence gathered during planning
 

--- a/docs/plans/archive/URL_FETCH_PLAN.md
+++ b/docs/plans/archive/URL_FETCH_PLAN.md
@@ -56,11 +56,11 @@ follow-up.**
 **The 2026-08-06 incident is at least the third occurrence of the same failure.** Discovered while
 reviewing open issues *after* the plan was drafted:
 
-- **[#7 — Add a URL fetch & summarize tool](../../../../issues/7)** (enhancement, priority: medium,
+- **[#7 — Add a URL fetch & summarize tool](../../../../../issues/7)** (enhancement, priority: medium,
   filed 2026-07-04) is this plan's Phase 1, already specified. Its acceptance criteria — "fetches a
   given URL and returns a usable summary" and "handles timeouts, blocked, and non-HTML fetches
   gracefully" — anticipated both halves of what this plan builds.
-- **[#36 — Turns are unbounded, terminate abnormally, and leave no legible trace](../../../../issues/36)**
+- **[#36 — Turns are unbounded, terminate abnormally, and leave no legible trace](../../../../../issues/36)**
   (bug, priority: **high**) records incident 2 on **2026-07-30**: the same x.com-link request, the
   same **14 consecutive `web_search` calls**, then a single LLM call burning **65,668 output tokens
   over 6m48s**, ending in `MALFORMED_FUNCTION_CALL`. 7m43s, ~$0.31, `error: null`, and
@@ -85,12 +85,12 @@ genuinely unreadable cases (nasdaq.com was measured as failing on both extract d
 
 | Issue | Relationship |
 |---|---|
-| [#7](../../../../issues/7) | **Closed by this plan's Phase 1.** Should be linked from the PR. |
-| [#36](../../../../issues/36) | **Partially addressed** by Phase 2's repeat-call cap, which bounds the 14-search flail. #36 is broader — unbounded turns in *both* scopes, `GraphRecursionError`, and no legible trace — so it stays open. |
-| [#59](../../../../issues/59) | Split out of #36: non-STOP finish reasons collapsing to an empty reply. Adjacent, not addressed here. The 08-06 turn terminated *normally*, so #59's path did not fire — same head, different tail. |
-| [#17](../../../../issues/17) | Load-time tool gating by required env vars. More attractive once `web` is a skill: with no `TAVILY_API_KEY`, the whole skill could be skipped at registration rather than failing per-call. Still low priority; current deploys always have the key. |
-| [#67](../../../../issues/67) | Staging shares prod's real external services, **explicitly including web search**. `fetch_url` adds a second consumer of the same 1,000-credit Tavily pool from staging. Minor, but it makes the shared-quota point slightly sharper. |
-| [#18](../../../../issues/18) | Reduce token spend. The `max_chars` decision and the N3 history-stripping follow-up both feed it. |
+| [#7](../../../../../issues/7) | **Closed by this plan's Phase 1.** Should be linked from the PR. |
+| [#36](../../../../../issues/36) | **Not addressed.** A repeat-call cap was designed for that purpose and then rejected (see Phase 2). What this plan removes is the *reason* the flail started, not the flail itself. A note on #36 records that Jarvis already has the global iteration budget both references use — LangGraph's default `recursion_limit` of 25 — and that the bug is its raising a `GraphRecursionError` where hermes-agent degrades into a tool-free summary. |
+| [#59](../../../../../issues/59) | Split out of #36: non-STOP finish reasons collapsing to an empty reply. Adjacent, not addressed here. The 08-06 turn terminated *normally*, so #59's path did not fire — same head, different tail. |
+| [#17](../../../../../issues/17) | Load-time tool gating by required env vars. More attractive once `web` is a skill: with no `TAVILY_API_KEY`, the whole skill could be skipped at registration rather than failing per-call. Still low priority; current deploys always have the key. |
+| [#67](../../../../../issues/67) | Staging shares prod's real external services, **explicitly including web search**. `fetch_url` adds a second consumer of the same 1,000-credit Tavily pool from staging. Minor, but it makes the shared-quota point slightly sharper. |
+| [#18](../../../../../issues/18) | Reduce token spend. The `max_chars` decision and the N3 history-stripping follow-up both feed it. |
 
 ## Evidence gathered during planning
 
@@ -130,7 +130,7 @@ naive re-measurement will not.
 ## References — OpenClaw and hermes-agent
 
 Both references solve this problem, and they converge. Following the comparison format of
-[CONTEXT_HANDLING_PLAN.md §Mechanisms](CONTEXT_HANDLING_PLAN.md):
+[CONTEXT_HANDLING_PLAN.md §Mechanisms](../CONTEXT_HANDLING_PLAN.md):
 
 | Mechanism | OpenClaw | hermes-agent | Jarvis today |
 |---|---|---|---|
@@ -299,7 +299,7 @@ Estimate: **~40 lines.**
 
 ## Phase 2 — bound the failure
 
-Three changes that matter even after Phase 1, because a fetch that fails will otherwise send the
+Two changes that matter even after Phase 1, because a fetch that fails will otherwise send the
 model straight back to `web_search` for another 14 rounds.
 
 - **[Q5 — decided] Input-shape guard in `web_search`.** Detect a query that is a URL or a bare long
@@ -307,13 +307,42 @@ model straight back to `web_search` for another 14 rounds.
   *"That looks like a URL or an ID, not a search query. Use `fetch_url` to read it directly."*
   Deterministic, nothing to tune, and it catches the incident's exact shape. See "Routing" below
   for why this is a *code* guard rather than a prompt rule.
-- **Repeat-call cap in `tools/registry.py`.** Cap identical-tool calls per turn (~5), then return a
-  hard stop: *"you have called `web_search` 5 times without success; stop and report what you could
-  not determine."* Uses the existing per-turn context (`turn_context.py`). This is the single
-  highest-leverage change in the plan — it bounds cost for *every* tool, not just this one.
-  The guard stops the *first* wrong search; the cap stops the *fourteenth*.
-- **A URL rule in `prompts/AGENTS.md`** (currently 26 lines, zero mentions of links/URLs), plus the
-  rewrite of line 4 and line 6 that the `web` skill move forces anyway.
+- **Prompt narrowing in `prompts/AGENTS.md`** — line 4 and line 6 rewritten as the `web` skill move
+  forces anyway. Note what this deliberately does **not** add: a rule that a link is a request to
+  read it. An early draft carried one and it was removed. A pasted URL is not by itself a reason to
+  spend a fetch; the rule that matters is narrower and lives in `tools/web/SKILL.md` — do not
+  *describe* a page you have not opened.
+
+### Rejected: a per-tool repeat-call cap
+
+Recorded so it is not re-proposed. The draft called this "the single highest-leverage change in
+the plan." It was implemented, measured, and reverted.
+
+**Measured against 1,947 logged turns, a cap of 5 would have fired on 152 of them (7.8%) — almost
+all legitimate:**
+
+| Tool | Turns | Max in one turn | Turns >5 | Verdict |
+|---|---|---|---|---|
+| `read_memory` | 1,719 | **22** | 141 | normal — reading many memory files |
+| `query_fitness_db` | 36 | 14 | 4 | normal — ad-hoc SQL exploration |
+| `delete_memory` | 12 | 10 | 3 | normal — bulk cleanup |
+| `web_search` | 29 | 14 | 4 | **all four are the known incidents** |
+
+A per-tool cap on `web_search` alone would have been defensible on that data. It was still dropped,
+for three reasons:
+
+1. **Neither reference has per-tool capping.** In OpenClaw it is an open feature request
+   ([#9912](https://github.com/openclaw/openclaw/issues/9912) `maxTurns`/`maxToolCalls`,
+   [#806](https://github.com/openclaw/openclaw/issues/806) loop detection); hermes-agent's
+   agent-loop docs do not mention loop detection or duplicate suppression at all. Both rely on a
+   **global iteration budget**.
+2. **Jarvis already has that budget.** Nothing sets `recursion_limit`, so LangGraph's default of 25
+   applies — and #36 incident 1 died on exactly it. The mechanism exists; what it lacks is
+   hermes-agent's graceful exhaustion (*"the agent stops and returns a summary of work done"*)
+   rather than raising. That belongs to #36.
+3. **It would not have prevented the bad outcome.** The 2026-08-06 turn made **16 LLM calls** —
+   under 25, so no budget of any size would have fired, and it ended by *succeeding* with a
+   fabrication. A cap bounds cost, not correctness.
 
 ### Rejected: a relevance-score threshold on `web_search`
 
@@ -392,7 +421,7 @@ Nothing stays "open" past the plan's close.
 
 2. ~~**`max_chars` default.**~~ **RESOLVED 2026-08-06 → 8,000 chars, 70/20 head+tail**, reusing the
    `[... truncated N chars ...]` marker shape already committed to by
-   [CONTEXT_HANDLING_PLAN](CONTEXT_HANDLING_PLAN.md) WS4 rather than inventing a second one.
+   [CONTEXT_HANDLING_PLAN](../CONTEXT_HANDLING_PLAN.md) WS4 rather than inventing a second one.
 
    Deliberately below both references (OpenClaw 20,000; Hermes 15,000/75-25) for two
    Jarvis-specific reasons they do not share:
@@ -420,21 +449,38 @@ Nothing stays "open" past the plan's close.
    measurements are recorded under "Rejected: a relevance-score threshold" so it is not
    re-proposed.
 
-**All five drafting questions are now closed.** What remains open is the two deferred next steps
-(N1, N2) plus the history-stripping follow-up noted under question 2.
+**All five drafting questions are closed, and all three deferred items are dispositioned.** Nothing
+in this plan remains open.
 
 ---
 
-## Possible next steps — deferred, not in Phase 1
+## Possible next steps — DISPOSITIONED 2026-08-06
 
-Both are enhancements to a shipped `fetch_url`, deliberately held back so Phase 1 stays minimal.
-Disposition (adopt / drop / escalate to a GitHub issue) happens at end-of-plan review, together.
+Held back so Phase 1 stayed minimal, then resolved together at end-of-plan review as the
+disposition rule requires. **Phase 1 therefore shipped basic depth and no cache** — the Tavily
+client defaults — and staging confirmed both are adequate in practice.
 
-**Consequence of deferring, stated plainly:** Phase 1 therefore ships **basic depth and no cache** —
-the Tavily client defaults. If the advanced-depth evidence below is judged compelling, that is an
-argument for pulling it into Phase 1 rather than deferring it.
+| | Outcome | Where it went |
+|---|---|---|
+| **N1** — advanced extract depth | **Escalated** | [#80](../../../../../issues/80) |
+| **N2** — local caching | **Dropped** | recorded below |
+| **N3** — strip fetched text from history | **Escalated**, broadened | [#81](../../../../../issues/81) |
 
-### N1 — `extract_depth="advanced"`
+**N2 is dropped, not deferred.** Tavily caches server-side (measured: 1.31s → 0.47s → 0.18s on
+repeat calls, byte-identical), so a local cache duplicates one we already inherit; its only
+remaining benefit is credits, which are not scarce. OpenClaw's reason for caching — that it fetches
+locally and has no provider cache to lean on — stopped applying the moment Q1 chose provider-only.
+
+**N3 grew in scope on review.** Stripping fetched text from history is destructive while there is
+nowhere to read it back from, so the real missing piece is an **overflow store** — the mechanism
+both references have and Jarvis lacks. hermes-agent's `[TRUNCATED]` footer points at the full file
+on disk; `fetch_url` had to *drop* that clause from the marker wording WS4 borrowed, because for
+fetched pages it would be a lie. #81 covers the store, a read-past-truncation tool, and the
+relaxation of the 8,000-char cap that becomes safe once stripping is non-destructive. It
+deliberately spans #61 (re-read dropped media) and #60 (large ingested text) rather than solving
+this for `fetch_url` alone.
+
+### N1 — `extract_depth="advanced"` → [#80](../../../../../issues/80)
 
    **Credits are not the constraint.** The 1,000/month free tier is a *single shared balance*
    across all Tavily endpoints, not per-endpoint. Current usage is ~95 credits/month. At 100
@@ -495,11 +541,12 @@ that is not a reason.
 **Caveat on the evidence:** Tavily's caching is inferred from timings, not a published guarantee.
 If they change it we lose the latency win silently — though no worse off than never having cached.
 
-**Overlap to keep in mind:** the failure mode a cache would blunt (the model hammering one URL) is
-addressed more directly by the Phase 2 repeat-call cap, which *stops* the loop rather than making
-it cheap. Adopting both means two mechanisms half-solving one problem.
+**Note on a since-removed argument:** an earlier draft justified dropping the cache partly because
+the Phase 2 repeat-call cap would *stop* a model hammering one URL rather than making it cheap.
+That cap was itself rejected, so the argument is void — but the conclusion stands on the
+server-side-cache measurement alone.
 
-### N3 — strip fetched text from history after its turn
+### N3 — strip fetched text from history after its turn → [#81](../../../../../issues/81)
 
 `_strip_media_blobs` (`agent.py:137`) already removes media blobs from messages the LLM has
 previously seen, keeping them only for the turn that needs them. Fetched page text has the same

--- a/prompts/AGENTS.md
+++ b/prompts/AGENTS.md
@@ -1,9 +1,9 @@
 Timezone: Roi lives in Tel Aviv (Asia/Jerusalem, UTC+3 in summer / UTC+2 in winter). Always display times to the user in Israel local time. Internally, reminder fire_at must be ISO 8601 UTC (scheduler requirement); convert to Israel time when communicating times to the user.
 
 Tools and skills:
-- Core tools (memory, reminders, conversation/notification history, web search, skill activation) are always available.
+- Core tools (memory, reminders, conversation/notification history, skill activation) are always available.
 - Every other capability belongs to a skill that you must activate before use. When a request needs a skill, call activate_skill for that skill and then use its tools in the SAME turn — do not ask the user to repeat themselves. Deactivate a skill when it is clearly no longer needed.
-- Always use tools rather than guessing. Use web search proactively for recent events, release dates, or anything that may have changed since your training cutoff, rather than guessing on time-sensitive topics.
+- Always use tools rather than guessing. Activate the `web` skill and search proactively for recent events, release dates, or anything that may have changed since your training cutoff, rather than guessing on time-sensitive topics. A link Roi sends is a request to read it — activate `web` and fetch it, in the same turn.
 
 Reminders & scheduling:
 You run autonomously on a 1-hour heartbeat. Use the reminder tool to create/list/delete reminders; to modify a reminder, delete then create; call create exactly once per request. For recurring proactivity prefer a HEARTBEAT.md task over scheduled reminders; use reminders for one-off, time-specific nudges.

--- a/prompts/AGENTS.md
+++ b/prompts/AGENTS.md
@@ -3,7 +3,7 @@ Timezone: Roi lives in Tel Aviv (Asia/Jerusalem, UTC+3 in summer / UTC+2 in wint
 Tools and skills:
 - Core tools (memory, reminders, conversation/notification history, skill activation) are always available.
 - Every other capability belongs to a skill that you must activate before use. When a request needs a skill, call activate_skill for that skill and then use its tools in the SAME turn — do not ask the user to repeat themselves. Deactivate a skill when it is clearly no longer needed.
-- Always use tools rather than guessing. Activate the `web` skill and search proactively for recent events, release dates, or anything that may have changed since your training cutoff, rather than guessing on time-sensitive topics. A link Roi sends is a request to read it — activate `web` and fetch it, in the same turn.
+- Always use tools rather than guessing. Activate the `web` skill and search proactively for recent events, release dates, or anything that may have changed since your training cutoff, rather than guessing on time-sensitive topics.
 
 Reminders & scheduling:
 You run autonomously on a 1-hour heartbeat. Use the reminder tool to create/list/delete reminders; to modify a reminder, delete then create; call create exactly once per request. For recurring proactivity prefer a HEARTBEAT.md task over scheduled reminders; use reminders for one-off, time-specific nudges.

--- a/tools/core/__init__.py
+++ b/tools/core/__init__.py
@@ -11,7 +11,6 @@ from tools.core.memory import (
     list_memory,
     delete_memory,
 )
-from tools.core.search import web_search
 from tools.core.history import (
     NOTIFICATION_LOG,
     CHAT_LOG,
@@ -36,7 +35,6 @@ __all__ = [
     "read_memory",
     "list_memory",
     "delete_memory",
-    "web_search",
     "NOTIFICATION_LOG",
     "CHAT_LOG",
     "trim_log",

--- a/tools/web/SKILL.md
+++ b/tools/web/SKILL.md
@@ -3,7 +3,7 @@ name: web
 description: search the web, and read the page at a URL
 ---
 - Having a URL and searching for it are different problems. A URL or a post id is an address — `fetch_url` reads it. `web_search` finds an address you don't have yet. Searching for an address cannot work, however many times you rephrase it.
-- When the owner sends a link, read it before doing anything with it. A link plus an instruction ("add this", "what do you think of this") is a request to read the page, not to recognize it.
+- A link appearing in conversation is not by itself a reason to fetch it. But before you *act* on one — summarizing it, filing it, judging it, describing what it is — read it. Producing a description of a page you have not opened is the failure to avoid, not leaving a link unread.
 - Never describe a page you could not read. If `fetch_url` fails, say so plainly, record the bare URL, and ask the owner what it was. A guessed description that lands in memory outlives the conversation and is worse than an admitted gap — this has already happened twice, and both times the guess was wrong.
 - Never infer a page's content from the conversation around it. The link the owner sent before this one tells you nothing about this one; two links in a row are not by the same author.
 - When a search does not find what you need, stop and say so. Rephrasing the same query repeatedly costs real money and does not turn an unanswerable search into an answerable one.

--- a/tools/web/SKILL.md
+++ b/tools/web/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: web
+description: search the web, and read the page at a URL
+---
+- Having a URL and searching for it are different problems. A URL or a post id is an address — `fetch_url` reads it. `web_search` finds an address you don't have yet. Searching for an address cannot work, however many times you rephrase it.
+- When the owner sends a link, read it before doing anything with it. A link plus an instruction ("add this", "what do you think of this") is a request to read the page, not to recognize it.
+- Never describe a page you could not read. If `fetch_url` fails, say so plainly, record the bare URL, and ask the owner what it was. A guessed description that lands in memory outlives the conversation and is worse than an admitted gap — this has already happened twice, and both times the guess was wrong.
+- Never infer a page's content from the conversation around it. The link the owner sent before this one tells you nothing about this one; two links in a row are not by the same author.
+- When a search does not find what you need, stop and say so. Rephrasing the same query repeatedly costs real money and does not turn an unanswerable search into an answerable one.

--- a/tools/web/__init__.py
+++ b/tools/web/__init__.py
@@ -1,0 +1,19 @@
+"""Web skill — find a page, and read one.
+
+`web_search` and `fetch_url` are two halves of one capability and share a
+namespace deliberately: with search always bound and fetch missing, a turn
+handed a URL reaches for the only web-shaped tool within reach and searches for
+it, which is what produced the incidents in #7. Bound together, that state is
+unreachable — either both are available or neither is.
+
+Importing this package imports each module, running its ``@tool_register``
+side-effects.
+"""
+
+from tools.web.fetch import fetch_url  # noqa: F401
+from tools.web.search import web_search  # noqa: F401
+
+__all__ = [
+    "fetch_url",
+    "web_search",
+]

--- a/tools/web/fetch.py
+++ b/tools/web/fetch.py
@@ -1,0 +1,116 @@
+"""Read the page at a URL.
+
+Extraction is provider-side: the URL goes to Tavily and the markdown comes
+back. Jarvis never dereferences a model-supplied URL itself, so a URL naming a
+host on the home network is fetched from Tavily's infrastructure, which cannot
+reach it — there is no SSRF surface to guard.
+"""
+import os
+from urllib.parse import urlparse
+
+from langchain_core.tools import tool
+
+from tools.registry import tool_register
+
+# Below the references (OpenClaw 20k, hermes-agent 15k) on purpose: tool results
+# are re-sent verbatim on every following turn inside agent.py's 50-message
+# window, so every fetched character is paid many times over.
+MAX_CHARS = 8_000
+_HEAD_CHARS = int(MAX_CHARS * 0.70)
+_TAIL_CHARS = int(MAX_CHARS * 0.20)
+
+
+def _truncate(text: str) -> str:
+    """Head + tail, so an article's conclusion and a thread's replies survive.
+
+    Marker shape matches the one CONTEXT_HANDLING_PLAN WS4 uses for injected
+    files, minus its "file intact on disk" clause — nothing is written to disk
+    here, so truncation is terminal and the text must not imply otherwise.
+    """
+    if len(text) <= MAX_CHARS:
+        return text
+    dropped = len(text) - _HEAD_CHARS - _TAIL_CHARS
+    return (
+        f"{text[:_HEAD_CHARS]}\n\n"
+        f"[... truncated {dropped:,} chars — this is all that was read ...]\n\n"
+        f"{text[-_TAIL_CHARS:]}"
+    )
+
+
+@tool_register(namespace="web")
+@tool
+def fetch_url(url: str) -> str:
+    """Read the page at a URL and return its text.
+
+    Use this whenever you are given a link — an article, a post, a repo, a PDF.
+    Never try to identify a link by searching for it: a URL or a post id is an
+    address, and web_search cannot look one up. Use web_search only when you do
+    NOT have a URL and need to find one.
+
+    If this returns an error, say you could not read the page and record the
+    bare URL. Do not guess what it contained, do not describe it from the
+    surrounding conversation, and do not fall back to web_search.
+
+    Args:
+        url: The full http(s) URL to read.
+    """
+    parsed = urlparse(url.strip())
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        return (
+            f"Not a fetchable URL: {url!r}. Only http and https addresses can be read. "
+            "Tell the user you could not read it rather than guessing its content."
+        )
+
+    try:
+        from tavily import TavilyClient
+        from tavily.errors import (
+            UsageLimitExceededError,
+            InvalidAPIKeyError,
+            MissingAPIKeyError,
+        )
+
+        api_key = os.environ.get("TAVILY_API_KEY")
+        if not api_key:
+            return (
+                "Page reading is unavailable: TAVILY_API_KEY is not configured. Tell the "
+                "user you could not read the page — do not guess what it contained."
+            )
+
+        client = TavilyClient(api_key=api_key)
+        response = client.extract(urls=[url], format="markdown")
+        results = response.get("results", [])
+        if not results:
+            return (
+                f"Could not read {url} — the page could not be extracted (it may be "
+                "login-walled, removed, or fully script-rendered). Tell the user you "
+                "could not read it and record the bare URL. Do not guess its content, "
+                "and do not search for it."
+            )
+
+        result = results[0]
+        text = (result.get("raw_content") or "").strip()
+        if not text:
+            return (
+                f"Read {url} but it contained no extractable text. Tell the user you "
+                "could not read it. Do not guess its content."
+            )
+
+        final_url = result.get("url") or url
+        return f"Source: {final_url}\n\n{_truncate(text)}"
+
+    except UsageLimitExceededError:
+        return (
+            "Page reading quota exhausted for this month. Tell the user you could not "
+            "read the page — do not guess what it contained."
+        )
+    except (InvalidAPIKeyError, MissingAPIKeyError):
+        return (
+            "Page reading is unavailable: invalid or missing API key. Tell the user you "
+            "could not read the page — do not guess what it contained."
+        )
+    except Exception as e:
+        return (
+            f"Could not read {url} ({type(e).__name__}: {e}). Tell the user you could not "
+            "read it and record the bare URL. Do not guess its content, and do not "
+            "search for it."
+        )

--- a/tools/web/search.py
+++ b/tools/web/search.py
@@ -4,13 +4,16 @@ from langchain_core.tools import tool
 from tools.registry import tool_register
 
 
-@tool_register(namespace="core")
+@tool_register(namespace="web")
 @tool
 def web_search(query: str) -> str:
     """Search the web for current information using Tavily.
 
     Use this for questions about recent events, news, release dates, or anything
     that may have changed since the model's training cutoff.
+
+    Use this only when you do NOT already have a URL. If you have a link, read it
+    with fetch_url — searching for a URL or a post id cannot find it.
 
     Args:
         query: The search query string.

--- a/tools/web/search.py
+++ b/tools/web/search.py
@@ -1,7 +1,22 @@
 import os
+import re
+
 from langchain_core.tools import tool
 
 from tools.registry import tool_register
+
+# A query that is an address rather than a description. Searching for one cannot
+# work: a search engine matches text, and a bare post id matches whatever else
+# contains those digits. The incident behind #7 searched `2084703057267286118`
+# fourteen times; Tavily returned ASCII code tables, scored 1.0. A relevance
+# threshold was measured and rejected for exactly that reason — the score was
+# maximal. Guard the shape of the input instead.
+_URL_LIKE = re.compile(r"^\s*(https?://|www\.)\S+\s*$", re.I)
+_BARE_ID = re.compile(r"^\s*\d{7,}\s*$")
+
+
+def _looks_like_an_address(query: str) -> bool:
+    return bool(_URL_LIKE.match(query) or _BARE_ID.match(query))
 
 
 @tool_register(namespace="web")
@@ -18,6 +33,14 @@ def web_search(query: str) -> str:
     Args:
         query: The search query string.
     """
+    if _looks_like_an_address(query):
+        return (
+            f"{query.strip()!r} is an address, not a search query — searching cannot "
+            "find it. Use fetch_url to read it directly. If fetch_url has already "
+            "failed on it, say you could not read it and record the bare URL; do not "
+            "try to identify it by searching."
+        )
+
     try:
         from tavily import TavilyClient
         from tavily.errors import UsageLimitExceededError, InvalidAPIKeyError, MissingAPIKeyError


### PR DESCRIPTION
Jarvis could not read a URL. `web_search` (Tavily search) was the only web capability, so a
link could only be guessed at. That produced the same failure at least three times, most
recently a 283-second turn that burned 495k input / 66k output tokens (~10x the median user
turn) and wrote a **fabricated** entry into `reading_list.md`.

Plan: [`docs/plans/archive/URL_FETCH_PLAN.md`](docs/plans/archive/URL_FETCH_PLAN.md)

## The failure was getting worse, not better

| When | Outcome |
|---|---|
| 2026-07-29 | 14-search flail; recovered by luck |
| 2026-07-30 | 14 searches, 65,668 output tokens in one 6m48s call, `MALFORMED_FUNCTION_CALL`, link never added (#36) |
| 2026-08-06 | 14 searches, 283.7s, ~$0.36 — and the turn **succeeded**, writing a fabrication into memory |

On 07-30 it died loudly and wrote nothing. On 08-06 it completed, reported confidently, and
silently corrupted stored memory. Two of the three `x.com` entries in `reading_list.md` are
misattributed as a result.

Root cause is structural: `web_search` returns a string on every path, so search can never
signal failure, and nothing bounded the retry.

## What this does

**New `tools/web/` skill** holding `web_search` (moved from `tools/core/`) and a new
`fetch_url`. Grouping them removes the asymmetry that caused the failure: with search bound
and fetch missing, a turn handed a URL reaches for the only web-shaped tool in reach. Bound
together, either both are available or neither is. hermes-agent groups its web tools the same
way. Safe to gate behind activation — `web_search` ran 53 times in 20 turns since 07-20, 100%
in user scope, **zero in heartbeat**.

**`fetch_url` is provider-only** (hermes-agent's shape, not OpenClaw's local-fetch +
Readability). The URL goes to Tavily; markdown comes back. Jarvis never dereferences a
model-supplied URL itself, so there is **no SSRF surface** despite the LAN running
Sonarr/Radarr/Prowlarr — verified: a fetch of `192.168.1.5:8989` is refused by Tavily, not by
us. No new dependency; `tavily-python` already ships `extract()`. ~40 lines.

**Truncation at 8,000 chars, 70/20 head+tail**, reusing the marker shape
`CONTEXT_HANDLING_PLAN` WS4 committed to — minus its "file intact on disk" clause, which for a
fetched page would be a lie (that gap is now #81).

**Input-shape guard on `web_search`**: a query that is a URL or a bare long digit string is an
address, not a description, and returns a redirect to `fetch_url` without spending a call.

**Every failure path** names the failure and tells the model to say it could not read the page
— explicitly not to guess, and not to fall back to search. That is the half that prevents
recurrence; the fetch succeeding is only the half that makes it useful.

## Rejected, with the measurements that killed them

- **Relevance-score threshold on `web_search`** — the incident's own query
  (`2084703057267286118`) scored **1.0** against ASCII code tables. Tavily's score measures
  match-to-query, not usefulness. A threshold would have caught a nonsense control and let the
  real failure through.
- **Per-tool repeat cap** — written, then reverted. Against 1,947 logged turns a cap of 5
  would have fired on **152 (7.8%)** of legitimate behaviour; `read_memory` legitimately
  reaches 22 calls in one turn. Neither reference has per-tool capping; both rely on a global
  iteration budget, which Jarvis already has (LangGraph's `recursion_limit`, default 25). Note
  on #36 covers making that budget degrade gracefully instead of raising.
- **x.com oEmbed adapter** — moot once extraction went provider-side. Neither reference has
  any per-host adapter.

## Verified on staging (`379d8c2`)

7 turns, 0 errors, slowest **9.4s**, max 4 LLM calls, **3,136 output tokens total** — 5% of
what the single incident turn spent.

- **Incident replayed** — correct attribution to **@norvex1029**, `0` searches (prod: 14)
- **Clean failure** — nasdaq AAPL page: 1 `fetch_url`, `0` `web_search`; it reported the fetch
  returned nothing and *offered* a search without running one
- **Truncation** — a 600,274-char Wikipedia page came in at 55,308 turn input tokens (~145k
  saved). The summary covers both the article's opening *and* its encoding/newline tables at
  the end, confirming the head+tail split works
- **Search** — `web_search` ran once, on a real query with no URL involved
- **Zero URLs triggered a search** across the whole session

Not tested: cold activation of `web` for a search (it was already active), and heartbeat
(staging runs `heartbeat=off`).

## Follow-ups

- **#80** — evaluate `extract_depth=advanced` (measured 3.3x more content on x.com; basic
  proved adequate in practice)
- **#81** — overflow store, so truncated content can be read back rather than lost
- `reading_list.md` repair is deliberately deferred until this is on prod, then done by Jarvis
  itself rather than rewriting prod memory from staging

Closes #7
