### PR TITLE
jarvis-app form block: neutral block layer, send_form, confirmation fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,8 @@ Jarvis is a stateful, proactive AI assistant running as a systemd service on a h
 │   ├── outbox.py          # Outbox — single owner-send seam (log-on-success, SendOutcome, thread→loop bridge)
 │   ├── factory.py         # per-channel build_*_stack(); default_outbox(); get_confirmation(); default_owner_thread_id()
 │   ├── confirmation/      # Confirmation/ConfirmationUI ABCs + InMemoryConfirmationStore
+│   ├── blocks/            # Neutral interactive-block contracts (Form + BlockAction); channel
+│   │                      #   adapters map them to their wire (see GATEWAY.md § Interactive Blocks)
 │   ├── commands/          # Channel-agnostic slash-command dispatch (pre-LLM short-circuit)
 │   ├── apps/              # Channel-agnostic structured surfaces — request/response, no model
 │   ├── channels/          # Concrete channels, one dir each (telegram/, jarvis_app/) — ONLY channel-specific code

--- a/docs/architecture/GATEWAY.md
+++ b/docs/architecture/GATEWAY.md
@@ -320,6 +320,87 @@ A channel publishes the manifest only if it has an Apps surface; one that doesn'
 
 ---
 
+## Interactive Blocks
+
+A block is structured content a message can carry beyond text — today a **form**
+(labelled, prefilled boxes the owner corrects and submits in one tap); the hub's
+contract also defines `buttons` and `card`, unbuilt here. The layer lives in
+`gateway/blocks/` and is deliberately **kind-generic**: adding a kind touches the
+neutral model and one channel adapter's table, never the `Channel` ABC, the
+Outbox, or another channel.
+
+### Module shape
+
+```
+gateway/blocks/
+├── base.py    # Block (kind, summary) · Interactive(Block) adds callback_id
+│              #   · BlockAction — one neutral inbound tap
+└── form.py    # Form / FormRow / TextField / NumberField + validation
+               #   + render_submission() (submitted values -> turn text)
+```
+
+Blocks are frozen dataclasses describing *intent*, never wire shape. All
+validation runs at construction, so a bad form fails at its caller with a
+correctable message rather than as a hub 422 inside an async send: row cap (6),
+units on every field of a multi-field row, type/default agreement (bools
+refused), unique snake_case field ids, non-empty title and summary.
+`callback_id` is always generated (caller slug + entropy, `push-day-a3f1`) —
+uniqueness is never the caller's job. `Form` has **no `values` field**: that
+records what the owner submitted, stamped by the hub on the tap, so a
+pre-stamped form is unconstructible rather than merely forbidden.
+
+### A form is content, not a protocol
+
+Unlike a confirmation — whose store holds a live `action_fn` genuinely pending
+approval — a form defers nothing. Nothing is pending while it sits untapped, so
+there is **no pending store, no TTL, no sweep**, and a restart forgets nothing
+that matters. The LangGraph thread is the only store: the sending tool's return
+string records what was asked (field ids + prefills), and the submit lands in a
+context that contains the question.
+
+### Outbound
+
+```
+caller ──▶ channel.supports_block(kind)?      # pre-flight — decides "this
+   │            no ──▶ caller's own fallback  #   channel has no forms"
+   ▼ yes
+origin_outbox().send_block_to_owner(text, block) ──▶ Channel.send_block(text, block)
+   │                                                   (one POST: text + block,
+   └─ returns SendOutcome — never raises                all-or-nothing)
+```
+
+The seam never invents a fallback: on a channel that can't render the kind,
+nothing is sent and the caller decides — the model says it conversationally
+(the `send_form` tool returns the prepared prefills as a directive), a code
+caller sends its own `notify_owner(...)`. Nothing goes out partially, so the
+owner never gets a dangling opener pointing at a card that isn't there. Wire
+mapping is an adapter-side table keyed by block type (`_BLOCK_WIRE` in the
+jarvis-app channel) — deliberately not a `to_wire()` on the neutral model,
+which would bake one hub's JSON into it.
+
+### Inbound
+
+The channel router translates a tap into a neutral `BlockAction(kind,
+action_id, message_id, callback_id, values)` and dispatches by kind:
+`confirmation` resolves below the LLM via the store (Plane 3); `form` becomes
+an ordinary inbound turn — `render_submission()` turns the values into text
+(`[Submitted form push-day-a3f1] bench_reps: 8 · core: (left empty)`; `null`
+stays visibly distinct from zero, the one distinction the hub preserves), which
+is persisted to `chat_history.jsonl` by the shared handler before the model
+runs. No deterministic handler touches a database on submit — what to do with
+the values is the model's decision in thread context.
+
+**A form's card is closed by `PATCH {state: "logged"}` strictly *after* the
+turn completes.** A turn that dies leaves the card live — and that is the
+recovery path: the hub's re-tap guard lifts once the update is acked (which
+happens at fetch), so the owner re-taps and the turn re-runs with thread
+context. A failed PATCH after a successful turn is logged and never fails the
+consumed update. The form vocabulary is `logged | expired` (no `cancelled` — a
+form has nothing to decline); expiry is nobody's job today, since with no
+pending store a stale card costs nothing.
+
+---
+
 ## Contracts
 
 ### `InboundMessage` (`gateway/base.py`)
@@ -365,6 +446,10 @@ class Channel(ABC):
         """Default: collect chunks, then send once. Streaming channels override."""
         full = "".join([c async for c in chunks])
         await self.send(chat_id, full)
+
+    # Interactive blocks (gateway/blocks/) — optional, kind-generic:
+    def supports_block(self, kind: str) -> bool:          # default False
+    async def send_block(self, text: str, block) -> None: # default raises NotImplementedError
 ```
 
 | Method | Purpose | Notes |
@@ -374,6 +459,8 @@ class Channel(ABC):
 | `authorize` | Is this user allowed to use Jarvis on this channel? | Single allowlist per channel today; can grow later. |
 | `owner_thread_id` | Agent thread id of the owner's conversation. | Same value the channel's router stamps on inbound messages; lets domain code address the owner's thread without knowing the format. |
 | `send_stream` | Streaming send (TTS, partial reply). | Default collect-then-send; voice channels override. |
+| `supports_block` | Can this channel render block `kind`? | The pre-flight callers consult before composing; default `False`, channels opt in. |
+| `send_block` | Owner-addressed text + interactive block, all-or-nothing. | Called via `Outbox.send_block_to_owner`. Default raises; a new kind never edits the ABC. |
 
 Lifecycle is deliberately **not** on the ABC: bring-up/tear-down is owned by the channel *package* (Telegram: `gateway/channels/telegram/host.py` wraps the PTB Application; the factory returns a stack with `start()`/`stop()`). A former abstract `start(on_message)` was removed once the host pattern left it with no caller.
 
@@ -395,6 +482,7 @@ class Outbox:
     def __init__(self, channel: Channel, log_sink: LogSink | None): ...
     async def notify_owner(text, *, event=None, metadata=None) -> SendOutcome
     async def notify_owner_media(kind, payload, caption=None, *, event=None, metadata=None) -> SendOutcome
+    async def send_block_to_owner(text, block, *, event=None, metadata=None) -> SendOutcome
 ```
 
 The single seam for owner-addressed sends (see Plane 2). `default_outbox()` in `gateway/factory.py` is how domain code reaches it; `LogSink` is injected by the host (`async_append_notification_log`) so the gateway stays free of tools-layer imports.
@@ -533,7 +621,7 @@ Jarvis takes option (2). Each channel's factory reads its owner-config env and p
 
 The factory reads the env value and passes it into the channel constructor; nowhere else in the codebase reads it (`main.py` only calls `load_dotenv` — it never sees channel config).
 
-Domain code reaches channels through factory accessors, never through a channel object. **Proactive** sends use `default_outbox()`, which resolves the configured default channel (`JARVIS_DEFAULT_CHANNEL`, default `telegram`) at call time through a name-keyed registry; `default_owner_thread_id()` addresses the owner's thread on that default channel, for origin-less owner-addressed routing. **Reactive** traffic follows its origin channel instead: a resolved confirmation acks on the thread it came from (the store carries its own channel's thread/outbox), and `get_confirmation()` resolves the origin channel's store from the running turn's `CURRENT_THREAD_ID`. Today every accessor resolves to the single Telegram channel; when a second channel ships, "which channel does this target" is a routing decision that lives in `factory.py`, not in callers.
+Domain code reaches channels through factory accessors, never through a channel object. **Proactive** sends use `default_outbox()`, which resolves the configured default channel (`JARVIS_DEFAULT_CHANNEL`, default `telegram`) at call time through a name-keyed registry; `default_owner_thread_id()` addresses the owner's thread on that default channel, for origin-less owner-addressed routing. **Reactive** traffic follows its origin channel instead: a resolved confirmation acks on the thread it came from (the store carries its own channel's thread/outbox), and `get_confirmation()` resolves the origin channel's store from the running turn's `CURRENT_THREAD_ID`. `origin_channel()` / `origin_outbox()` apply the same origin rule to what a turn *produces* — a tool-initiated send (e.g. `send_form`) consults the origin channel's capability and sends on its outbox, falling back to the default entry for origin-less turns. The failure modes differ on purpose: `get_confirmation()` **raises** when the resolved channel has no store (a destructive tool with nowhere to confirm is a wiring bug), while `origin_*` **falls back** to the default (an origin-less turn is a normal case). "Which channel does this target" is a routing decision that lives in `factory.py`, not in callers.
 
 ---
 

--- a/docs/architecture/channels/jarvis-app/contract.md
+++ b/docs/architecture/channels/jarvis-app/contract.md
@@ -6,7 +6,7 @@
 JSON Schema plus the endpoint list, generated from the Pydantic models and
 the mounted routes under `backend/jarvis_app_backend`.
 
-`contract_version`: `45e79b46aed20391`
+`contract_version`: `b2dcd9534e07bd23`
 
 ## Endpoints
 
@@ -41,7 +41,7 @@ the mounted routes under `backend/jarvis_app_backend`.
 ```json
 {
   "additionalProperties": false,
-  "description": "`POST /v1/actions`'s body \u2014 a tap on a live block. `action_id` names\none of the block's declared affordances, or, for `confirmation` (which\ndeclares none of its own \u2014 it has exactly two outcomes), the reserved\n`\"confirm\"`/`\"cancel\"` (architecture \u00a75). No `values` field here: it\nexists for submitted form data, and nothing reads it until a `form`\nrenderer exists.",
+  "description": "`POST /v1/actions`'s body \u2014 a tap on a live block. `action_id` names\none of the block's declared affordances, or, for `confirmation` (which\ndeclares none of its own \u2014 it has exactly two outcomes), the reserved\n`\"confirm\"`/`\"cancel\"` (architecture \u00a75).\n\n`values` carries what was typed into a `form`, and only a `form`: a kind\nthat declares no fields may not send it at all. Every declared `field_id`\nmust be present and `null` stands for a box left empty, so the agent can\ntell *\"seen and left blank\"* from *\"the app dropped a field\"* \u2014 an\nambiguity that would otherwise have no answer.\n\n`int` sits in the union ahead of `float` so a count stays a count: a reps\nbox holding `8` reaches the agent as `8`, not `8.0`, which it would if\nevery number widened to the only numeric type on offer. **A `bool` is not\nrefused, it is coerced** \u2014 Python's `bool` subclasses `int`, so `true`\narrives as `1`. Nothing this app ships can send one (no field type\ncollects a boolean), and refusing it would mean hand-written validation\nguarding against a value our own client cannot produce; it is recorded\nhere rather than defended against.",
   "properties": {
     "action_id": {
       "title": "Action Id",
@@ -50,6 +50,34 @@ the mounted routes under `backend/jarvis_app_backend`.
     "message_id": {
       "title": "Message Id",
       "type": "integer"
+    },
+    "values": {
+      "anyOf": [
+        {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Values"
     }
   },
   "required": [
@@ -65,7 +93,7 @@ the mounted routes under `backend/jarvis_app_backend`.
 
 ```json
 {
-  "description": "A tap the hub already validated against the block it names. `callback_id`\nis `None` when the block that was tapped carries none of its own.",
+  "description": "A tap the hub already validated against the block it names. `callback_id`\nis `None` when the block that was tapped carries none of its own.\n\n`values` is what was typed into a `form`, relayed unchanged and `None` for\nevery other kind \u2014 the hub refuses a tap that carries it on a kind with no\nfields, so its presence here already means the block declared them. Every\ndeclared `field_id` is present; a `null` is a box the user saw and left\nempty, which is why the agent never has to guess whether a missing key\nmeans blank or lost.",
   "properties": {
     "action_id": {
       "title": "Action Id",
@@ -99,6 +127,34 @@ the mounted routes under `backend/jarvis_app_backend`.
     "update_id": {
       "title": "Update Id",
       "type": "integer"
+    },
+    "values": {
+      "anyOf": [
+        {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Values"
     }
   },
   "required": [
@@ -873,6 +929,7 @@ the mounted routes under `backend/jarvis_app_backend`.
     },
     "FormBlock": {
       "additionalProperties": false,
+      "description": "`state` narrows to two values, not three: a form has nothing to decline,\nso there is no `cancelled` to sit beside `logged`. `expired` still applies \u2014\nthat is the absence of a decision, which a form can have like any other\nkind.\n\n**`values` is the one field in this contract a *client* writes onto a row\nthe agent authored**, and it is what makes a resolved form a record of what\nwas submitted rather than an echo of what was proposed. Everything else\nhere came from the agent's send; `state` is agent-written too, through\n`PATCH`, even though a tap is what triggers it. This arrives on\n`POST /v1/actions`, is validated against the fields `payload` declares, and\nis stamped by the hub in that same transaction.\n\nIt sits here rather than inside `FormPayload` because the payload is what\nthe agent proposed, and merging the user's own work into it would erase the\none distinction the field exists to make.\n\n**The send route refuses it, and that refusal is load-bearing rather than\ntidy.** `values` is *evidence of what the user submitted*, and evidence an\nagent can write is not evidence \u2014 without the refusal an agent could send a\nform pre-stamped with a submission that never happened, and a client would\nrender it under the word `logged`. Declared optional here because a form is\nsent without it and carries it only after a tap; refused at the door\nrather than by this type, since Pydantic cannot see which direction a\nblock is travelling.",
       "properties": {
         "kind": {
           "const": "form",
@@ -886,6 +943,10 @@ the mounted routes under `backend/jarvis_app_backend`.
         "state": {
           "anyOf": [
             {
+              "enum": [
+                "logged",
+                "expired"
+              ],
               "type": "string"
             },
             {
@@ -898,6 +959,34 @@ the mounted routes under `backend/jarvis_app_backend`.
         "summary": {
           "title": "Summary",
           "type": "string"
+        },
+        "values": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Values"
         }
       },
       "required": [
@@ -907,12 +996,76 @@ the mounted routes under `backend/jarvis_app_backend`.
       "title": "FormBlock",
       "type": "object"
     },
-    "FormField": {
+    "FormPayload": {
       "additionalProperties": false,
+      "description": "`type` opens at `text` and `number` alone \u2014 the two a renderer draws.\nThe wider set a form could plausibly want (a choice, a toggle, a date, a\ntime) is deliberately absent rather than declared and unhandled: a type\nnothing can draw is a promise the system cannot keep, and each of those\nneeds a design before it needs a schema.\n\n`callback_id` sits here because the hub stamps it onto every action update,\nwhich is what lets an agent resolve the right pending decision without\nkeeping a `message_id`\u2192handle map it would lose on each deploy.\n\nA form declares no actions. It has exactly one, so naming it would be a\nsecond name for the same thing, and its tap carries the reserved\n`\"submit\"` \u2014 the same shape `confirmation` uses for its own two fixed\noutcomes. `submit_label` is the words on that one control, nothing more.",
       "properties": {
-        "field_id": {
-          "title": "Field Id",
+        "callback_id": {
+          "title": "Callback Id",
           "type": "string"
+        },
+        "rows": {
+          "items": {
+            "$ref": "#/$defs/FormRow"
+          },
+          "title": "Rows",
+          "type": "array"
+        },
+        "submit_label": {
+          "default": "Submit",
+          "title": "Submit Label",
+          "type": "string"
+        },
+        "subtitle": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Subtitle"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        }
+      },
+      "required": [
+        "callback_id",
+        "title",
+        "rows"
+      ],
+      "title": "FormPayload",
+      "type": "object"
+    },
+    "FormRow": {
+      "additionalProperties": false,
+      "description": "One labelled thing being filled in, and the one or two boxes it takes \u2014\n*\"Bench press\"* with a reps box and a kg box beside it. The grouping lives\nhere rather than being inferred from a flat list because the resolved and\nexpired renders collapse a **row** to a single value, so it has to exist in\nthe payload rather than be re-derived at draw time. A flat list carrying a\n`group` key was rejected for the reason the union above exists: the\ngrouping would become a convention the hub cannot check.",
+      "properties": {
+        "fields": {
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "number": "#/$defs/NumberField",
+                "text": "#/$defs/TextField"
+              },
+              "propertyName": "type"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/TextField"
+              },
+              {
+                "$ref": "#/$defs/NumberField"
+              }
+            ]
+          },
+          "minItems": 1,
+          "title": "Fields",
+          "type": "array"
         },
         "label": {
           "title": "Label",
@@ -920,33 +1073,100 @@ the mounted routes under `backend/jarvis_app_backend`.
         }
       },
       "required": [
-        "field_id",
-        "label"
+        "label",
+        "fields"
       ],
-      "title": "FormField",
+      "title": "FormRow",
       "type": "object"
     },
-    "FormPayload": {
+    "NumberField": {
       "additionalProperties": false,
-      "description": "`fields` carries a label and an id and nothing else \u2014 there is no field\n*type*, no required flag, no default. That is the whole taxonomy, and it\nstays this small until a renderer forces the question: a type nothing can\ndraw is a promise the system cannot keep.",
+      "description": "A numeric box. Identical to `TextField` but for what `default` may hold,\nwhich is the whole reason these are two models rather than one with a\n`type` tag beside an untyped default.",
       "properties": {
-        "fields": {
-          "items": {
-            "$ref": "#/$defs/FormField"
-          },
-          "title": "Fields",
-          "type": "array"
+        "default": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Default"
         },
-        "submit_label": {
-          "default": "Submit",
-          "title": "Submit Label",
+        "field_id": {
+          "title": "Field Id",
           "type": "string"
+        },
+        "type": {
+          "const": "number",
+          "default": "number",
+          "title": "Type",
+          "type": "string"
+        },
+        "unit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Unit"
         }
       },
       "required": [
-        "fields"
+        "field_id"
       ],
-      "title": "FormPayload",
+      "title": "NumberField",
+      "type": "object"
+    },
+    "TextField": {
+      "additionalProperties": false,
+      "description": "A free-text box. `default` is the *prepopulation*, not a hint: a form\narrives with the agent's best guess already in the box, to be corrected or\naccepted rather than composed from nothing. There is no placeholder \u2014 that\nrenders only into an empty box, which is a state nothing draws \u2014 and no\nper-field label, because `unit` is what names a box on screen and in the\nname a screen reader composes from the row's label plus it.",
+      "properties": {
+        "default": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Default"
+        },
+        "field_id": {
+          "title": "Field Id",
+          "type": "string"
+        },
+        "type": {
+          "const": "text",
+          "default": "text",
+          "title": "Type",
+          "type": "string"
+        },
+        "unit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Unit"
+        }
+      },
+      "required": [
+        "field_id"
+      ],
+      "title": "TextField",
       "type": "object"
     }
   },
@@ -1341,12 +1561,76 @@ the mounted routes under `backend/jarvis_app_backend`.
 ```json
 {
   "$defs": {
-    "FormField": {
+    "FormPayload": {
       "additionalProperties": false,
+      "description": "`type` opens at `text` and `number` alone \u2014 the two a renderer draws.\nThe wider set a form could plausibly want (a choice, a toggle, a date, a\ntime) is deliberately absent rather than declared and unhandled: a type\nnothing can draw is a promise the system cannot keep, and each of those\nneeds a design before it needs a schema.\n\n`callback_id` sits here because the hub stamps it onto every action update,\nwhich is what lets an agent resolve the right pending decision without\nkeeping a `message_id`\u2192handle map it would lose on each deploy.\n\nA form declares no actions. It has exactly one, so naming it would be a\nsecond name for the same thing, and its tap carries the reserved\n`\"submit\"` \u2014 the same shape `confirmation` uses for its own two fixed\noutcomes. `submit_label` is the words on that one control, nothing more.",
       "properties": {
-        "field_id": {
-          "title": "Field Id",
+        "callback_id": {
+          "title": "Callback Id",
           "type": "string"
+        },
+        "rows": {
+          "items": {
+            "$ref": "#/$defs/FormRow"
+          },
+          "title": "Rows",
+          "type": "array"
+        },
+        "submit_label": {
+          "default": "Submit",
+          "title": "Submit Label",
+          "type": "string"
+        },
+        "subtitle": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Subtitle"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        }
+      },
+      "required": [
+        "callback_id",
+        "title",
+        "rows"
+      ],
+      "title": "FormPayload",
+      "type": "object"
+    },
+    "FormRow": {
+      "additionalProperties": false,
+      "description": "One labelled thing being filled in, and the one or two boxes it takes \u2014\n*\"Bench press\"* with a reps box and a kg box beside it. The grouping lives\nhere rather than being inferred from a flat list because the resolved and\nexpired renders collapse a **row** to a single value, so it has to exist in\nthe payload rather than be re-derived at draw time. A flat list carrying a\n`group` key was rejected for the reason the union above exists: the\ngrouping would become a convention the hub cannot check.",
+      "properties": {
+        "fields": {
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "number": "#/$defs/NumberField",
+                "text": "#/$defs/TextField"
+              },
+              "propertyName": "type"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/TextField"
+              },
+              {
+                "$ref": "#/$defs/NumberField"
+              }
+            ]
+          },
+          "minItems": 1,
+          "title": "Fields",
+          "type": "array"
         },
         "label": {
           "title": "Label",
@@ -1354,37 +1638,105 @@ the mounted routes under `backend/jarvis_app_backend`.
         }
       },
       "required": [
-        "field_id",
-        "label"
+        "label",
+        "fields"
       ],
-      "title": "FormField",
+      "title": "FormRow",
       "type": "object"
     },
-    "FormPayload": {
+    "NumberField": {
       "additionalProperties": false,
-      "description": "`fields` carries a label and an id and nothing else \u2014 there is no field\n*type*, no required flag, no default. That is the whole taxonomy, and it\nstays this small until a renderer forces the question: a type nothing can\ndraw is a promise the system cannot keep.",
+      "description": "A numeric box. Identical to `TextField` but for what `default` may hold,\nwhich is the whole reason these are two models rather than one with a\n`type` tag beside an untyped default.",
       "properties": {
-        "fields": {
-          "items": {
-            "$ref": "#/$defs/FormField"
-          },
-          "title": "Fields",
-          "type": "array"
+        "default": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Default"
         },
-        "submit_label": {
-          "default": "Submit",
-          "title": "Submit Label",
+        "field_id": {
+          "title": "Field Id",
           "type": "string"
+        },
+        "type": {
+          "const": "number",
+          "default": "number",
+          "title": "Type",
+          "type": "string"
+        },
+        "unit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Unit"
         }
       },
       "required": [
-        "fields"
+        "field_id"
       ],
-      "title": "FormPayload",
+      "title": "NumberField",
+      "type": "object"
+    },
+    "TextField": {
+      "additionalProperties": false,
+      "description": "A free-text box. `default` is the *prepopulation*, not a hint: a form\narrives with the agent's best guess already in the box, to be corrected or\naccepted rather than composed from nothing. There is no placeholder \u2014 that\nrenders only into an empty box, which is a state nothing draws \u2014 and no\nper-field label, because `unit` is what names a box on screen and in the\nname a screen reader composes from the row's label plus it.",
+      "properties": {
+        "default": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Default"
+        },
+        "field_id": {
+          "title": "Field Id",
+          "type": "string"
+        },
+        "type": {
+          "const": "text",
+          "default": "text",
+          "title": "Type",
+          "type": "string"
+        },
+        "unit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Unit"
+        }
+      },
+      "required": [
+        "field_id"
+      ],
+      "title": "TextField",
       "type": "object"
     }
   },
   "additionalProperties": false,
+  "description": "`state` narrows to two values, not three: a form has nothing to decline,\nso there is no `cancelled` to sit beside `logged`. `expired` still applies \u2014\nthat is the absence of a decision, which a form can have like any other\nkind.\n\n**`values` is the one field in this contract a *client* writes onto a row\nthe agent authored**, and it is what makes a resolved form a record of what\nwas submitted rather than an echo of what was proposed. Everything else\nhere came from the agent's send; `state` is agent-written too, through\n`PATCH`, even though a tap is what triggers it. This arrives on\n`POST /v1/actions`, is validated against the fields `payload` declares, and\nis stamped by the hub in that same transaction.\n\nIt sits here rather than inside `FormPayload` because the payload is what\nthe agent proposed, and merging the user's own work into it would erase the\none distinction the field exists to make.\n\n**The send route refuses it, and that refusal is load-bearing rather than\ntidy.** `values` is *evidence of what the user submitted*, and evidence an\nagent can write is not evidence \u2014 without the refusal an agent could send a\nform pre-stamped with a submission that never happened, and a client would\nrender it under the word `logged`. Declared optional here because a form is\nsent without it and carries it only after a tap; refused at the door\nrather than by this type, since Pydantic cannot see which direction a\nblock is travelling.",
   "properties": {
     "kind": {
       "const": "form",
@@ -1398,6 +1750,10 @@ the mounted routes under `backend/jarvis_app_backend`.
     "state": {
       "anyOf": [
         {
+          "enum": [
+            "logged",
+            "expired"
+          ],
           "type": "string"
         },
         {
@@ -1410,6 +1766,34 @@ the mounted routes under `backend/jarvis_app_backend`.
     "summary": {
       "title": "Summary",
       "type": "string"
+    },
+    "values": {
+      "anyOf": [
+        {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Values"
     }
   },
   "required": [
@@ -1883,6 +2267,7 @@ the mounted routes under `backend/jarvis_app_backend`.
     },
     "FormBlock": {
       "additionalProperties": false,
+      "description": "`state` narrows to two values, not three: a form has nothing to decline,\nso there is no `cancelled` to sit beside `logged`. `expired` still applies \u2014\nthat is the absence of a decision, which a form can have like any other\nkind.\n\n**`values` is the one field in this contract a *client* writes onto a row\nthe agent authored**, and it is what makes a resolved form a record of what\nwas submitted rather than an echo of what was proposed. Everything else\nhere came from the agent's send; `state` is agent-written too, through\n`PATCH`, even though a tap is what triggers it. This arrives on\n`POST /v1/actions`, is validated against the fields `payload` declares, and\nis stamped by the hub in that same transaction.\n\nIt sits here rather than inside `FormPayload` because the payload is what\nthe agent proposed, and merging the user's own work into it would erase the\none distinction the field exists to make.\n\n**The send route refuses it, and that refusal is load-bearing rather than\ntidy.** `values` is *evidence of what the user submitted*, and evidence an\nagent can write is not evidence \u2014 without the refusal an agent could send a\nform pre-stamped with a submission that never happened, and a client would\nrender it under the word `logged`. Declared optional here because a form is\nsent without it and carries it only after a tap; refused at the door\nrather than by this type, since Pydantic cannot see which direction a\nblock is travelling.",
       "properties": {
         "kind": {
           "const": "form",
@@ -1896,6 +2281,10 @@ the mounted routes under `backend/jarvis_app_backend`.
         "state": {
           "anyOf": [
             {
+              "enum": [
+                "logged",
+                "expired"
+              ],
               "type": "string"
             },
             {
@@ -1908,6 +2297,34 @@ the mounted routes under `backend/jarvis_app_backend`.
         "summary": {
           "title": "Summary",
           "type": "string"
+        },
+        "values": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Values"
         }
       },
       "required": [
@@ -1917,12 +2334,76 @@ the mounted routes under `backend/jarvis_app_backend`.
       "title": "FormBlock",
       "type": "object"
     },
-    "FormField": {
+    "FormPayload": {
       "additionalProperties": false,
+      "description": "`type` opens at `text` and `number` alone \u2014 the two a renderer draws.\nThe wider set a form could plausibly want (a choice, a toggle, a date, a\ntime) is deliberately absent rather than declared and unhandled: a type\nnothing can draw is a promise the system cannot keep, and each of those\nneeds a design before it needs a schema.\n\n`callback_id` sits here because the hub stamps it onto every action update,\nwhich is what lets an agent resolve the right pending decision without\nkeeping a `message_id`\u2192handle map it would lose on each deploy.\n\nA form declares no actions. It has exactly one, so naming it would be a\nsecond name for the same thing, and its tap carries the reserved\n`\"submit\"` \u2014 the same shape `confirmation` uses for its own two fixed\noutcomes. `submit_label` is the words on that one control, nothing more.",
       "properties": {
-        "field_id": {
-          "title": "Field Id",
+        "callback_id": {
+          "title": "Callback Id",
           "type": "string"
+        },
+        "rows": {
+          "items": {
+            "$ref": "#/$defs/FormRow"
+          },
+          "title": "Rows",
+          "type": "array"
+        },
+        "submit_label": {
+          "default": "Submit",
+          "title": "Submit Label",
+          "type": "string"
+        },
+        "subtitle": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Subtitle"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        }
+      },
+      "required": [
+        "callback_id",
+        "title",
+        "rows"
+      ],
+      "title": "FormPayload",
+      "type": "object"
+    },
+    "FormRow": {
+      "additionalProperties": false,
+      "description": "One labelled thing being filled in, and the one or two boxes it takes \u2014\n*\"Bench press\"* with a reps box and a kg box beside it. The grouping lives\nhere rather than being inferred from a flat list because the resolved and\nexpired renders collapse a **row** to a single value, so it has to exist in\nthe payload rather than be re-derived at draw time. A flat list carrying a\n`group` key was rejected for the reason the union above exists: the\ngrouping would become a convention the hub cannot check.",
+      "properties": {
+        "fields": {
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "number": "#/$defs/NumberField",
+                "text": "#/$defs/TextField"
+              },
+              "propertyName": "type"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/TextField"
+              },
+              {
+                "$ref": "#/$defs/NumberField"
+              }
+            ]
+          },
+          "minItems": 1,
+          "title": "Fields",
+          "type": "array"
         },
         "label": {
           "title": "Label",
@@ -1930,33 +2411,10 @@ the mounted routes under `backend/jarvis_app_backend`.
         }
       },
       "required": [
-        "field_id",
-        "label"
-      ],
-      "title": "FormField",
-      "type": "object"
-    },
-    "FormPayload": {
-      "additionalProperties": false,
-      "description": "`fields` carries a label and an id and nothing else \u2014 there is no field\n*type*, no required flag, no default. That is the whole taxonomy, and it\nstays this small until a renderer forces the question: a type nothing can\ndraw is a promise the system cannot keep.",
-      "properties": {
-        "fields": {
-          "items": {
-            "$ref": "#/$defs/FormField"
-          },
-          "title": "Fields",
-          "type": "array"
-        },
-        "submit_label": {
-          "default": "Submit",
-          "title": "Submit Label",
-          "type": "string"
-        }
-      },
-      "required": [
+        "label",
         "fields"
       ],
-      "title": "FormPayload",
+      "title": "FormRow",
       "type": "object"
     },
     "MessageMeta": {
@@ -1979,6 +2437,96 @@ the mounted routes under `backend/jarvis_app_backend`.
         "source"
       ],
       "title": "MessageMeta",
+      "type": "object"
+    },
+    "NumberField": {
+      "additionalProperties": false,
+      "description": "A numeric box. Identical to `TextField` but for what `default` may hold,\nwhich is the whole reason these are two models rather than one with a\n`type` tag beside an untyped default.",
+      "properties": {
+        "default": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Default"
+        },
+        "field_id": {
+          "title": "Field Id",
+          "type": "string"
+        },
+        "type": {
+          "const": "number",
+          "default": "number",
+          "title": "Type",
+          "type": "string"
+        },
+        "unit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Unit"
+        }
+      },
+      "required": [
+        "field_id"
+      ],
+      "title": "NumberField",
+      "type": "object"
+    },
+    "TextField": {
+      "additionalProperties": false,
+      "description": "A free-text box. `default` is the *prepopulation*, not a hint: a form\narrives with the agent's best guess already in the box, to be corrected or\naccepted rather than composed from nothing. There is no placeholder \u2014 that\nrenders only into an empty box, which is a state nothing draws \u2014 and no\nper-field label, because `unit` is what names a box on screen and in the\nname a screen reader composes from the row's label plus it.",
+      "properties": {
+        "default": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Default"
+        },
+        "field_id": {
+          "title": "Field Id",
+          "type": "string"
+        },
+        "type": {
+          "const": "text",
+          "default": "text",
+          "title": "Type",
+          "type": "string"
+        },
+        "unit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Unit"
+        }
+      },
+      "required": [
+        "field_id"
+      ],
+      "title": "TextField",
       "type": "object"
     }
   },
@@ -2496,6 +3044,7 @@ the mounted routes under `backend/jarvis_app_backend`.
     },
     "FormBlock": {
       "additionalProperties": false,
+      "description": "`state` narrows to two values, not three: a form has nothing to decline,\nso there is no `cancelled` to sit beside `logged`. `expired` still applies \u2014\nthat is the absence of a decision, which a form can have like any other\nkind.\n\n**`values` is the one field in this contract a *client* writes onto a row\nthe agent authored**, and it is what makes a resolved form a record of what\nwas submitted rather than an echo of what was proposed. Everything else\nhere came from the agent's send; `state` is agent-written too, through\n`PATCH`, even though a tap is what triggers it. This arrives on\n`POST /v1/actions`, is validated against the fields `payload` declares, and\nis stamped by the hub in that same transaction.\n\nIt sits here rather than inside `FormPayload` because the payload is what\nthe agent proposed, and merging the user's own work into it would erase the\none distinction the field exists to make.\n\n**The send route refuses it, and that refusal is load-bearing rather than\ntidy.** `values` is *evidence of what the user submitted*, and evidence an\nagent can write is not evidence \u2014 without the refusal an agent could send a\nform pre-stamped with a submission that never happened, and a client would\nrender it under the word `logged`. Declared optional here because a form is\nsent without it and carries it only after a tap; refused at the door\nrather than by this type, since Pydantic cannot see which direction a\nblock is travelling.",
       "properties": {
         "kind": {
           "const": "form",
@@ -2509,6 +3058,10 @@ the mounted routes under `backend/jarvis_app_backend`.
         "state": {
           "anyOf": [
             {
+              "enum": [
+                "logged",
+                "expired"
+              ],
               "type": "string"
             },
             {
@@ -2521,6 +3074,34 @@ the mounted routes under `backend/jarvis_app_backend`.
         "summary": {
           "title": "Summary",
           "type": "string"
+        },
+        "values": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Values"
         }
       },
       "required": [
@@ -2530,12 +3111,76 @@ the mounted routes under `backend/jarvis_app_backend`.
       "title": "FormBlock",
       "type": "object"
     },
-    "FormField": {
+    "FormPayload": {
       "additionalProperties": false,
+      "description": "`type` opens at `text` and `number` alone \u2014 the two a renderer draws.\nThe wider set a form could plausibly want (a choice, a toggle, a date, a\ntime) is deliberately absent rather than declared and unhandled: a type\nnothing can draw is a promise the system cannot keep, and each of those\nneeds a design before it needs a schema.\n\n`callback_id` sits here because the hub stamps it onto every action update,\nwhich is what lets an agent resolve the right pending decision without\nkeeping a `message_id`\u2192handle map it would lose on each deploy.\n\nA form declares no actions. It has exactly one, so naming it would be a\nsecond name for the same thing, and its tap carries the reserved\n`\"submit\"` \u2014 the same shape `confirmation` uses for its own two fixed\noutcomes. `submit_label` is the words on that one control, nothing more.",
       "properties": {
-        "field_id": {
-          "title": "Field Id",
+        "callback_id": {
+          "title": "Callback Id",
           "type": "string"
+        },
+        "rows": {
+          "items": {
+            "$ref": "#/$defs/FormRow"
+          },
+          "title": "Rows",
+          "type": "array"
+        },
+        "submit_label": {
+          "default": "Submit",
+          "title": "Submit Label",
+          "type": "string"
+        },
+        "subtitle": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Subtitle"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        }
+      },
+      "required": [
+        "callback_id",
+        "title",
+        "rows"
+      ],
+      "title": "FormPayload",
+      "type": "object"
+    },
+    "FormRow": {
+      "additionalProperties": false,
+      "description": "One labelled thing being filled in, and the one or two boxes it takes \u2014\n*\"Bench press\"* with a reps box and a kg box beside it. The grouping lives\nhere rather than being inferred from a flat list because the resolved and\nexpired renders collapse a **row** to a single value, so it has to exist in\nthe payload rather than be re-derived at draw time. A flat list carrying a\n`group` key was rejected for the reason the union above exists: the\ngrouping would become a convention the hub cannot check.",
+      "properties": {
+        "fields": {
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "number": "#/$defs/NumberField",
+                "text": "#/$defs/TextField"
+              },
+              "propertyName": "type"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/TextField"
+              },
+              {
+                "$ref": "#/$defs/NumberField"
+              }
+            ]
+          },
+          "minItems": 1,
+          "title": "Fields",
+          "type": "array"
         },
         "label": {
           "title": "Label",
@@ -2543,33 +3188,10 @@ the mounted routes under `backend/jarvis_app_backend`.
         }
       },
       "required": [
-        "field_id",
-        "label"
-      ],
-      "title": "FormField",
-      "type": "object"
-    },
-    "FormPayload": {
-      "additionalProperties": false,
-      "description": "`fields` carries a label and an id and nothing else \u2014 there is no field\n*type*, no required flag, no default. That is the whole taxonomy, and it\nstays this small until a renderer forces the question: a type nothing can\ndraw is a promise the system cannot keep.",
-      "properties": {
-        "fields": {
-          "items": {
-            "$ref": "#/$defs/FormField"
-          },
-          "title": "Fields",
-          "type": "array"
-        },
-        "submit_label": {
-          "default": "Submit",
-          "title": "Submit Label",
-          "type": "string"
-        }
-      },
-      "required": [
+        "label",
         "fields"
       ],
-      "title": "FormPayload",
+      "title": "FormRow",
       "type": "object"
     },
     "Message": {
@@ -2722,6 +3344,96 @@ the mounted routes under `backend/jarvis_app_backend`.
         "source"
       ],
       "title": "MessageMeta",
+      "type": "object"
+    },
+    "NumberField": {
+      "additionalProperties": false,
+      "description": "A numeric box. Identical to `TextField` but for what `default` may hold,\nwhich is the whole reason these are two models rather than one with a\n`type` tag beside an untyped default.",
+      "properties": {
+        "default": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Default"
+        },
+        "field_id": {
+          "title": "Field Id",
+          "type": "string"
+        },
+        "type": {
+          "const": "number",
+          "default": "number",
+          "title": "Type",
+          "type": "string"
+        },
+        "unit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Unit"
+        }
+      },
+      "required": [
+        "field_id"
+      ],
+      "title": "NumberField",
+      "type": "object"
+    },
+    "TextField": {
+      "additionalProperties": false,
+      "description": "A free-text box. `default` is the *prepopulation*, not a hint: a form\narrives with the agent's best guess already in the box, to be corrected or\naccepted rather than composed from nothing. There is no placeholder \u2014 that\nrenders only into an empty box, which is a state nothing draws \u2014 and no\nper-field label, because `unit` is what names a box on screen and in the\nname a screen reader composes from the row's label plus it.",
+      "properties": {
+        "default": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Default"
+        },
+        "field_id": {
+          "title": "Field Id",
+          "type": "string"
+        },
+        "type": {
+          "const": "text",
+          "default": "text",
+          "title": "Type",
+          "type": "string"
+        },
+        "unit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Unit"
+        }
+      },
+      "required": [
+        "field_id"
+      ],
+      "title": "TextField",
       "type": "object"
     }
   },
@@ -3105,6 +3817,7 @@ the mounted routes under `backend/jarvis_app_backend`.
     },
     "FormBlock": {
       "additionalProperties": false,
+      "description": "`state` narrows to two values, not three: a form has nothing to decline,\nso there is no `cancelled` to sit beside `logged`. `expired` still applies \u2014\nthat is the absence of a decision, which a form can have like any other\nkind.\n\n**`values` is the one field in this contract a *client* writes onto a row\nthe agent authored**, and it is what makes a resolved form a record of what\nwas submitted rather than an echo of what was proposed. Everything else\nhere came from the agent's send; `state` is agent-written too, through\n`PATCH`, even though a tap is what triggers it. This arrives on\n`POST /v1/actions`, is validated against the fields `payload` declares, and\nis stamped by the hub in that same transaction.\n\nIt sits here rather than inside `FormPayload` because the payload is what\nthe agent proposed, and merging the user's own work into it would erase the\none distinction the field exists to make.\n\n**The send route refuses it, and that refusal is load-bearing rather than\ntidy.** `values` is *evidence of what the user submitted*, and evidence an\nagent can write is not evidence \u2014 without the refusal an agent could send a\nform pre-stamped with a submission that never happened, and a client would\nrender it under the word `logged`. Declared optional here because a form is\nsent without it and carries it only after a tap; refused at the door\nrather than by this type, since Pydantic cannot see which direction a\nblock is travelling.",
       "properties": {
         "kind": {
           "const": "form",
@@ -3118,6 +3831,10 @@ the mounted routes under `backend/jarvis_app_backend`.
         "state": {
           "anyOf": [
             {
+              "enum": [
+                "logged",
+                "expired"
+              ],
               "type": "string"
             },
             {
@@ -3130,6 +3847,34 @@ the mounted routes under `backend/jarvis_app_backend`.
         "summary": {
           "title": "Summary",
           "type": "string"
+        },
+        "values": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Values"
         }
       },
       "required": [
@@ -3139,12 +3884,76 @@ the mounted routes under `backend/jarvis_app_backend`.
       "title": "FormBlock",
       "type": "object"
     },
-    "FormField": {
+    "FormPayload": {
       "additionalProperties": false,
+      "description": "`type` opens at `text` and `number` alone \u2014 the two a renderer draws.\nThe wider set a form could plausibly want (a choice, a toggle, a date, a\ntime) is deliberately absent rather than declared and unhandled: a type\nnothing can draw is a promise the system cannot keep, and each of those\nneeds a design before it needs a schema.\n\n`callback_id` sits here because the hub stamps it onto every action update,\nwhich is what lets an agent resolve the right pending decision without\nkeeping a `message_id`\u2192handle map it would lose on each deploy.\n\nA form declares no actions. It has exactly one, so naming it would be a\nsecond name for the same thing, and its tap carries the reserved\n`\"submit\"` \u2014 the same shape `confirmation` uses for its own two fixed\noutcomes. `submit_label` is the words on that one control, nothing more.",
       "properties": {
-        "field_id": {
-          "title": "Field Id",
+        "callback_id": {
+          "title": "Callback Id",
           "type": "string"
+        },
+        "rows": {
+          "items": {
+            "$ref": "#/$defs/FormRow"
+          },
+          "title": "Rows",
+          "type": "array"
+        },
+        "submit_label": {
+          "default": "Submit",
+          "title": "Submit Label",
+          "type": "string"
+        },
+        "subtitle": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Subtitle"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        }
+      },
+      "required": [
+        "callback_id",
+        "title",
+        "rows"
+      ],
+      "title": "FormPayload",
+      "type": "object"
+    },
+    "FormRow": {
+      "additionalProperties": false,
+      "description": "One labelled thing being filled in, and the one or two boxes it takes \u2014\n*\"Bench press\"* with a reps box and a kg box beside it. The grouping lives\nhere rather than being inferred from a flat list because the resolved and\nexpired renders collapse a **row** to a single value, so it has to exist in\nthe payload rather than be re-derived at draw time. A flat list carrying a\n`group` key was rejected for the reason the union above exists: the\ngrouping would become a convention the hub cannot check.",
+      "properties": {
+        "fields": {
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "number": "#/$defs/NumberField",
+                "text": "#/$defs/TextField"
+              },
+              "propertyName": "type"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/TextField"
+              },
+              {
+                "$ref": "#/$defs/NumberField"
+              }
+            ]
+          },
+          "minItems": 1,
+          "title": "Fields",
+          "type": "array"
         },
         "label": {
           "title": "Label",
@@ -3152,33 +3961,10 @@ the mounted routes under `backend/jarvis_app_backend`.
         }
       },
       "required": [
-        "field_id",
-        "label"
-      ],
-      "title": "FormField",
-      "type": "object"
-    },
-    "FormPayload": {
-      "additionalProperties": false,
-      "description": "`fields` carries a label and an id and nothing else \u2014 there is no field\n*type*, no required flag, no default. That is the whole taxonomy, and it\nstays this small until a renderer forces the question: a type nothing can\ndraw is a promise the system cannot keep.",
-      "properties": {
-        "fields": {
-          "items": {
-            "$ref": "#/$defs/FormField"
-          },
-          "title": "Fields",
-          "type": "array"
-        },
-        "submit_label": {
-          "default": "Submit",
-          "title": "Submit Label",
-          "type": "string"
-        }
-      },
-      "required": [
+        "label",
         "fields"
       ],
-      "title": "FormPayload",
+      "title": "FormRow",
       "type": "object"
     },
     "Message": {
@@ -3331,6 +4117,96 @@ the mounted routes under `backend/jarvis_app_backend`.
         "source"
       ],
       "title": "MessageMeta",
+      "type": "object"
+    },
+    "NumberField": {
+      "additionalProperties": false,
+      "description": "A numeric box. Identical to `TextField` but for what `default` may hold,\nwhich is the whole reason these are two models rather than one with a\n`type` tag beside an untyped default.",
+      "properties": {
+        "default": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Default"
+        },
+        "field_id": {
+          "title": "Field Id",
+          "type": "string"
+        },
+        "type": {
+          "const": "number",
+          "default": "number",
+          "title": "Type",
+          "type": "string"
+        },
+        "unit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Unit"
+        }
+      },
+      "required": [
+        "field_id"
+      ],
+      "title": "NumberField",
+      "type": "object"
+    },
+    "TextField": {
+      "additionalProperties": false,
+      "description": "A free-text box. `default` is the *prepopulation*, not a hint: a form\narrives with the agent's best guess already in the box, to be corrected or\naccepted rather than composed from nothing. There is no placeholder \u2014 that\nrenders only into an empty box, which is a state nothing draws \u2014 and no\nper-field label, because `unit` is what names a box on screen and in the\nname a screen reader composes from the row's label plus it.",
+      "properties": {
+        "default": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Default"
+        },
+        "field_id": {
+          "title": "Field Id",
+          "type": "string"
+        },
+        "type": {
+          "const": "text",
+          "default": "text",
+          "title": "Type",
+          "type": "string"
+        },
+        "unit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Unit"
+        }
+      },
+      "required": [
+        "field_id"
+      ],
+      "title": "TextField",
       "type": "object"
     }
   },
@@ -3643,6 +4519,7 @@ the mounted routes under `backend/jarvis_app_backend`.
     },
     "FormBlock": {
       "additionalProperties": false,
+      "description": "`state` narrows to two values, not three: a form has nothing to decline,\nso there is no `cancelled` to sit beside `logged`. `expired` still applies \u2014\nthat is the absence of a decision, which a form can have like any other\nkind.\n\n**`values` is the one field in this contract a *client* writes onto a row\nthe agent authored**, and it is what makes a resolved form a record of what\nwas submitted rather than an echo of what was proposed. Everything else\nhere came from the agent's send; `state` is agent-written too, through\n`PATCH`, even though a tap is what triggers it. This arrives on\n`POST /v1/actions`, is validated against the fields `payload` declares, and\nis stamped by the hub in that same transaction.\n\nIt sits here rather than inside `FormPayload` because the payload is what\nthe agent proposed, and merging the user's own work into it would erase the\none distinction the field exists to make.\n\n**The send route refuses it, and that refusal is load-bearing rather than\ntidy.** `values` is *evidence of what the user submitted*, and evidence an\nagent can write is not evidence \u2014 without the refusal an agent could send a\nform pre-stamped with a submission that never happened, and a client would\nrender it under the word `logged`. Declared optional here because a form is\nsent without it and carries it only after a tap; refused at the door\nrather than by this type, since Pydantic cannot see which direction a\nblock is travelling.",
       "properties": {
         "kind": {
           "const": "form",
@@ -3656,6 +4533,10 @@ the mounted routes under `backend/jarvis_app_backend`.
         "state": {
           "anyOf": [
             {
+              "enum": [
+                "logged",
+                "expired"
+              ],
               "type": "string"
             },
             {
@@ -3668,6 +4549,34 @@ the mounted routes under `backend/jarvis_app_backend`.
         "summary": {
           "title": "Summary",
           "type": "string"
+        },
+        "values": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Values"
         }
       },
       "required": [
@@ -3677,12 +4586,76 @@ the mounted routes under `backend/jarvis_app_backend`.
       "title": "FormBlock",
       "type": "object"
     },
-    "FormField": {
+    "FormPayload": {
       "additionalProperties": false,
+      "description": "`type` opens at `text` and `number` alone \u2014 the two a renderer draws.\nThe wider set a form could plausibly want (a choice, a toggle, a date, a\ntime) is deliberately absent rather than declared and unhandled: a type\nnothing can draw is a promise the system cannot keep, and each of those\nneeds a design before it needs a schema.\n\n`callback_id` sits here because the hub stamps it onto every action update,\nwhich is what lets an agent resolve the right pending decision without\nkeeping a `message_id`\u2192handle map it would lose on each deploy.\n\nA form declares no actions. It has exactly one, so naming it would be a\nsecond name for the same thing, and its tap carries the reserved\n`\"submit\"` \u2014 the same shape `confirmation` uses for its own two fixed\noutcomes. `submit_label` is the words on that one control, nothing more.",
       "properties": {
-        "field_id": {
-          "title": "Field Id",
+        "callback_id": {
+          "title": "Callback Id",
           "type": "string"
+        },
+        "rows": {
+          "items": {
+            "$ref": "#/$defs/FormRow"
+          },
+          "title": "Rows",
+          "type": "array"
+        },
+        "submit_label": {
+          "default": "Submit",
+          "title": "Submit Label",
+          "type": "string"
+        },
+        "subtitle": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Subtitle"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        }
+      },
+      "required": [
+        "callback_id",
+        "title",
+        "rows"
+      ],
+      "title": "FormPayload",
+      "type": "object"
+    },
+    "FormRow": {
+      "additionalProperties": false,
+      "description": "One labelled thing being filled in, and the one or two boxes it takes \u2014\n*\"Bench press\"* with a reps box and a kg box beside it. The grouping lives\nhere rather than being inferred from a flat list because the resolved and\nexpired renders collapse a **row** to a single value, so it has to exist in\nthe payload rather than be re-derived at draw time. A flat list carrying a\n`group` key was rejected for the reason the union above exists: the\ngrouping would become a convention the hub cannot check.",
+      "properties": {
+        "fields": {
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "number": "#/$defs/NumberField",
+                "text": "#/$defs/TextField"
+              },
+              "propertyName": "type"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/TextField"
+              },
+              {
+                "$ref": "#/$defs/NumberField"
+              }
+            ]
+          },
+          "minItems": 1,
+          "title": "Fields",
+          "type": "array"
         },
         "label": {
           "title": "Label",
@@ -3690,33 +4663,100 @@ the mounted routes under `backend/jarvis_app_backend`.
         }
       },
       "required": [
-        "field_id",
-        "label"
+        "label",
+        "fields"
       ],
-      "title": "FormField",
+      "title": "FormRow",
       "type": "object"
     },
-    "FormPayload": {
+    "NumberField": {
       "additionalProperties": false,
-      "description": "`fields` carries a label and an id and nothing else \u2014 there is no field\n*type*, no required flag, no default. That is the whole taxonomy, and it\nstays this small until a renderer forces the question: a type nothing can\ndraw is a promise the system cannot keep.",
+      "description": "A numeric box. Identical to `TextField` but for what `default` may hold,\nwhich is the whole reason these are two models rather than one with a\n`type` tag beside an untyped default.",
       "properties": {
-        "fields": {
-          "items": {
-            "$ref": "#/$defs/FormField"
-          },
-          "title": "Fields",
-          "type": "array"
+        "default": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Default"
         },
-        "submit_label": {
-          "default": "Submit",
-          "title": "Submit Label",
+        "field_id": {
+          "title": "Field Id",
           "type": "string"
+        },
+        "type": {
+          "const": "number",
+          "default": "number",
+          "title": "Type",
+          "type": "string"
+        },
+        "unit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Unit"
         }
       },
       "required": [
-        "fields"
+        "field_id"
       ],
-      "title": "FormPayload",
+      "title": "NumberField",
+      "type": "object"
+    },
+    "TextField": {
+      "additionalProperties": false,
+      "description": "A free-text box. `default` is the *prepopulation*, not a hint: a form\narrives with the agent's best guess already in the box, to be corrected or\naccepted rather than composed from nothing. There is no placeholder \u2014 that\nrenders only into an empty box, which is a state nothing draws \u2014 and no\nper-field label, because `unit` is what names a box on screen and in the\nname a screen reader composes from the row's label plus it.",
+      "properties": {
+        "default": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Default"
+        },
+        "field_id": {
+          "title": "Field Id",
+          "type": "string"
+        },
+        "type": {
+          "const": "text",
+          "default": "text",
+          "title": "Type",
+          "type": "string"
+        },
+        "unit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Unit"
+        }
+      },
+      "required": [
+        "field_id"
+      ],
+      "title": "TextField",
       "type": "object"
     }
   },

--- a/docs/architecture/channels/jarvis-app/contract.md
+++ b/docs/architecture/channels/jarvis-app/contract.md
@@ -6,7 +6,7 @@
 JSON Schema plus the endpoint list, generated from the Pydantic models and
 the mounted routes under `backend/jarvis_app_backend`.
 
-`contract_version`: `b2dcd9534e07bd23`
+`contract_version`: `509c222e84e2c915`
 
 ## Endpoints
 
@@ -1126,7 +1126,7 @@ the mounted routes under `backend/jarvis_app_backend`.
     },
     "TextField": {
       "additionalProperties": false,
-      "description": "A free-text box. `default` is the *prepopulation*, not a hint: a form\narrives with the agent's best guess already in the box, to be corrected or\naccepted rather than composed from nothing. There is no placeholder \u2014 that\nrenders only into an empty box, which is a state nothing draws \u2014 and no\nper-field label, because `unit` is what names a box on screen and in the\nname a screen reader composes from the row's label plus it.",
+      "description": "A free-text box. `default` is the *prepopulation*, not a hint: a form\narrives with the agent's best guess already in the box, to be corrected or\naccepted rather than composed from nothing. There is no placeholder \u2014 that\nrenders only into an empty box, which is a state nothing draws \u2014 and no\nper-field label, because `unit` is what names a box.",
       "properties": {
         "default": {
           "anyOf": [
@@ -1691,7 +1691,7 @@ the mounted routes under `backend/jarvis_app_backend`.
     },
     "TextField": {
       "additionalProperties": false,
-      "description": "A free-text box. `default` is the *prepopulation*, not a hint: a form\narrives with the agent's best guess already in the box, to be corrected or\naccepted rather than composed from nothing. There is no placeholder \u2014 that\nrenders only into an empty box, which is a state nothing draws \u2014 and no\nper-field label, because `unit` is what names a box on screen and in the\nname a screen reader composes from the row's label plus it.",
+      "description": "A free-text box. `default` is the *prepopulation*, not a hint: a form\narrives with the agent's best guess already in the box, to be corrected or\naccepted rather than composed from nothing. There is no placeholder \u2014 that\nrenders only into an empty box, which is a state nothing draws \u2014 and no\nper-field label, because `unit` is what names a box.",
       "properties": {
         "default": {
           "anyOf": [
@@ -2486,7 +2486,7 @@ the mounted routes under `backend/jarvis_app_backend`.
     },
     "TextField": {
       "additionalProperties": false,
-      "description": "A free-text box. `default` is the *prepopulation*, not a hint: a form\narrives with the agent's best guess already in the box, to be corrected or\naccepted rather than composed from nothing. There is no placeholder \u2014 that\nrenders only into an empty box, which is a state nothing draws \u2014 and no\nper-field label, because `unit` is what names a box on screen and in the\nname a screen reader composes from the row's label plus it.",
+      "description": "A free-text box. `default` is the *prepopulation*, not a hint: a form\narrives with the agent's best guess already in the box, to be corrected or\naccepted rather than composed from nothing. There is no placeholder \u2014 that\nrenders only into an empty box, which is a state nothing draws \u2014 and no\nper-field label, because `unit` is what names a box.",
       "properties": {
         "default": {
           "anyOf": [
@@ -3393,7 +3393,7 @@ the mounted routes under `backend/jarvis_app_backend`.
     },
     "TextField": {
       "additionalProperties": false,
-      "description": "A free-text box. `default` is the *prepopulation*, not a hint: a form\narrives with the agent's best guess already in the box, to be corrected or\naccepted rather than composed from nothing. There is no placeholder \u2014 that\nrenders only into an empty box, which is a state nothing draws \u2014 and no\nper-field label, because `unit` is what names a box on screen and in the\nname a screen reader composes from the row's label plus it.",
+      "description": "A free-text box. `default` is the *prepopulation*, not a hint: a form\narrives with the agent's best guess already in the box, to be corrected or\naccepted rather than composed from nothing. There is no placeholder \u2014 that\nrenders only into an empty box, which is a state nothing draws \u2014 and no\nper-field label, because `unit` is what names a box.",
       "properties": {
         "default": {
           "anyOf": [
@@ -4166,7 +4166,7 @@ the mounted routes under `backend/jarvis_app_backend`.
     },
     "TextField": {
       "additionalProperties": false,
-      "description": "A free-text box. `default` is the *prepopulation*, not a hint: a form\narrives with the agent's best guess already in the box, to be corrected or\naccepted rather than composed from nothing. There is no placeholder \u2014 that\nrenders only into an empty box, which is a state nothing draws \u2014 and no\nper-field label, because `unit` is what names a box on screen and in the\nname a screen reader composes from the row's label plus it.",
+      "description": "A free-text box. `default` is the *prepopulation*, not a hint: a form\narrives with the agent's best guess already in the box, to be corrected or\naccepted rather than composed from nothing. There is no placeholder \u2014 that\nrenders only into an empty box, which is a state nothing draws \u2014 and no\nper-field label, because `unit` is what names a box.",
       "properties": {
         "default": {
           "anyOf": [
@@ -4716,7 +4716,7 @@ the mounted routes under `backend/jarvis_app_backend`.
     },
     "TextField": {
       "additionalProperties": false,
-      "description": "A free-text box. `default` is the *prepopulation*, not a hint: a form\narrives with the agent's best guess already in the box, to be corrected or\naccepted rather than composed from nothing. There is no placeholder \u2014 that\nrenders only into an empty box, which is a state nothing draws \u2014 and no\nper-field label, because `unit` is what names a box on screen and in the\nname a screen reader composes from the row's label plus it.",
+      "description": "A free-text box. `default` is the *prepopulation*, not a hint: a form\narrives with the agent's best guess already in the box, to be corrected or\naccepted rather than composed from nothing. There is no placeholder \u2014 that\nrenders only into an empty box, which is a state nothing draws \u2014 and no\nper-field label, because `unit` is what names a box.",
       "properties": {
         "default": {
           "anyOf": [

--- a/docs/plans/FORM_BLOCK_PLAN.md
+++ b/docs/plans/FORM_BLOCK_PLAN.md
@@ -1,7 +1,8 @@
 # Form block — structured input from the app
 
-**Status:** planned, not started. Slice 0 blocked on the hub's updated contract.
-**Date:** 2026-08-15.
+**Status:** in progress — slices 0–1 done (1 verified live on staging 2026-08-24); the hub is
+deployed with the form contract, so nothing remaining is blocked on it. Next: slice 2.
+**Date:** 2026-08-15 (last updated 2026-08-24).
 **Branch:** `feat/app-form-block`.
 **Goal:** let a message carry a small set of labelled, prefilled boxes the owner corrects and
 submits in one tap, and let the submitted values come back as ordinary inbound content. The
@@ -11,14 +12,17 @@ mechanism is a gateway capability with several possible callers; the agent's too
 
 ## Checklist
 
-Slice detail is at the bottom; this is the tracking view. Slice 0 gates 2–6; slice 1 is
-independent and can land first.
+Slice detail is at the bottom; this is the tracking view. Slices 0–1 are done; 2–6 are
+unblocked (the hub runs the form contract as of 2026-08-24).
 
 - [x] **0 · Contract intake**
-  - [x] Updated `contract.md` in `docs/architecture/channels/jarvis-app/` (`b2dcd9534e07bd23`)
-  - [ ] Bump `PINNED_CONTRACT_VERSION` in `gateway/channels/jarvis_app/client.py` — deferred to
-        the end of slice 3/4, since it names the version the adapter *speaks*, and silencing the
-        skew warning before then hides the one signal that matters mid-build
+  - [x] Updated `contract.md` in `docs/architecture/channels/jarvis-app/` — now at
+        `509c222e84e2c915`, the version the hub actually deployed and staging reports (the
+        interim `b2dcd9534e07bd23` never shipped; the delta is prose-only)
+  - [ ] Bump `PINNED_CONTRACT_VERSION` in `gateway/channels/jarvis_app/client.py` to
+        `509c222e84e2c915` — deferred to the end of slice 3/4, since it names the version the
+        adapter *speaks*, and silencing the skew warning before then hides the one signal that
+        matters mid-build
 - [x] **1 · Confirmation fixes** — independent of forms
   - [x] Expire an orphaned `callback_id` using the action update's own `message_id`
   - [x] Retain `callback_id → settled_state` past resolution so a re-tap re-affirms. Only the
@@ -27,19 +31,29 @@ independent and can land first.
   - [x] Learn the settled state from a `MessageAlreadyResolved` refusal, so a further tap
         re-affirms what actually stands rather than losing the same argument again
   - [x] Keep the `ALREADY_HANDLED` guard (declining the handoff's "dead code" note)
+  - [x] Verified live on staging (2026-08-24): confirm, cancel, re-tap, TTL eviction, orphan tap
+        after a restart, and a Telegram regression pass
 - [ ] **2 · Neutral seam** — no callers yet, testable alone
-  - [ ] `FormSpec` in `gateway/`, channel-agnostic, with construction-time validation
-  - [ ] Size cap (~6 rows) enforced at construction
-  - [ ] `Channel.send_form` + `can_send_form` (default `False`)
-  - [ ] Outbox method with a distinct unsupported-channel `SendOutcome`, never a partial send
-  - [ ] Telegram declines
+  - [ ] `gateway/blocks/` package: `base.py` (`Block`, `Interactive`, `BlockAction`) +
+        `form.py` (`Form`, `FormRow`, `TextField`, `NumberField`) — frozen dataclasses,
+        construction-time validation, no wire shapes
+  - [ ] Size cap (~6 rows) and the units-on-multi-field-row rule enforced at construction
+  - [ ] `callback_id` generated at construction (caller slug + our entropy)
+  - [ ] `Channel.supports_block(kind)` (default `False`) + `Channel.send_block(text, block)`
+        (default raises) — kind-generic, so a future kind never edits the ABC
+  - [ ] Outbox method; never a partial send. `SendOutcome` unchanged — `supports_block` is the
+        pre-flight, so the permanent case never reaches the seam
+  - [ ] Telegram declines (implements neither)
 - [ ] **3 · Outbound** — jarvis-app
-  - [ ] `FormSpec` → hub wire mapping
-  - [ ] `callback_id` generation (caller slug + our entropy)
+  - [ ] Wire mapping in the channel adapter, as a table keyed by block type (no `to_wire()` on
+        the neutral model)
   - [ ] Origin routing via `CURRENT_THREAD_ID`, not the proactive default
 - [ ] **4 · Inbound** — jarvis-app
-  - [ ] Route `block_kind == "form"` into an `InboundMessage` instead of `handle_action`
+  - [ ] Router builds a neutral `BlockAction`; dispatch by kind is a table, not an `if/elif`
+        chain — `confirmation` resolves below the LLM, `form` becomes an `InboundMessage`
   - [ ] Carry structured values alongside rendered text; `null` survives as "left empty"
+  - [ ] Persist the submission to `chat_history.jsonl` before the turn runs, so a dead turn
+        cannot lose what was typed
   - [ ] `PATCH` `logged` — **timing still open**, see Open questions
 - [ ] **5 · The tool** — `tools/core/`
   - [ ] Docstring guardrails: submit-unchanged precondition, anti-examples, evidence-only defaults
@@ -58,11 +72,12 @@ long-poll as a `type: "action"` update carrying `values` — every declared `fie
 meaning "seen and left empty". The agent resolves the card by `PATCH`ing `state` to `logged` or
 `expired`. No new endpoint, no new auth.
 
-This is a **contract change, not an addition**. The pinned contract already declares a `FormBlock`
-(`docs/architecture/channels/jarvis-app/contract.md:1339`), but a placeholder one: fields are
+This was a **contract change, not an addition**. The previously pinned contract
+(`45e79b46aed20391`) already declared a `FormBlock`, but a placeholder one: fields were
 `{field_id, label}` with no type, no default, no `callback_id`, and an open-string `state`. The
-hub's new shape replaces it, so `contract_version` moves and `PINNED_CONTRACT_VERSION`
-(`gateway/channels/jarvis_app/client.py:21`) must move with it.
+hub's shape replaces it — the vendored `contract.md` now carries the real one — so
+`contract_version` moved and `PINNED_CONTRACT_VERSION` (`gateway/channels/jarvis_app/client.py:21`)
+must eventually move with it.
 
 Deploy order is one-way: the hub validates strictly, so a `form` sent to an older hub is a `422`,
 not a degraded render.
@@ -107,44 +122,69 @@ Consequences, all of which shrink the build:
 
 ### The mechanism is a gateway capability, not a tool
 
-Building this as "a tool that sends a form" would make it agent-only by construction. Layering:
+Building this as "a tool that sends a form" would make it agent-only by construction. And
+building the channel seam as `send_form` would make blocks a method-per-kind affair — every future
+kind (`buttons` and `card` already exist in the contract) editing the ABC, the Outbox, and every
+channel. So the capability is **blocks, not forms**; a form is the first kind carried, not the
+shape of the seam. Layering:
 
-- **Neutral model** in `gateway/` — a `FormSpec` of rows and fields, channel-agnostic, no hub wire
-  shape in it. Every caller constructs this.
-- **Channel capability** — `Channel.send_form(spec)` plus a `can_send_form` property defaulting to
-  `False`. jarvis-app implements it; Telegram doesn't.
-- **Outbox method** — the owner-addressed seam, with the same log-on-success / `SendOutcome`
-  treatment every other send gets. This is what makes it reachable from the heartbeat, a reminder,
-  a slash command, or a future skill tool, all as peers of the agent's tool.
-- **Channel adapter** owns the wire mapping and the `PATCH`.
-- **The tool** in `tools/core/` is a thin caller: build a spec from model args, call the seam,
+- **Neutral model** in `gateway/blocks/` — `base.py` holds `Block` (kind, summary), `Interactive`
+  (a `Block` with a `callback_id` — encoding which kinds can be *resolved* as a class check, since
+  `card` has no callback and `form`/`buttons`/`confirmation` do), and `BlockAction` (the neutral
+  inbound tap). `form.py` holds `Form`/`FormRow`/`TextField`/`NumberField`. Frozen dataclasses,
+  channel-agnostic, no hub wire shape anywhere in the package. Every caller constructs these.
+- **Channel capability** — `Channel.supports_block(kind)` defaulting to `False` and
+  `Channel.send_block(text, block)` defaulting to raise. Kind-generic: adding a block kind never
+  edits the ABC. jarvis-app opts in; Telegram doesn't. (Telegram is not actually blockless — a
+  `buttons` block *is* an inline keyboard — which is what makes blocks a genuinely neutral concept
+  with partial implementations rather than one channel's vocabulary hoisted into the gateway. A
+  mature block layer could eventually subsume `ConfirmationUI`; designed-for, not built.)
+- **Outbox method** — the owner-addressed seam, with the same log-on-success treatment every other
+  send gets. This is what makes it reachable from the heartbeat, a reminder, a slash command, or a
+  future skill tool, all as peers of the agent's tool.
+- **Channel adapter** owns the wire mapping — an explicit table keyed by block type, deliberately
+  *not* a `to_wire()` method on the neutral model, which would put the hub's JSON inside it and
+  break the first time a second channel renders the same block — and the `PATCH`.
+- **The tool** in `tools/core/` is a thin caller: build a `Form` from model args, call the seam,
   return a description. One caller among several.
 
-**Validation lives in `FormSpec` construction**, not the adapter — a bad form should fail at the
+Inbound gets the same symmetry: the router builds one neutral `BlockAction` and dispatches by kind
+through a table (not an `if/elif` chain) — `confirmation` resolves below the LLM, `form` becomes an
+`InboundMessage`. Per-kind resolution vocabularies (`confirmed|cancelled|expired`,
+`logged|expired`, `buttons`' open string) live beside each kind's dataclass.
+
+The test of this design is the cost of the **second** kind: adding `buttons` later should be a
+dataclass in `gateway/blocks/buttons.py`, one entry in the adapter's wire table, and one entry in
+the inbound dispatch table — no edits to the ABC, the Outbox, Telegram, or `Form`. Build only
+`form` now: the `scopes` axis in `tools/registry.py` is the standing reminder of what speculative
+generality earns.
+
+**Validation lives in block construction**, not the adapter — a bad form should fail at the
 caller with a clear message the model can correct, not as a `422` inside an async send after the
 tool already returned a hopeful string. Only rules that stand on their own merits go there (units
 on multi-field rows is a real accessibility rule); genuinely hub-specific limits stay in the
 adapter.
 
-What the vendored schema does and doesn't enforce, which decides what `FormSpec` must carry:
+What the vendored schema does and doesn't enforce, which decides what `Form` must carry:
 
 - **`type`/`default` agreement is schema-enforced** — `TextField.default` is a string,
   `NumberField.default` a number, via a discriminated union on `type`. So is `minItems: 1` on a
   row's `fields`.
 - **The units-on-a-multi-field-row rule is not.** `unit` is plain optional in the schema and the
   rule lives in a hub-side validator, so violating it is a runtime `422` with no local signal.
-  This is the rule `FormSpec` most needs to catch itself.
+  This is the rule `Form` most needs to catch itself.
 - **`rows` has no `maxItems`.** The hub imposes no size limit; the ~6-row cap is purely our policy
   and should not later be "corrected" to match the wire.
 - **`default` is optional and nullable on both field types** — only `field_id` is required. The
   wire agrees a box can arrive legitimately empty, which is why mandatory defaults were rejected.
 - **`values` is refused by the send *route*, not by the type** — the contract notes Pydantic
-  cannot see which direction a block travels. The outbound `FormSpec` should therefore not have
-  the field at all, making a pre-stamped form unconstructible rather than merely forbidden.
+  cannot see which direction a block travels. The outbound `Form` therefore has no such field at
+  all, making a pre-stamped form unconstructible rather than merely forbidden.
 
-**We generate `callback_id`.** Uniqueness-per-live-form is a correctness property and shouldn't be
-delegated to a model that will happily reuse `workout-today`. The caller supplies a semantic slug
-and we append entropy — `push-day-a3f1`. Semantics from the caller, uniqueness from us.
+**We generate `callback_id`, at construction.** Uniqueness-per-live-form is a correctness property
+and shouldn't be delegated to a model that will happily reuse `workout-today`. The caller supplies
+a semantic slug and construction appends entropy — `push-day-a3f1` — so an id always exists by the
+time anyone holds a block. Semantics from the caller, uniqueness from us.
 
 **Origin routing, not the proactive default.** A form issued during a turn goes to the turn's
 origin channel, the way `get_confirmation()` resolves through `CURRENT_THREAD_ID`
@@ -153,11 +193,16 @@ arrives with no conversation around it. Proactive sends keep using the default c
 
 ### Channels that can't render a form
 
-**The seam never falls back — it reports.** An unsupported channel is a distinct `SendOutcome`, not
-a generic failure, and nothing goes out partially: either the message-with-form sends or nothing
-does, so the owner never receives a dangling opener. Every caller then decides for itself — the
-model composes prose, a code caller sends its own `notify_owner(...)`. The gateway invents no
-message.
+**The seam never falls back — it reports.** Nothing goes out partially: either the
+message-with-form sends or nothing does, so the owner never receives a dangling opener. Every
+caller then decides for itself — the model composes prose, a code caller sends its own
+`notify_owner(...)`. The gateway invents no message.
+
+`SendOutcome` itself stays untouched (a considered no-op: it is just `{ok, error}` and nothing
+branches on it structurally today). The permanent case — "this channel has no forms" — is
+distinguished from a transient failure by asking `supports_block` *before* sending, so it never
+reaches the seam and never needs its own outcome value; whatever the seam returns after a positive
+pre-flight is an ordinary transient failure.
 
 The tool turns that outcome into a directive the model recovers from inside the same turn, echoing
 the prepared values back so the recovery is a rewrite rather than a re-derivation:
@@ -185,7 +230,7 @@ together would make the value space a union of unrelated vocabularies. It's also
 not more: with the tool always bound, the decline is visible in the transcript as a `ToolMessage`,
 whereas a silently absent tool is the thing that's hard to explain when reading a log weeks later.
 The decline path is needed regardless (as the bind-then-send backstop, and as what a code caller
-reads off `SendOutcome`), so this is a strict subset of the deferred work. Revisit with telemetry
+sees from the pre-flight), so this is a strict subset of the deferred work. Revisit with telemetry
 if the model reaches for forms on form-less channels often. If it is ever built it must be
 **capability-shaped** (`requires=("forms",)`), never channel-shaped — tools must not name a
 channel. Weak supporting evidence: `scopes` was built speculatively and no tool uses it today.
@@ -240,11 +285,14 @@ Keep it; read that sentence as scoped to hub-side duplicate delivery.
 
 ## Open questions
 
-- **`PATCH` timing.** On submit arrival, or after the turn that handles it succeeds? Arrival is
-  honest to the hub's relay model and can't leave a card hanging if the turn crashes. After-the-turn
-  makes the card's state mean "this was acted on", which is how the owner will read it. Leaning
-  arrival, with the agent's reply carrying the real outcome — a UX call more than an architectural
-  one.
+- **`PATCH` timing.** On submit arrival, or after the turn that handles it succeeds? Leaning
+  **arrival**: the hub refuses a second tap while an earlier one is unacked, so a turn that dies
+  before an after-the-turn PATCH could leave the card both unresolved and un-retappable; there is
+  no `failed` state for the card to express a bad write anyway; and `logged` meaning "received"
+  is honest to the hub's relay model, with the chat reply carrying the real outcome. **To verify
+  with the hub side first:** whether "unacked" means our PATCH or the updates cursor — our fetch
+  loop advances the offset before the turn runs, so if it is the cursor, the freeze risk
+  disappears and after-the-turn becomes viable.
 - **Double-logging.** A workout logged in chat, then the stale card gets tapped. Thread context
   mostly covers it and the agent can see and mention it, but it replaces "lost state" as the
   failure mode to watch.
@@ -257,21 +305,27 @@ Keep it; read that sentence as scoped to hub-side duplicate delivery.
 
 ## Slices
 
-**0 — Contract intake.** *Blocked on the hub.* Updated `contract.md` and the new
-`PINNED_CONTRACT_VERSION`. Nothing else can start against a schema we don't have.
+**0 — Contract intake.** *Done.* `contract.md` vendored at `509c222e84e2c915` — the version the
+hub deployed and staging reports. The `PINNED_CONTRACT_VERSION` bump is deliberately deferred to
+the end of slice 3/4.
 
-**1 — Confirmation fixes.** The two bugs above. Independent of forms; ships alone.
+**1 — Confirmation fixes.** *Done; verified live on staging 2026-08-24* (confirm, cancel, re-tap,
+TTL eviction, orphan tap after a restart, Telegram regression). Shipped as its own commit.
 
-**2 — Neutral seam.** `FormSpec` + construction-time validation, `Channel.send_form` /
-`can_send_form`, the Outbox method and its unsupported outcome, Telegram declining. No callers, so
-it is testable on its own.
+**2 — Neutral seam.** The `gateway/blocks/` package (`Block`/`Interactive`/`BlockAction` +
+`Form`/`FormRow`/`TextField`/`NumberField`) with construction-time validation and `callback_id`
+generation; `Channel.supports_block`/`send_block`; the Outbox method; Telegram declining. No
+callers, so it is testable on its own.
 
-**3 — Outbound.** jarvis-app wire mapping and send; `callback_id` generation.
+**3 — Outbound.** jarvis-app wire mapping (adapter-side table keyed by block type) and send;
+origin routing via `CURRENT_THREAD_ID`. Ends with the `PINNED_CONTRACT_VERSION` bump alongside
+slice 4.
 
-**4 — Inbound.** Route `block_kind == "form"` in the router into an `InboundMessage` carrying
-rendered text plus the structured values (`null` surviving as "left empty", distinguishable from
-zero — it is the one distinction the hub went out of its way to preserve). `PATCH` per the timing
-decision above.
+**4 — Inbound.** The router builds a neutral `BlockAction` and dispatches by kind: `confirmation`
+to the store as today, `form` into an `InboundMessage` carrying rendered text plus the structured
+values (`null` surviving as "left empty", distinguishable from zero — it is the one distinction
+the hub went out of its way to preserve), persisted to `chat_history.jsonl` before the turn runs
+so a dead turn cannot lose what was typed. `PATCH` per the timing decision above.
 
 **5 — The tool.** `tools/core/`, with the size cap, the docstring guardrails, and the decline
 directive.

--- a/docs/plans/FORM_BLOCK_PLAN.md
+++ b/docs/plans/FORM_BLOCK_PLAN.md
@@ -1,0 +1,259 @@
+# Form block — structured input from the app
+
+**Status:** planned, not started. Slice 0 blocked on the hub's updated contract.
+**Date:** 2026-08-15.
+**Branch:** `feat/app-form-block`.
+**Goal:** let a message carry a small set of labelled, prefilled boxes the owner corrects and
+submits in one tap, and let the submitted values come back as ordinary inbound content. The
+mechanism is a gateway capability with several possible callers; the agent's tool is one of them.
+
+---
+
+## Checklist
+
+Slice detail is at the bottom; this is the tracking view. Slice 0 gates 2–6; slice 1 is
+independent and can land first.
+
+- [ ] **0 · Contract intake** — *blocked on the hub*
+  - [ ] Updated `contract.md` in `docs/architecture/channels/jarvis-app/`
+  - [ ] New `PINNED_CONTRACT_VERSION` in `gateway/channels/jarvis_app/client.py`
+- [ ] **1 · Confirmation fixes** — independent of forms
+  - [ ] Expire an orphaned `callback_id` using the action update's own `message_id`
+  - [ ] Retain `callback_id → (message_id, settled_state)` past resolution so a re-tap re-affirms
+  - [ ] Keep the `ALREADY_HANDLED` guard (declining the handoff's "dead code" note)
+- [ ] **2 · Neutral seam** — no callers yet, testable alone
+  - [ ] `FormSpec` in `gateway/`, channel-agnostic, with construction-time validation
+  - [ ] Size cap (~6 rows) enforced at construction
+  - [ ] `Channel.send_form` + `can_send_form` (default `False`)
+  - [ ] Outbox method with a distinct unsupported-channel `SendOutcome`, never a partial send
+  - [ ] Telegram declines
+- [ ] **3 · Outbound** — jarvis-app
+  - [ ] `FormSpec` → hub wire mapping
+  - [ ] `callback_id` generation (caller slug + our entropy)
+  - [ ] Origin routing via `CURRENT_THREAD_ID`, not the proactive default
+- [ ] **4 · Inbound** — jarvis-app
+  - [ ] Route `block_kind == "form"` into an `InboundMessage` instead of `handle_action`
+  - [ ] Carry structured values alongside rendered text; `null` survives as "left empty"
+  - [ ] `PATCH` `logged` — **timing still open**, see Open questions
+- [ ] **5 · The tool** — `tools/core/`
+  - [ ] Docstring guardrails: submit-unchanged precondition, anti-examples, evidence-only defaults
+  - [ ] Return string describes what was asked (field ids + prefills) — the thread is the store
+  - [ ] Decline directive on an unsupported channel, echoing the prepared values back
+- [ ] **6 · First real caller** — proactive post-workout form, prefilled from
+      `query_exercise_history`
+
+---
+
+## Context
+
+The jarvis-app hub is adding a `form` block kind: `rows` of `fields`, each field a `text` or
+`number` box with an optional `unit` and `default`. A tap arrives on the existing updates
+long-poll as a `type: "action"` update carrying `values` — every declared `field_id`, with `null`
+meaning "seen and left empty". The agent resolves the card by `PATCH`ing `state` to `logged` or
+`expired`. No new endpoint, no new auth.
+
+This is a **contract change, not an addition**. The pinned contract already declares a `FormBlock`
+(`docs/architecture/channels/jarvis-app/contract.md:1339`), but a placeholder one: fields are
+`{field_id, label}` with no type, no default, no `callback_id`, and an open-string `state`. The
+hub's new shape replaces it, so `contract_version` moves and `PINNED_CONTRACT_VERSION`
+(`gateway/channels/jarvis_app/client.py:21`) must move with it.
+
+Deploy order is one-way: the hub validates strictly, so a `form` sent to an older hub is a `422`,
+not a degraded render.
+
+**Today's baseline.** Blocks exist only on the jarvis-app channel, and only one kind is wired:
+`confirmation`. An action update is handled below the LLM (`gateway/channels/jarvis_app/router.py:292`
+→ `AppConfirmationUI.handle_action`), never reaching the model. `values` is dropped on the floor —
+the router doesn't read it. Telegram has no block concept at all.
+
+---
+
+## Decisions carried in from discussion
+
+### A form is content, not a protocol
+
+Confirmation earns its store because something is genuinely pending: `action_fn` is a live closure
+waiting for a yes, and losing the `callback_id` loses the action. A form holds none of that.
+Nothing is deferred, nothing runs on submit, nothing is lost if we forget it. The submit is
+content arriving — more structured than free text, same nature.
+
+Consequences, all of which shrink the build:
+
+- **No pending store.** The action update carries `message_id`, `callback_id`, `block_kind`, and
+  `values` — everything needed to `PATCH` and to run a turn. Nothing to look up, nothing to forget
+  across a restart.
+- **The thread is the store.** The message that sent the form is already in the LangGraph thread,
+  so the submit lands in a context that contains the question. This only holds if the sending
+  tool's **return string describes what it asked** (field ids and prefills), not just "form sent".
+  Correctness never depends on our memory — only intelligibility does, and the worst case is the
+  agent asking what a stale submit refers to rather than a card hanging live forever.
+- **No TTL, no sweep.** With nothing pending, an untapped form going stale costs nothing. Tapped
+  late, it arrives as content and the agent handles it in context. Revisit only if a real problem
+  appears.
+- **Most of the handoff's §3 dissolves.** "Unknown `callback_id` → expire" and "already-resolved →
+  re-affirm" are rules for a system holding pending state. Holding none, every submit is answerable
+  the same way. A `MessageAlreadyResolved` on the `PATCH` stays a log line, not a branch.
+- **The submit runs a model turn.** Rejected: a deterministic handler that maps `field_id` → a DB
+  write with no model in the path. That carries confirmation's semantics onto something that has
+  none, and the model is already the thing that composed the form. The inbound path should still
+  carry the structured values alongside the rendered text, so a future caller *can* register a
+  resolver without re-plumbing — but no resolver registry is built now.
+
+### The mechanism is a gateway capability, not a tool
+
+Building this as "a tool that sends a form" would make it agent-only by construction. Layering:
+
+- **Neutral model** in `gateway/` — a `FormSpec` of rows and fields, channel-agnostic, no hub wire
+  shape in it. Every caller constructs this.
+- **Channel capability** — `Channel.send_form(spec)` plus a `can_send_form` property defaulting to
+  `False`. jarvis-app implements it; Telegram doesn't.
+- **Outbox method** — the owner-addressed seam, with the same log-on-success / `SendOutcome`
+  treatment every other send gets. This is what makes it reachable from the heartbeat, a reminder,
+  a slash command, or a future skill tool, all as peers of the agent's tool.
+- **Channel adapter** owns the wire mapping and the `PATCH`.
+- **The tool** in `tools/core/` is a thin caller: build a spec from model args, call the seam,
+  return a description. One caller among several.
+
+**Validation lives in `FormSpec` construction**, not the adapter — a bad form should fail at the
+caller with a clear message the model can correct, not as a `422` inside an async send after the
+tool already returned a hopeful string. Only rules that stand on their own merits go there (units
+on multi-field rows is a real accessibility rule); genuinely hub-specific limits stay in the
+adapter.
+
+**We generate `callback_id`.** Uniqueness-per-live-form is a correctness property and shouldn't be
+delegated to a model that will happily reuse `workout-today`. The caller supplies a semantic slug
+and we append entropy — `push-day-a3f1`. Semantics from the caller, uniqueness from us.
+
+**Origin routing, not the proactive default.** A form issued during a turn goes to the turn's
+origin channel, the way `get_confirmation()` resolves through `CURRENT_THREAD_ID`
+(`gateway/factory.py:163`). Otherwise a Telegram turn sends a card into the app, where the tap
+arrives with no conversation around it. Proactive sends keep using the default channel.
+
+### Channels that can't render a form
+
+**The seam never falls back — it reports.** An unsupported channel is a distinct `SendOutcome`, not
+a generic failure, and nothing goes out partially: either the message-with-form sends or nothing
+does, so the owner never receives a dangling opener. Every caller then decides for itself — the
+model composes prose, a code caller sends its own `notify_owner(...)`. The gateway invents no
+message.
+
+The tool turns that outcome into a directive the model recovers from inside the same turn, echoing
+the prepared values back so the recovery is a rewrite rather than a re-derivation:
+
+> `Forms aren't available on telegram — nothing was sent. Say this conversationally instead. You
+> had prepared: Bench press 8 reps @ 60kg · Cable fly @ 22.5kg · Core: plank 3×45s.`
+
+That note is strictly agent-facing. Appending "(a form could not be sent)" to the owner's message
+exposes plumbing to someone on a channel that never had cards and doesn't know it's missing
+anything.
+
+**Rejected: auto-sending the message's `text` as the fallback.** A form's payload carries no prose,
+so every send already has an authored sentence — but that sentence is written *for a card* and
+references an affordance ("fill in what you hit") that doesn't exist elsewhere. Requiring it to
+read well in both situations produces a sentence that's mediocre in both.
+
+**Rejected: `summary` as the fallback.** The contract gives `summary` no description on any block
+kind; our own confirmation code guesses at its purpose. It's plausibly a notification preview or a
+collapsed-list label, and reads as a label rather than something said to a person.
+
+**Rejected (for now): capability-scoped tool binding.** Not binding the form tool at all on a
+channel that can't render one is cleaner in principle, but it's a genuinely new registry axis —
+`scopes` (`tools/registry.py:43`) filters on *why* a turn runs, not *where*, and folding the two
+together would make the value space a union of unrelated vocabularies. It's also *less* legible,
+not more: with the tool always bound, the decline is visible in the transcript as a `ToolMessage`,
+whereas a silently absent tool is the thing that's hard to explain when reading a log weeks later.
+The decline path is needed regardless (as the bind-then-send backstop, and as what a code caller
+reads off `SendOutcome`), so this is a strict subset of the deferred work. Revisit with telemetry
+if the model reaches for forms on form-less channels often. If it is ever built it must be
+**capability-shaped** (`requires=("forms",)`), never channel-shaped — tools must not name a
+channel. Weak supporting evidence: `scopes` was built speculatively and no tool uses it today.
+
+### Keeping the tool from being over-used
+
+A generic form tool is one the model will reach for. Ranked by how much they can be trusted:
+
+1. **Size cap** (~6 rows). A twelve-row form is a survey, and a survey is a conversation someone
+   decided to skip. Mechanical, enforced at construction.
+2. **Docstring with anti-examples.** Tool usage in this repo is driven by docstrings, so this is
+   the real lever: a form is appropriate only when the expected outcome is *submit unchanged*.
+   Anything the owner has to compose belongs in chat, where they can be vague, correct themselves,
+   and get a follow-up — none of which a form can do.
+3. **Defaults must be evidence, never guesses.** Last session's weight, yes; a plausible-looking
+   number for an exercise with no history, no.
+4. **The channel gate is free.** Forms don't exist on Telegram, so that traffic is unaffected.
+5. **Measure it.** Sent-vs-tapped ratio is the empirical over-use signal; sends are already in
+   `tool_calls.jsonl`. Forms sent and ignored mean the model is reaching where a sentence would do.
+
+**Rejected: mandatory `default` on every field.** The intent was to make questionnaire-misuse
+structurally impossible, but it forces a caller with no history to invent a prefill — and an
+invented prefill is the most dangerous thing on the card, because submit-unchanged is the designed
+happy path. The owner taps through and the DB holds a lift nobody did. It also fights the
+contract's own model, where `null` exists precisely so a box can be empty *meaningfully*.
+Fabricated evidence is worse than a blank box.
+
+### Two confirmation bugs found on the way
+
+Both are about the confirmation protocol, which does keep state, and both stand alone — worth
+fixing whether or not forms ship.
+
+1. **Orphaned confirmations never expire.** An unknown `callback_id` routes into `store.resolve`,
+   hits `ALREADY_HANDLED` (`gateway/confirmation/store.py:139`), which maps to `None` in
+   `_WIRE_STATE` (`gateway/channels/jarvis_app/confirmation.py:31`) and returns without `PATCH`ing.
+   After a restart the owner's card sits live forever. The fix is in the handoff's own detail: the
+   action update carries `message_id`, so expiring an orphan never needed the in-memory map.
+2. **"Re-affirm, don't expire" is impossible as written.** `apply_outcome` does
+   `self._message_ids.pop(...)` (`gateway/channels/jarvis_app/confirmation.py:60`), discarding the
+   handle at resolution. Re-affirming needs `callback_id → (message_id, settled_state)` retained
+   past resolution, in a bounded set with its own eviction.
+
+**Declining one instruction from the handoff.** It says the hub now refuses a second tap while one
+is unacked, so any defensive dedup is dead code. Our `ALREADY_HANDLED` path is not that defense —
+it's the deploy-amnesia path and the failed-`PATCH` path, both still live and both required by §3.
+Keep it; read that sentence as scoped to hub-side duplicate delivery.
+
+---
+
+## Open questions
+
+- **`PATCH` timing.** On submit arrival, or after the turn that handles it succeeds? Arrival is
+  honest to the hub's relay model and can't leave a card hanging if the turn crashes. After-the-turn
+  makes the card's state mean "this was acted on", which is how the owner will read it. Leaning
+  arrival, with the agent's reply carrying the real outcome — a UX call more than an architectural
+  one.
+- **Double-logging.** A workout logged in chat, then the stale card gets tapped. Thread context
+  mostly covers it and the agent can see and mention it, but it replaces "lost state" as the
+  failure mode to watch.
+- **Taxonomy gaps for the first caller.** No `choice` type, so `pain_level` (0–3) becomes a number
+  box with `unit: "0-3"`, and `prehab_done` (a bool) has no clean representation — the handoff
+  warns against leaning on the bool→1 coercion. Tolerable while the form is a suggestion the model
+  interprets; it would not be if values bound straight to a function signature.
+
+---
+
+## Slices
+
+**0 — Contract intake.** *Blocked on the hub.* Updated `contract.md` and the new
+`PINNED_CONTRACT_VERSION`. Nothing else can start against a schema we don't have.
+
+**1 — Confirmation fixes.** The two bugs above. Independent of forms; ships alone.
+
+**2 — Neutral seam.** `FormSpec` + construction-time validation, `Channel.send_form` /
+`can_send_form`, the Outbox method and its unsupported outcome, Telegram declining. No callers, so
+it is testable on its own.
+
+**3 — Outbound.** jarvis-app wire mapping and send; `callback_id` generation.
+
+**4 — Inbound.** Route `block_kind == "form"` in the router into an `InboundMessage` carrying
+rendered text plus the structured values (`null` surviving as "left empty", distinguishable from
+zero — it is the one distinction the hub went out of its way to preserve). `PATCH` per the timing
+decision above.
+
+**5 — The tool.** `tools/core/`, with the size cap, the docstring guardrails, and the decline
+directive.
+
+**6 — First real caller.** A proactive post-workout form, prefilled from `query_exercise_history`.
+
+Slices 2–4 are the architecture; 5–6 are the product. Slice 6 is where the premise gets tested:
+for reactive chat a form is not obviously better than typing "bench 8x62.5", which already works.
+The case that justifies the build is the **unprompted** one — the heartbeat sees a session ended,
+pushes a prefilled card, and one tap logs a workout that today simply doesn't get logged.

--- a/docs/plans/FORM_BLOCK_PLAN.md
+++ b/docs/plans/FORM_BLOCK_PLAN.md
@@ -54,7 +54,8 @@ unblocked (the hub runs the form contract as of 2026-08-24).
   - [ ] Carry structured values alongside rendered text; `null` survives as "left empty"
   - [ ] Persist the submission to `chat_history.jsonl` before the turn runs, so a dead turn
         cannot lose what was typed
-  - [ ] `PATCH` `logged` — **timing still open**, see Open questions
+  - [ ] `PATCH` `logged` after the turn completes — settled, see Open questions; a crashed
+        turn leaves the card live, and the re-tap is the recovery path
 - [ ] **5 · The tool** — `tools/core/`
   - [ ] Docstring guardrails: submit-unchanged precondition, anti-examples, evidence-only defaults
   - [ ] Return string describes what was asked (field ids + prefills) — the thread is the store
@@ -285,14 +286,18 @@ Keep it; read that sentence as scoped to hub-side duplicate delivery.
 
 ## Open questions
 
-- **`PATCH` timing.** On submit arrival, or after the turn that handles it succeeds? Leaning
-  **arrival**: the hub refuses a second tap while an earlier one is unacked, so a turn that dies
-  before an after-the-turn PATCH could leave the card both unresolved and un-retappable; there is
-  no `failed` state for the card to express a bad write anyway; and `logged` meaning "received"
-  is honest to the hub's relay model, with the chat reply carrying the real outcome. **To verify
-  with the hub side first:** whether "unacked" means our PATCH or the updates cursor — our fetch
-  loop advances the offset before the turn runs, so if it is the cursor, the freeze risk
-  disappears and after-the-turn becomes viable.
+- ~~**`PATCH` timing.**~~ **Settled (2026-08-24), from the hub's own source** (`form-renderer`
+  branch, the code staging runs): "unacked" is the updates cursor, not our PATCH — an acked
+  update is deleted, and the `already_pending` refusal keys off presence in `bot_updates`. Our
+  fetch loop acks within milliseconds of the tap, so the re-tap lock is transient and a turn that
+  dies before PATCHing leaves the card live and re-tappable, never stranded. That kills the case
+  for arrival-PATCHing, which was defensive against a freeze that cannot happen. **Decision:
+  PATCH `logged` after the turn completes.** `logged` then means the turn actually ran; a crashed
+  turn's recovery is the untouched card itself (re-tap → fresh update → the turn re-runs with
+  thread context, so the model can avoid double-logging). Two hub facts back this up: `values`
+  are stamped onto the block in the tap's own transaction, so the evidence survives our crash
+  regardless; and the hub explicitly accepts losing an update to a crash between ack and turn
+  (§7) — which is also why the submission is persisted to `chat_history.jsonl` before the turn.
 - **Double-logging.** A workout logged in chat, then the stale card gets tapped. Thread context
   mostly covers it and the agent can see and mention it, but it replaces "lost state" as the
   failure mode to watch.

--- a/docs/plans/FORM_BLOCK_PLAN.md
+++ b/docs/plans/FORM_BLOCK_PLAN.md
@@ -33,33 +33,37 @@ unblocked (the hub runs the form contract as of 2026-08-24).
   - [x] Keep the `ALREADY_HANDLED` guard (declining the handoff's "dead code" note)
   - [x] Verified live on staging (2026-08-24): confirm, cancel, re-tap, TTL eviction, orphan tap
         after a restart, and a Telegram regression pass
-- [ ] **2 · Neutral seam** — no callers yet, testable alone
-  - [ ] `gateway/blocks/` package: `base.py` (`Block`, `Interactive`, `BlockAction`) +
+- [x] **2 · Neutral seam** — code done 2026-08-24; offline harness green, staging test pending
+  - [x] `gateway/blocks/` package: `base.py` (`Block`, `Interactive`, `BlockAction`) +
         `form.py` (`Form`, `FormRow`, `TextField`, `NumberField`) — frozen dataclasses,
         construction-time validation, no wire shapes
-  - [ ] Size cap (~6 rows) and the units-on-multi-field-row rule enforced at construction
-  - [ ] `callback_id` generated at construction (caller slug + our entropy)
-  - [ ] `Channel.supports_block(kind)` (default `False`) + `Channel.send_block(text, block)`
+  - [x] Size cap (6 rows) and the units-on-multi-field-row rule enforced at construction
+  - [x] `callback_id` generated at construction (caller slug + our entropy)
+  - [x] `Channel.supports_block(kind)` (default `False`) + `Channel.send_block(text, block)`
         (default raises) — kind-generic, so a future kind never edits the ABC
-  - [ ] Outbox method; never a partial send. `SendOutcome` unchanged — `supports_block` is the
-        pre-flight, so the permanent case never reaches the seam
-  - [ ] Telegram declines (implements neither)
-- [ ] **3 · Outbound** — jarvis-app
-  - [ ] Wire mapping in the channel adapter, as a table keyed by block type (no `to_wire()` on
-        the neutral model)
-  - [ ] Origin routing via `CURRENT_THREAD_ID`, not the proactive default
-- [ ] **4 · Inbound** — jarvis-app
-  - [ ] Router builds a neutral `BlockAction`; dispatch by kind is a table, not an `if/elif`
-        chain — `confirmation` resolves below the LLM, `form` becomes an `InboundMessage`
-  - [ ] Carry structured values alongside rendered text; `null` survives as "left empty"
-  - [ ] Persist the submission to `chat_history.jsonl` before the turn runs, so a dead turn
-        cannot lose what was typed
-  - [ ] `PATCH` `logged` after the turn completes — settled, see Open questions; a crashed
-        turn leaves the card live, and the re-tap is the recovery path
-- [ ] **5 · The tool** — `tools/core/`
-  - [ ] Docstring guardrails: submit-unchanged precondition, anti-examples, evidence-only defaults
-  - [ ] Return string describes what was asked (field ids + prefills) — the thread is the store
-  - [ ] Decline directive on an unsupported channel, echoing the prepared values back
+  - [x] Outbox `send_block_to_owner`; never a partial send. `SendOutcome` unchanged —
+        `supports_block` is the pre-flight, so the permanent case never reaches the seam
+  - [x] Telegram declines (inherits both defaults; implements neither)
+- [x] **3 · Outbound** — jarvis-app; code done 2026-08-24
+  - [x] Wire mapping in the channel adapter (`_BLOCK_WIRE` table keyed by block type; no
+        `to_wire()` on the neutral model); output validated against the vendored FormBlock schema
+  - [x] Origin routing via `CURRENT_THREAD_ID` (`factory.origin_channel`/`origin_outbox`)
+  - [x] `PINNED_CONTRACT_VERSION` bumped to `509c222e84e2c915`
+  - [x] Rider: the contract check now re-runs on reconnect, not only at startup
+- [x] **4 · Inbound** — jarvis-app; code done 2026-08-24
+  - [x] Router builds a neutral `BlockAction`; dispatch by kind — `confirmation` resolves below
+        the LLM, `form` becomes an inbound turn, other kinds fall through
+  - [x] `null` survives as "left empty" in the rendered turn text (`render_submission`)
+  - [x] Submission persisted to `chat_history.jsonl` before the turn — free: the shared
+        `process_inbound_message` already logs user text before `ask_jarvis`
+  - [x] `PATCH` `logged` strictly after the turn; a crashed turn leaves the card live (re-tap
+        is the recovery), a failed PATCH is logged and never fails the consumed update
+- [x] **5 · The tool** — `tools/core/forms.py`; code done 2026-08-24
+  - [x] Docstring guardrails: submit-unchanged precondition, anti-examples, evidence-only
+        defaults, "(left empty) is an explicit no-value"
+  - [x] Return string describes what was asked (`Form.describe()`: field ids + prefills) —
+        the thread is the store
+  - [x] Decline directive on an unsupported channel, echoing the prepared values back
 - [ ] **6 · First real caller** — proactive post-workout form, prefilled from
       `query_exercise_history`
 

--- a/docs/plans/FORM_BLOCK_PLAN.md
+++ b/docs/plans/FORM_BLOCK_PLAN.md
@@ -14,13 +14,19 @@ mechanism is a gateway capability with several possible callers; the agent's too
 Slice detail is at the bottom; this is the tracking view. Slice 0 gates 2–6; slice 1 is
 independent and can land first.
 
-- [ ] **0 · Contract intake** — *blocked on the hub*
-  - [ ] Updated `contract.md` in `docs/architecture/channels/jarvis-app/`
-  - [ ] New `PINNED_CONTRACT_VERSION` in `gateway/channels/jarvis_app/client.py`
-- [ ] **1 · Confirmation fixes** — independent of forms
-  - [ ] Expire an orphaned `callback_id` using the action update's own `message_id`
-  - [ ] Retain `callback_id → (message_id, settled_state)` past resolution so a re-tap re-affirms
-  - [ ] Keep the `ALREADY_HANDLED` guard (declining the handoff's "dead code" note)
+- [x] **0 · Contract intake**
+  - [x] Updated `contract.md` in `docs/architecture/channels/jarvis-app/` (`b2dcd9534e07bd23`)
+  - [ ] Bump `PINNED_CONTRACT_VERSION` in `gateway/channels/jarvis_app/client.py` — deferred to
+        the end of slice 3/4, since it names the version the adapter *speaks*, and silencing the
+        skew warning before then hides the one signal that matters mid-build
+- [x] **1 · Confirmation fixes** — independent of forms
+  - [x] Expire an orphaned `callback_id` using the action update's own `message_id`
+  - [x] Retain `callback_id → settled_state` past resolution so a re-tap re-affirms. Only the
+        *state* needs retaining, not the message id: `handle_action` records the tap's own
+        `message_id`, so the handle a restart forgets is handed back by the update that needs it
+  - [x] Learn the settled state from a `MessageAlreadyResolved` refusal, so a further tap
+        re-affirms what actually stands rather than losing the same argument again
+  - [x] Keep the `ALREADY_HANDLED` guard (declining the handoff's "dead code" note)
 - [ ] **2 · Neutral seam** — no callers yet, testable alone
   - [ ] `FormSpec` in `gateway/`, channel-agnostic, with construction-time validation
   - [ ] Size cap (~6 rows) enforced at construction
@@ -120,6 +126,22 @@ tool already returned a hopeful string. Only rules that stand on their own merit
 on multi-field rows is a real accessibility rule); genuinely hub-specific limits stay in the
 adapter.
 
+What the vendored schema does and doesn't enforce, which decides what `FormSpec` must carry:
+
+- **`type`/`default` agreement is schema-enforced** — `TextField.default` is a string,
+  `NumberField.default` a number, via a discriminated union on `type`. So is `minItems: 1` on a
+  row's `fields`.
+- **The units-on-a-multi-field-row rule is not.** `unit` is plain optional in the schema and the
+  rule lives in a hub-side validator, so violating it is a runtime `422` with no local signal.
+  This is the rule `FormSpec` most needs to catch itself.
+- **`rows` has no `maxItems`.** The hub imposes no size limit; the ~6-row cap is purely our policy
+  and should not later be "corrected" to match the wire.
+- **`default` is optional and nullable on both field types** — only `field_id` is required. The
+  wire agrees a box can arrive legitimately empty, which is why mandatory defaults were rejected.
+- **`values` is refused by the send *route*, not by the type** — the contract notes Pydantic
+  cannot see which direction a block travels. The outbound `FormSpec` should therefore not have
+  the field at all, making a pre-stamped form unconstructible rather than merely forbidden.
+
 **We generate `callback_id`.** Uniqueness-per-live-form is a correctness property and shouldn't be
 delegated to a model that will happily reuse `workout-today`. The caller supplies a semantic slug
 and we append entropy — `push-day-a3f1`. Semantics from the caller, uniqueness from us.
@@ -200,7 +222,10 @@ fixing whether or not forms ship.
    hits `ALREADY_HANDLED` (`gateway/confirmation/store.py:139`), which maps to `None` in
    `_WIRE_STATE` (`gateway/channels/jarvis_app/confirmation.py:31`) and returns without `PATCH`ing.
    After a restart the owner's card sits live forever. The fix is in the handoff's own detail: the
-   action update carries `message_id`, so expiring an orphan never needed the in-memory map.
+   action update carries `message_id`, so expiring an orphan never needed the in-memory map. The
+   contract says as much directly — `callback_id` sits on the payload precisely so an agent can
+   resolve a decision "without keeping a `message_id`→handle map it would lose on each deploy",
+   which is the map `_message_ids` is.
 2. **"Re-affirm, don't expire" is impossible as written.** `apply_outcome` does
    `self._message_ids.pop(...)` (`gateway/channels/jarvis_app/confirmation.py:60`), discarding the
    handle at resolution. Re-affirming needs `callback_id → (message_id, settled_state)` retained

--- a/docs/plans/archive/FORM_BLOCK_PLAN.md
+++ b/docs/plans/archive/FORM_BLOCK_PLAN.md
@@ -1,7 +1,8 @@
 # Form block — structured input from the app
 
-**Status:** in progress — slices 0–1 done (1 verified live on staging 2026-08-24); the hub is
-deployed with the form contract, so nothing remaining is blocked on it. Next: slice 2.
+**Status:** COMPLETE 2026-08-24 — slices 0–6 shipped on `feat/app-form-block`; reactive flow
+verified live on staging; the proactive run (6d) awaits a real run-day tick with the heartbeat
+toggle on. Archived with the branch.
 **Date:** 2026-08-15 (last updated 2026-08-24).
 **Branch:** `feat/app-form-block`.
 **Goal:** let a message carry a small set of labelled, prefilled boxes the owner corrects and
@@ -64,8 +65,22 @@ unblocked (the hub runs the form contract as of 2026-08-24).
   - [x] Return string describes what was asked (`Form.describe()`: field ids + prefills) —
         the thread is the store
   - [x] Decline directive on an unsupported channel, echoing the prepared values back
-- [ ] **6 · First real caller** — proactive post-workout form, prefilled from
-      `query_exercise_history`
+- [x] **6 · First real caller** — proactive post-workout form; prompt-content only
+  - [x] 6b · One bullet in `tools/fitness/SKILL.md`: prefer `send_form` prefilled from history
+        for stat collection; a `[Submitted form ...]` message is Roi reporting stats. Nothing
+        added to `prompts/heartbeat.md` — the ack-interplay rule (don't restate a sent form in
+        `notification_text`) was judged speculative prompt-hardening; add it only if live
+        ticks actually double-message. No task edits: HEARTBEAT.md is Jarvis-owned, and the
+        existing "proactively ask" wording is medium-agnostic — the skill rule picks the medium
+  - [ ] 6d · Live verification (owner-run): heartbeat toggle on, forced run-day flow end to
+        end. The default channel is already jarvis-app, so no env change; prod routing is a
+        non-question for the same reason
+  - Known limitation, deferred to jarvis-agent#50 (cross-scope context): a heartbeat-sent
+    form's submission runs on the owner's chat thread, which never saw the send — the model
+    gets callback_id + bare values, no prefills to distinguish corrections from confirmations.
+    A notification-log bridge was drafted and deliberately reverted (2026-08-24): it would
+    extend the flat prompt-slice mechanism #50 exists to replace. Semantic field ids are the
+    interim context; #50's resolution should treat block sends as first-class utterances
 
 ---
 

--- a/docs/plans/archive/TRAVEL_DAY_TAGS_PLAN.md
+++ b/docs/plans/archive/TRAVEL_DAY_TAGS_PLAN.md
@@ -1,6 +1,6 @@
 # Travel — day tags
 
-**Status:** planned, not started.
+**Status:** COMPLETE — shipped via feat/travel-day-tags (PR #87, merged 2026-08); archived.
 **Date:** 2026-08-07.
 **Goal:** a day-level label on a trip ("beach", "rest day"), freeform, spanning one or more dates,
 with an optional description — rendered on the day header, not as a timeline item.

--- a/gateway/base.py
+++ b/gateway/base.py
@@ -91,3 +91,21 @@ class Channel(ABC):
         """Default: collect chunks, then send once. Streaming channels override."""
         full = "".join([c async for c in chunks])
         await self.send(chat_id, full)
+
+    # ------------------------------------------------------------------
+    # Interactive blocks (gateway/blocks/) — optional per channel, and
+    # deliberately kind-generic: a new block kind never edits this ABC.
+    # ------------------------------------------------------------------
+
+    def supports_block(self, kind: str) -> bool:
+        """Whether this channel can render block `kind`. The pre-flight callers
+        consult *before* composing — so "this channel has no forms" is decided
+        here, and a send that still fails is an ordinary transient failure."""
+        return False
+
+    async def send_block(self, text: str, block) -> None:
+        """Send `text` to the owner with `block` (a gateway.blocks.Block)
+        attached. All-or-nothing: a channel must never deliver the text without
+        the block, or the owner gets a dangling opener pointing at a card that
+        isn't there."""
+        raise NotImplementedError(f"{self.name} does not render blocks")

--- a/gateway/blocks/__init__.py
+++ b/gateway/blocks/__init__.py
@@ -1,0 +1,27 @@
+"""Neutral interactive-block layer — see base.py for the contracts and one
+module per kind beside it (form.py). Channel adapters map these to their own
+wire; tools and domain code import only from here."""
+
+from gateway.blocks.base import Block, BlockAction, Interactive
+from gateway.blocks.form import (
+    FORM_STATES,
+    MAX_ROWS,
+    Form,
+    FormRow,
+    NumberField,
+    TextField,
+    render_submission,
+)
+
+__all__ = [
+    "Block",
+    "BlockAction",
+    "Interactive",
+    "Form",
+    "FormRow",
+    "TextField",
+    "NumberField",
+    "FORM_STATES",
+    "MAX_ROWS",
+    "render_submission",
+]

--- a/gateway/blocks/base.py
+++ b/gateway/blocks/base.py
@@ -1,0 +1,48 @@
+"""
+Neutral interactive-block contracts — what a channel may carry beyond text.
+
+A Block describes *intent* (what is being asked), never wire shape: rendering
+one into a concrete payload is a channel adapter's job, so nothing in this
+package imports a channel or names one. `Interactive` marks the kinds that can
+be resolved after a tap — they carry a `callback_id`; a kind without one (a
+card) is display-only. `BlockAction` is the inbound mirror: one neutral tap,
+built by a channel's router from its own update shape.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Block:
+    """Base of every outbound block. `kind` is the wire discriminator each
+    subclass fixes; `summary` is the block's one-line stand-in where the full
+    render doesn't fit (notification preview, collapsed list)."""
+
+    summary: str
+
+    kind = ""  # overridden per subclass
+
+
+@dataclass(frozen=True)
+class Interactive(Block):
+    """A block that resolves: it carries the callback_id a later tap names.
+    Which terminal states it may resolve to is per-kind, declared beside the
+    kind's own dataclass."""
+
+    callback_id: str = ""
+
+
+@dataclass(frozen=True)
+class BlockAction:
+    """One tap on a live block, translated out of a channel's update shape.
+
+    `values` is form-submission data (field_id -> str | int | float | None)
+    and None for every other kind — mirroring the wire, where only a block
+    that declared fields may carry it.
+    """
+
+    kind: str
+    action_id: str
+    message_id: int
+    callback_id: str | None
+    values: dict | None = None

--- a/gateway/blocks/form.py
+++ b/gateway/blocks/form.py
@@ -1,0 +1,177 @@
+"""
+Form — the first interactive block kind: labelled, prefilled boxes the owner
+corrects and submits in one tap.
+
+A form is content, not a protocol: nothing is pending while it sits untapped,
+and the submit comes back as ordinary inbound conversation. Everything here is
+validated at construction so a bad form fails at its caller with a correctable
+message, not as a hub 422 inside an async send. Two rules matter beyond what
+the hub's schema already enforces:
+
+- every field on a multi-field row needs a `unit` (a screen reader has only
+  the row label to name bare boxes) — the hub checks this only at runtime;
+- the ~row cap is purely local policy: a form is for correcting guesses, and
+  anything longer is a survey that should have been a conversation.
+
+`default` is a prepopulation, not a hint — but never a *mandatory* one:
+an invented prefill is worse than an empty box, because submit-unchanged is
+the designed happy path and would turn the guess into recorded fact.
+"""
+
+import re
+import secrets
+from dataclasses import dataclass
+
+from gateway.blocks.base import Interactive
+
+MAX_ROWS = 6
+
+# What a form may resolve to. No "cancelled": a form has nothing to decline —
+# expiry (the absence of a decision) is the only non-submit ending.
+FORM_STATES = ("logged", "expired")
+
+_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+_FIELD_ID_RE = re.compile(r"^[a-z0-9_]+$")
+
+
+@dataclass(frozen=True)
+class TextField:
+    """A free-text box. `unit` is the only text beside a box (there is no
+    per-field label); `default` must be a string when present."""
+
+    field_id: str
+    default: str | None = None
+    unit: str | None = None
+
+    type = "text"
+
+    def __post_init__(self):
+        _check_field_id(self.field_id)
+        if self.default is not None and not isinstance(self.default, str):
+            raise ValueError(
+                f"field {self.field_id!r}: a text field's default must be a string, "
+                f"got {type(self.default).__name__}"
+            )
+
+
+@dataclass(frozen=True)
+class NumberField:
+    """A numeric box. `default` must be an int or float when present — bools
+    are refused here even though the wire would coerce True to 1, because
+    nothing should be relying on that."""
+
+    field_id: str
+    default: int | float | None = None
+    unit: str | None = None
+
+    type = "number"
+
+    def __post_init__(self):
+        _check_field_id(self.field_id)
+        if self.default is not None and (
+            isinstance(self.default, bool) or not isinstance(self.default, (int, float))
+        ):
+            raise ValueError(
+                f"field {self.field_id!r}: a number field's default must be a number, "
+                f"got {type(self.default).__name__}"
+            )
+
+
+@dataclass(frozen=True)
+class FormRow:
+    """One labelled thing being filled in, and the box(es) it takes."""
+
+    label: str
+    fields: tuple = ()
+
+    def __post_init__(self):
+        object.__setattr__(self, "fields", tuple(self.fields))
+        if not self.label or not self.label.strip():
+            raise ValueError("every form row needs a label")
+        if not self.fields:
+            raise ValueError(f"row {self.label!r} has no fields")
+        if len(self.fields) > 1:
+            missing = [f.field_id for f in self.fields if not f.unit]
+            if missing:
+                raise ValueError(
+                    f"row {self.label!r} has multiple fields, so every one needs a "
+                    f"unit (missing on: {', '.join(missing)})"
+                )
+
+
+@dataclass(frozen=True)
+class Form(Interactive):
+    """The outbound form. Note what it deliberately has no field for: `values`
+    — that records what the *owner* submitted, stamped by the hub on the tap,
+    and a pre-stamped form must be unconstructible, not merely forbidden.
+
+    `slug` is the caller's semantic name; construction appends entropy to make
+    the callback_id (`push-day-a3f1`) so uniqueness is never the caller's job.
+    """
+
+    slug: str = ""
+    title: str = ""
+    rows: tuple = ()
+    subtitle: str | None = None
+    submit_label: str | None = None
+
+    kind = "form"
+
+    def __post_init__(self):
+        object.__setattr__(self, "rows", tuple(self.rows))
+        if not _SLUG_RE.match(self.slug or ""):
+            raise ValueError(
+                f"slug {self.slug!r} must be lowercase kebab-case (a-z, 0-9, '-')"
+            )
+        if not self.title or not self.title.strip():
+            raise ValueError("a form needs a title")
+        if not self.summary or not self.summary.strip():
+            raise ValueError("a form needs a summary — it is the notification preview")
+        if not self.rows:
+            raise ValueError("a form needs at least one row")
+        if len(self.rows) > MAX_ROWS:
+            raise ValueError(
+                f"{len(self.rows)} rows — a form is for correcting a handful of "
+                f"guesses, {MAX_ROWS} at most; anything longer belongs in conversation"
+            )
+        seen: set[str] = set()
+        for row in self.rows:
+            for f in row.fields:
+                if f.field_id in seen:
+                    raise ValueError(f"duplicate field_id {f.field_id!r}")
+                seen.add(f.field_id)
+        object.__setattr__(self, "callback_id", f"{self.slug}-{secrets.token_hex(2)}")
+
+    def describe(self) -> str:
+        """The form restated as text — what a tool returns so the thread itself
+        records what was asked (field ids and prefills), and what a decline
+        path echoes back for the model to say conversationally."""
+        parts = []
+        for row in self.rows:
+            fields = ", ".join(
+                f"{f.field_id}={f.default if f.default is not None else '(empty)'}"
+                + (f" {f.unit}" if f.unit else "")
+                for f in row.fields
+            )
+            parts.append(f"{row.label}: {fields}")
+        return " · ".join(parts)
+
+
+def _check_field_id(field_id: str) -> None:
+    if not _FIELD_ID_RE.match(field_id or ""):
+        raise ValueError(
+            f"field_id {field_id!r} must be lowercase snake_case (a-z, 0-9, '_')"
+        )
+
+
+def render_submission(callback_id: str, values: dict) -> str:
+    """A submitted form's values as turn text — the neutral rendering every
+    channel's router hands the agent. `None` stays visibly distinct from zero
+    or an empty string: "seen and left empty" is the one distinction the hub
+    goes out of its way to preserve, so the rendering must not collapse it.
+    The callback_id ties the submission back to the send recorded in the
+    thread (the sending tool's return string)."""
+    rendered = " · ".join(
+        f"{k}: {'(left empty)' if v is None else v}" for k, v in values.items()
+    )
+    return f"[Submitted form {callback_id}] {rendered}"

--- a/gateway/channels/jarvis_app/channel.py
+++ b/gateway/channels/jarvis_app/channel.py
@@ -24,6 +24,7 @@ except ImportError:
     Image = None
 
 from gateway.base import Channel
+from gateway.blocks import Form
 from gateway.channels.jarvis_app.client import HubClient
 
 logger = logging.getLogger(__name__)
@@ -82,6 +83,40 @@ def _image_metadata(payload: bytes) -> dict:
         return {}
 
 
+# Neutral block -> hub wire payload. One entry per kind this channel renders;
+# the mapping lives here (not as a to_wire() on the neutral model) because the
+# JSON is this hub's vocabulary, and a second channel rendering the same block
+# would need a different one.
+def _form_wire(form: Form) -> dict:
+    payload: dict = {
+        "callback_id": form.callback_id,
+        "title": form.title,
+        "rows": [
+            {
+                "label": row.label,
+                "fields": [
+                    {
+                        "field_id": f.field_id,
+                        "type": f.type,
+                        **({"unit": f.unit} if f.unit is not None else {}),
+                        **({"default": f.default} if f.default is not None else {}),
+                    }
+                    for f in row.fields
+                ],
+            }
+            for row in form.rows
+        ],
+    }
+    if form.subtitle:
+        payload["subtitle"] = form.subtitle
+    if form.submit_label:
+        payload["submit_label"] = form.submit_label
+    return {"kind": form.kind, "summary": form.summary, "payload": payload}
+
+
+_BLOCK_WIRE = {Form: _form_wire}
+
+
 class JarvisAppChannel(Channel):
     name = "jarvis-app"
 
@@ -126,6 +161,19 @@ class JarvisAppChannel(Channel):
         if caption:
             body["text"] = caption
         await self._client.send_message(body)
+
+    def supports_block(self, kind: str) -> bool:
+        return any(cls.kind == kind for cls in _BLOCK_WIRE)
+
+    async def send_block(self, text: str, block) -> None:
+        # One POST carries text and block together, so the all-or-nothing
+        # contract holds without any compensation logic.
+        to_wire = _BLOCK_WIRE.get(type(block))
+        if to_wire is None:
+            raise NotImplementedError(
+                f"jarvis-app cannot render block kind={getattr(block, 'kind', '?')!r}"
+            )
+        await self._client.send_message({"text": text, "blocks": [to_wire(block)]})
 
     def authorize(self, raw_user_id: str) -> bool:
         # The bot token scopes the hub to the single owner, so inbound updates are

--- a/gateway/channels/jarvis_app/client.py
+++ b/gateway/channels/jarvis_app/client.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 # The version the adapter was written against. The hub reports its own
 # contract_version on GET /v1/health; a mismatch is logged, never fatal — the hub
 # already 422s a malformed payload, so this only gives a *silent* skew a voice.
-PINNED_CONTRACT_VERSION = "45e79b46aed20391"
+PINNED_CONTRACT_VERSION = "509c222e84e2c915"
 
 # The hanging poll's server-side wait. The client read timeout sits a little above
 # it so a genuinely dead connection eventually errors instead of hanging forever.

--- a/gateway/channels/jarvis_app/confirmation.py
+++ b/gateway/channels/jarvis_app/confirmation.py
@@ -8,9 +8,14 @@ confirmed/cancelled/expired. apply_outcome reads only `outcome` (the structured
 result) and ignores `outcome_text`, the prose half a text-rendering channel
 would use instead. Resolution flows the other way through handle_action, the
 router's entry point for an ActionUpdate.
+
+`_message_ids` holds the prompt id from send time (the TTL-expiry path has no
+tap to read one from); `_resolved` holds what this process settled a block to.
+Neither survives a restart and neither has to — a tap names its own message_id.
 """
 
 import logging
+from collections import OrderedDict
 
 from gateway.confirmation.base import ConfirmationOutcome, ConfirmationUI
 from gateway.channels.jarvis_app.client import HubClient, MessageAlreadyResolved
@@ -20,16 +25,17 @@ logger = logging.getLogger(__name__)
 # Maps a resolved confirmation to the hub's wire vocabulary for a confirmation
 # block's `state`. FAILED still means the tap itself was honored (the owner
 # confirmed) — the wire has no separate "the action then failed" state, only
-# what the human decided. ALREADY_HANDLED maps to None: this process no longer
-# knows which value it originally intended, and the hub's own terminal-state
-# guard is what actually protects the stored value either way.
-_WIRE_STATE: dict[ConfirmationOutcome, str | None] = {
+# what the human decided. ALREADY_HANDLED is absent: it names the absence of a
+# pending action, not an outcome, so its state is resolved per call below.
+_WIRE_STATE: dict[ConfirmationOutcome, str] = {
     ConfirmationOutcome.CONFIRMED: "confirmed",
     ConfirmationOutcome.FAILED: "confirmed",
     ConfirmationOutcome.CANCELLED: "cancelled",
     ConfirmationOutcome.EXPIRED: "expired",
-    ConfirmationOutcome.ALREADY_HANDLED: None,
 }
+
+# A bound on the re-affirmation memory, not an expected eviction.
+_RESOLVED_MEMORY = 64
 
 
 class AppConfirmationUI(ConfirmationUI):
@@ -37,6 +43,8 @@ class AppConfirmationUI(ConfirmationUI):
         self._client = client
         self._store = None  # set via bind_store() to break the construction cycle
         self._message_ids: dict[str, int] = {}  # callback_id -> prompt message_id
+        # callback_id -> the wire state this process settled it to.
+        self._resolved: "OrderedDict[str, str]" = OrderedDict()
 
     def bind_store(self, store) -> None:
         self._store = store
@@ -60,9 +68,7 @@ class AppConfirmationUI(ConfirmationUI):
         message_id = self._message_ids.pop(callback_id, None)
         if message_id is None:
             return  # prompt was never successfully sent — nothing to PATCH
-        wire_state = _WIRE_STATE[outcome]
-        if wire_state is None:
-            return
+        wire_state = self._wire_state_for(callback_id, outcome)
         try:
             await self._client.patch_message_state(message_id, wire_state)
         except MessageAlreadyResolved as e:
@@ -70,8 +76,30 @@ class AppConfirmationUI(ConfirmationUI):
                 "jarvis-app PATCH state=%s for callback %s lost to already-settled state=%s",
                 wire_state, callback_id, e.state,
             )
+            # Record what stands, not what we attempted, so a further tap agrees.
+            self._remember_resolved(callback_id, e.state)
         except Exception:
             logger.exception("jarvis-app PATCH state failed for callback %s", callback_id)
+        else:
+            self._remember_resolved(callback_id, wire_state)
+
+    def _wire_state_for(
+        self, callback_id: str, outcome: ConfirmationOutcome
+    ) -> str:
+        """The `state` to PATCH. ALREADY_HANDLED means nothing was pending —
+        two cases the store cannot separate but this side can: a block this
+        process already settled (re-affirm it; the hub refuses a change), or a
+        handle that was never ours (expire it, or the card waits forever).
+        """
+        if outcome is not ConfirmationOutcome.ALREADY_HANDLED:
+            return _WIRE_STATE[outcome]
+        return self._resolved.get(callback_id, "expired")
+
+    def _remember_resolved(self, callback_id: str, state: str) -> None:
+        self._resolved[callback_id] = state
+        self._resolved.move_to_end(callback_id)
+        while len(self._resolved) > _RESOLVED_MEMORY:
+            self._resolved.popitem(last=False)
 
     async def handle_action(
         self, *, action_id: str, message_id: int, block_kind: str, callback_id: str | None
@@ -95,4 +123,6 @@ class AppConfirmationUI(ConfirmationUI):
         if self._store is None:
             logger.error("Confirmation store not bound; cannot resolve %s", callback_id)
             return
+        # The tap names its own message — the only handle a restart cannot lose.
+        self._message_ids[callback_id] = message_id
         await self._store.resolve(callback_id, confirmed=(action_id == "confirm"))

--- a/gateway/channels/jarvis_app/router.py
+++ b/gateway/channels/jarvis_app/router.py
@@ -19,6 +19,7 @@ import re
 
 from gateway.apps import AppError, dispatch, list_apps
 from gateway.base import InboundMessage, OnMessage
+from gateway.blocks import BlockAction, render_submission
 from gateway.commands import list_commands
 from gateway.channels.jarvis_app import media_cache
 from gateway.channels.jarvis_app.channel import JarvisAppChannel
@@ -214,6 +215,10 @@ class JarvisAppInboundRouter:
                 # The outage may have been a hub restart, which drops the
                 # in-memory command and app registries — re-declare before
                 # serving, since only this transition knows a link was re-made.
+                # A restart can equally mean a new hub version, so re-check the
+                # contract too; startup-only checking left an upgrade invisible
+                # until this process's own next restart.
+                await self._check_contract()
                 await self._declare_all()
             backoff = _BACKOFF_START_S
             for update in updates:
@@ -291,11 +296,14 @@ class JarvisAppInboundRouter:
 
     async def _handle(self, update: dict) -> None:
         if update.get("type") == "action":
-            await self._confirmation_ui.handle_action(
-                action_id=update.get("action_id"),
-                message_id=update.get("message_id"),
-                block_kind=update.get("block_kind"),
-                callback_id=update.get("callback_id"),
+            await self._handle_action(
+                BlockAction(
+                    kind=update["block_kind"],
+                    action_id=update["action_id"],
+                    message_id=update["message_id"],
+                    callback_id=update.get("callback_id"),
+                    values=update.get("values"),
+                )
             )
             return
         if update.get("type") != "message":
@@ -318,6 +326,49 @@ class JarvisAppInboundRouter:
             elif raw_attachments:
                 text = "[an attachment was sent but could not be retrieved]"
 
+        await self._run_turn(text, attachments)
+
+    async def _handle_action(self, action: BlockAction) -> None:
+        """Dispatch one tap by block kind. `confirmation` resolves below the
+        LLM via the store; `form` is content — its submission becomes an
+        ordinary inbound turn; anything else has no handler yet."""
+        if action.kind == "confirmation":
+            await self._confirmation_ui.handle_action(
+                action_id=action.action_id,
+                message_id=action.message_id,
+                block_kind=action.kind,
+                callback_id=action.callback_id,
+            )
+            return
+        if action.kind == "form":
+            await self._handle_form_submit(action)
+            return
+        logger.info(
+            "jarvis-app ignoring action for block_kind=%r (no handler yet)", action.kind
+        )
+
+    async def _handle_form_submit(self, action: BlockAction) -> None:
+        """Run a submitted form's values through the agent, then close the card.
+
+        The PATCH to `logged` comes strictly after the turn: `logged` means the
+        turn actually ran. A turn that raises leaves the card untouched — the
+        hub's re-tap guard lifts once the update is acked (which happened at
+        fetch), so the live card itself is the retry path, with thread context
+        (submission text logged before the turn) guarding against a re-run
+        double-logging.
+        """
+        await self._run_turn(render_submission(action.callback_id, action.values), [])
+        try:
+            await self._client.patch_message_state(action.message_id, "logged")
+        except Exception:
+            # The turn already ran and replied; a lost PATCH costs a card stuck
+            # on pending, which a re-tap or a later sweep can settle — never
+            # worth failing the consumed update over.
+            logger.exception(
+                "jarvis-app PATCH logged failed for form %s", action.callback_id
+            )
+
+    async def _run_turn(self, text: str, attachments: list[dict]) -> None:
         # The hub carries no per-message user id (the bot token scopes the single
         # owner), so user_id/chat_id are placeholders — nothing downstream reads
         # them; the thread id is what namespaces the conversation.

--- a/gateway/factory.py
+++ b/gateway/factory.py
@@ -156,6 +156,30 @@ def default_outbox() -> Outbox:
     return _default_entry().outbox
 
 
+def _origin_entry() -> _Registered:
+    """The registered channel of the running turn's origin thread, falling back
+    to the proactive default for origin-less turns (heartbeat) — the same
+    routing rule get_confirmation() applies, over the send registry."""
+    thread_id = turn_context.current_thread_id()
+    if thread_id:
+        entry = _registry.get(thread_id.split("_", 1)[0])
+        if entry is not None:
+            return entry
+    return _default_entry()
+
+
+def origin_channel() -> Channel:
+    """The origin channel of the running turn — what a tool consults for
+    capability (e.g. supports_block) before composing anything for it."""
+    return _origin_entry().channel
+
+
+def origin_outbox() -> Outbox:
+    """The origin channel's outbox — where a tool-initiated send belongs, so
+    what a turn produces lands on the channel the turn came from."""
+    return _origin_entry().outbox
+
+
 def register_confirmation(name: str, store: Confirmation) -> None:
     """Register a channel's confirmation store under its channel name."""
     _confirmation_stores[name] = store

--- a/gateway/outbox.py
+++ b/gateway/outbox.py
@@ -115,6 +115,30 @@ class Outbox:
         await self._log(event, caption or f"[{kind}]", metadata)
         return SendOutcome(ok=True)
 
+    async def send_block_to_owner(
+        self,
+        text: str,
+        block,
+        *,
+        event: str | None = None,
+        metadata: dict | None = None,
+    ) -> SendOutcome:
+        """Send text with an interactive block attached (gateway.blocks). Same
+        logging/failure semantics as notify_owner; never a partial send — the
+        channel delivers both or neither. Callers pre-flight with
+        channel.supports_block(); an unsupported kind surfacing here is still
+        just a failed SendOutcome, never a raise."""
+        try:
+            await self._channel.send_block(text, block)
+        except Exception as e:
+            logger.exception(
+                "Outbox: failed to send owner block (kind=%s, event=%s)",
+                block.kind, event,
+            )
+            return SendOutcome(ok=False, error=str(e))
+        await self._log(event, text, metadata)
+        return SendOutcome(ok=True)
+
     async def _log(self, event: str | None, text: str, metadata: dict | None) -> None:
         """Notification logging must never turn a delivered message into a
         reported failure — the send already happened."""

--- a/scripts/ci/check_channel_agnostic.py
+++ b/scripts/ci/check_channel_agnostic.py
@@ -44,6 +44,14 @@ _FORBIDDEN_IMPORT = "gateway.channels"
 # Repo-relative, matched against _rel(path) so os.walk's "/./" segments normalize.
 _CHANNEL_IMPORT_EXEMPT_FILE = os.path.join("gateway", "factory.py")
 _CHANNEL_IMPORT_EXEMPT_TREE = os.path.join("gateway", "channels") + os.sep
+# A channel's own offline test harness drives that channel's internals against
+# fakes, which factory cannot hand it — conceptually part of the channel
+# package, just living in scripts/. Named per file so new scripts stay covered
+# by default.
+_CHANNEL_IMPORT_EXEMPT_TESTS = (
+    os.path.join("scripts", "test_app_blocks.py"),
+    os.path.join("scripts", "test_app_confirmation.py"),
+)
 
 # gateway/ is thin adapters + core contracts; it must not import back up into the
 # app — EXCEPT gateway/commands/ (the documented slash-command bridge).
@@ -104,7 +112,8 @@ def check_domain_imports():
     leaks = []
     for path in _py_files("."):
         rel = _rel(path)
-        if rel == _CHANNEL_IMPORT_EXEMPT_FILE or rel.startswith(_CHANNEL_IMPORT_EXEMPT_TREE):
+        if (rel == _CHANNEL_IMPORT_EXEMPT_FILE or rel.startswith(_CHANNEL_IMPORT_EXEMPT_TREE)
+                or rel in _CHANNEL_IMPORT_EXEMPT_TESTS):
             continue
         for mod, line in _imports(path):
             if mod == _FORBIDDEN_IMPORT or mod.startswith(_FORBIDDEN_IMPORT + "."):

--- a/scripts/test_app_blocks.py
+++ b/scripts/test_app_blocks.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Offline harness for the block layer — no hub, no service, no model.
+
+Drives the real Form validation, the real jarvis-app wire mapping, the real
+router dispatch, and the real send_form tool against fakes at the seams
+(HubClient, on_message, channel registry). Run from the repo root:
+
+    JARVIS_ROOT=/app/jarvis_staging ./venv/bin/python scripts/test_app_blocks.py
+"""
+
+import asyncio
+import pathlib
+import sys
+import threading
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+
+FAILS: list[str] = []
+
+
+def check(name, got, want=True):
+    ok = got == want
+    print(f"{'PASS' if ok else 'FAIL'}  {name}" + ("" if ok else f": {got!r} != {want!r}"))
+    if not ok:
+        FAILS.append(name)
+
+
+def raises(name, fn, *needles):
+    try:
+        fn()
+    except (ValueError, TypeError) as e:
+        ok = all(n in str(e) for n in needles)
+        print(f"{'PASS' if ok else 'FAIL'}  {name}" + ("" if ok else f": {e}"))
+        if not ok:
+            FAILS.append(name)
+    else:
+        print(f"FAIL  {name}: did not raise")
+        FAILS.append(name)
+
+
+# ── 1 · Form validation ────────────────────────────────────────────────────
+from gateway.blocks import Form, FormRow, NumberField, TextField, render_submission
+
+
+def bench_form(**kw):
+    args = dict(
+        summary="Push day: 2 to log",
+        slug="push-day",
+        title="Push day",
+        rows=(
+            FormRow("Bench press", (
+                NumberField("bench_reps", default=8, unit="reps"),
+                NumberField("bench_kg", default=60, unit="kg"),
+            )),
+            FormRow("Core", (TextField("core", default="plank 3×45s"),)),
+        ),
+    )
+    args.update(kw)
+    return Form(**args)
+
+
+f = bench_form()
+check("valid form builds", f.title, "Push day")
+check("callback_id = slug + entropy", f.callback_id.startswith("push-day-") and len(f.callback_id) > len("push-day-"))
+check("two forms never share an id", bench_form().callback_id != bench_form().callback_id)
+check("describe carries ids and prefills",
+      f.describe(), "Bench press: bench_reps=8 reps, bench_kg=60 kg · Core: core=plank 3×45s")
+
+raises("values is unconstructible", lambda: Form(summary="s", slug="s", title="t", rows=(), values={}), "values")
+raises("empty rows refused", lambda: bench_form(rows=()), "at least one row")
+raises("row cap enforced",
+       lambda: bench_form(rows=tuple(FormRow(f"r{i}", (NumberField(f"f{i}", unit="x"),)) for i in range(7))),
+       "7 rows")
+raises("bare boxes on a multi-field row refused",
+       lambda: FormRow("Bench", (NumberField("a", unit="kg"), NumberField("b"))), "unit", "b")
+check("single field needs no unit", FormRow("Core", (TextField("core"),)).label, "Core")
+raises("text default must be a string", lambda: TextField("t", default=7), "must be a string")
+raises("number default must be a number", lambda: NumberField("n", default="sixty"), "must be a number")
+raises("bool default refused", lambda: NumberField("n", default=True), "must be a number")
+raises("duplicate field_id refused",
+       lambda: bench_form(rows=(FormRow("A", (NumberField("x", unit="kg"),)),
+                                FormRow("B", (NumberField("x", unit="kg"),)))), "duplicate")
+raises("slug is kebab-case", lambda: bench_form(slug="Push Day"), "kebab")
+raises("field_id is snake_case", lambda: TextField("Bench-Reps"), "snake_case")
+raises("a form needs a title", lambda: bench_form(title=" "), "title")
+raises("a form needs a summary", lambda: bench_form(summary=""), "notification preview")
+
+check("null renders as left empty, int stays int",
+      render_submission("push-day-a3f1", {"bench_reps": 8, "fly_kg": None, "core": "plank"}),
+      "[Submitted form push-day-a3f1] bench_reps: 8 · fly_kg: (left empty) · core: plank")
+
+# ── 2 · Wire mapping ───────────────────────────────────────────────────────
+from gateway.channels.jarvis_app.channel import JarvisAppChannel, _form_wire
+
+wire = _form_wire(f)
+check("wire kind/summary", (wire["kind"], wire["summary"]), ("form", "Push day: 2 to log"))
+check("wire payload keys", sorted(wire["payload"]), ["callback_id", "rows", "title"])
+check("wire row", wire["payload"]["rows"][0],
+      {"label": "Bench press", "fields": [
+          {"field_id": "bench_reps", "type": "number", "unit": "reps", "default": 8},
+          {"field_id": "bench_kg", "type": "number", "unit": "kg", "default": 60}]})
+check("absent unit/default omitted, not null",
+      "unit" not in wire["payload"]["rows"][1]["fields"][0]
+      and wire["payload"]["rows"][1]["fields"][0]["default"] == "plank 3×45s")
+g = bench_form(subtitle="2 exercises", submit_label="Log workout")
+gw = _form_wire(g)["payload"]
+check("subtitle/submit_label pass through", (gw["subtitle"], gw["submit_label"]),
+      ("2 exercises", "Log workout"))
+
+
+# ── 3 · Channel send_block ─────────────────────────────────────────────────
+class FakeClient:
+    def __init__(self):
+        self.sent, self.patches = [], []
+
+    async def send_message(self, body):
+        self.sent.append(body)
+        return {"id": 41}
+
+    async def patch_message_state(self, message_id, state):
+        self.patches.append((message_id, state))
+
+
+fc = FakeClient()
+app_channel = JarvisAppChannel(fc, owner_id="owner")
+check("jarvis-app supports form", app_channel.supports_block("form"))
+check("jarvis-app does not claim card", app_channel.supports_block("card"), False)
+asyncio.run(app_channel.send_block("Fill it in.", f))
+check("one POST carries text and block",
+      (fc.sent[0]["text"], fc.sent[0]["blocks"][0]["kind"]), ("Fill it in.", "form"))
+
+from gateway.base import Channel
+
+check("Channel default declines blocks", Channel.supports_block(app_channel, "form"), False)
+
+
+# ── 4 · Router dispatch ────────────────────────────────────────────────────
+from gateway.channels.jarvis_app.router import JarvisAppInboundRouter
+
+
+class FakeUI:
+    def __init__(self):
+        self.calls = []
+
+    async def handle_action(self, **kw):
+        self.calls.append(kw)
+
+
+def build_router(on_message):
+    fc = FakeClient()
+    channel = JarvisAppChannel(fc, owner_id="owner")
+    ui = FakeUI()
+    return JarvisAppInboundRouter(channel, fc, on_message, ui), fc, ui
+
+
+def submit_update(values):
+    return {"type": "action", "update_id": 1, "message_id": 412, "action_id": "submit",
+            "block_kind": "form", "callback_id": "push-day-a3f1", "values": values}
+
+
+turns = []
+
+
+async def ok_turn(inbound):
+    turns.append(inbound)
+    return "Logged it."
+
+
+router, fc, ui = build_router(ok_turn)
+asyncio.run(router._handle(submit_update({"bench_reps": 8, "core": None})))
+check("submit runs a turn with the rendered text",
+      turns[0].user_text, "[Submitted form push-day-a3f1] bench_reps: 8 · core: (left empty)")
+check("submit lands on the owner thread", turns[0].thread_id, "jarvis-app_owner")
+check("reply sent, then PATCH logged",
+      (fc.sent[0]["text"], fc.patches), ("Logged it.", [(412, "logged")]))
+
+
+async def dead_turn(inbound):
+    raise RuntimeError("model exploded")
+
+
+router, fc, ui = build_router(dead_turn)
+try:
+    asyncio.run(router._handle(submit_update({"a": 1})))
+except RuntimeError:
+    pass
+check("crashed turn leaves the card alone (no PATCH)", fc.patches, [])
+
+router, fc, ui = build_router(ok_turn)
+asyncio.run(router._handle({"type": "action", "update_id": 2, "message_id": 9,
+                            "action_id": "confirm", "block_kind": "confirmation",
+                            "callback_id": "cb1"}))
+check("confirmation still routes below the LLM",
+      ui.calls, [{"action_id": "confirm", "message_id": 9,
+                  "block_kind": "confirmation", "callback_id": "cb1"}])
+
+n_turns = len(turns)
+asyncio.run(router._handle({"type": "action", "update_id": 3, "message_id": 10,
+                            "action_id": "pick", "block_kind": "buttons",
+                            "callback_id": None}))
+check("unhandled kind ignored quietly", (len(turns), fc.patches), (n_turns, []))
+
+
+# ── 5 · The tool ───────────────────────────────────────────────────────────
+import turn_context
+from gateway import factory
+from gateway import outbox as outbox_mod
+from gateway.outbox import Outbox
+from tools.core.forms import send_form
+
+ROWS = [{"label": "Bench press", "fields": [
+    {"field_id": "bench_reps", "type": "number", "unit": "reps", "default": 8},
+    {"field_id": "bench_kg", "type": "number", "unit": "kg", "default": 60}]}]
+ARGS = dict(message_text="Push day — fill in what you hit.", slug="push-day",
+            title="Push day", summary="Push day: log it", rows=ROWS)
+
+# A loop in a background thread stands in for the host loop, so the tool's
+# sync body can block on submit(...).result() exactly as it does in production.
+loop = asyncio.new_event_loop()
+threading.Thread(target=loop.run_forever, daemon=True).start()
+outbox_mod.bind_loop(loop)
+
+fc = FakeClient()
+app_channel = JarvisAppChannel(fc, owner_id="owner")
+factory.register_channel(app_channel, Outbox(app_channel))
+
+
+class Blockless:
+    name = "telegram"
+
+    def supports_block(self, kind):
+        return False
+
+
+factory._registry["telegram"] = factory._Registered(Blockless(), Outbox(Blockless()))
+
+tok = turn_context.CURRENT_THREAD_ID.set("jarvis-app_owner")
+out = send_form.func(**ARGS)
+check("tool sends on the origin channel",
+      out.startswith("Sent form push-day-") and "bench_reps=8 reps" in out)
+check("hub got text + form", (fc.sent[0]["text"], fc.sent[0]["blocks"][0]["kind"]),
+      ("Push day — fill in what you hit.", "form"))
+turn_context.CURRENT_THREAD_ID.reset(tok)
+
+tok = turn_context.CURRENT_THREAD_ID.set("telegram_42")
+out = send_form.func(**ARGS)
+check("blockless origin declines with the prefills",
+      out.startswith("Forms aren't available on telegram — nothing was sent")
+      and "bench_reps=8 reps" in out)
+turn_context.CURRENT_THREAD_ID.reset(tok)
+
+out = send_form.func(**{**ARGS, "rows": [{"label": "Bench", "fields": [
+    {"field_id": "reps", "type": "choice"}]}]})
+check("bad field type is a correctable error",
+      out.startswith("Error: invalid form") and "'text' or 'number'" in out)
+
+out = send_form.func(**{**ARGS, "rows": []})
+check("no rows is a correctable error", out.startswith("Error: invalid form"))
+
+out = send_form.func(**{**ARGS, "rows": [{"label": "Bench", "fields": [
+    {"field_id": "reps", "type": "number", "value": 8}]}]})
+check("unknown field key refused, not dropped",
+      out.startswith("Error: invalid form") and "'value'" in out)
+
+out = send_form.func(**{**ARGS, "rows": [{"label": "Bench", "group": "push", "fields": [
+    {"field_id": "reps", "type": "number"}]}]})
+check("unknown row key refused", out.startswith("Error: invalid form") and "'group'" in out)
+
+# Timeout path: a send_block that never resolves must come back as an explicit
+# delivery-unknown directive, not a blank error.
+import tools.core.forms as forms_mod
+
+
+class Hanging:
+    name = "jarvis-app"
+
+    def supports_block(self, kind):
+        return True
+
+    async def send_block(self, text, block):
+        await asyncio.sleep(3600)
+
+
+factory._registry["jarvis-app"] = factory._Registered(Hanging(), Outbox(Hanging()))
+forms_mod._SEND_TIMEOUT_S = 0.2
+tok = turn_context.CURRENT_THREAD_ID.set("jarvis-app_owner")
+out = send_form.func(**ARGS)
+check("timeout returns delivery-unknown directive",
+      out.startswith("Error: the form send was not confirmed")
+      and "Do not send it again" in out)
+turn_context.CURRENT_THREAD_ID.reset(tok)
+factory._registry["jarvis-app"] = factory._Registered(app_channel, Outbox(app_channel))
+
+loop.call_soon_threadsafe(loop.stop)
+
+print()
+print("ALL PASS" if not FAILS else f"{len(FAILS)} FAILURES: {FAILS}")
+sys.exit(1 if FAILS else 0)

--- a/scripts/test_app_confirmation.py
+++ b/scripts/test_app_confirmation.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Exercise AppConfirmationUI against a fake hub, using the real store."""
+import asyncio, sys
+sys.path.insert(0, str(__import__('pathlib').Path(__file__).resolve().parent.parent))
+
+from gateway.channels.jarvis_app.confirmation import AppConfirmationUI
+from gateway.channels.jarvis_app.client import MessageAlreadyResolved
+from gateway.confirmation.base import PendingAction
+from gateway.confirmation.store import InMemoryConfirmationStore
+
+
+class FakeClient:
+    def __init__(self, raise_state=None):
+        self.patches = []
+        self.raise_state = raise_state
+        self._next_id = 100
+
+    async def send_message(self, body):
+        self._next_id += 1
+        return {"id": self._next_id}
+
+    async def patch_message_state(self, message_id, state):
+        self.patches.append((message_id, state))
+        if self.raise_state:
+            s, self.raise_state = self.raise_state, None
+            raise MessageAlreadyResolved(s)
+
+
+class FakeOutbox:
+    async def notify_owner(self, text, **kw):
+        return None
+
+
+def build(raise_state=None):
+    client = FakeClient(raise_state)
+    ui = AppConfirmationUI(client)
+    store = InMemoryConfirmationStore(ui, FakeOutbox(), "jarvis-app_1")
+    ui.bind_store(store)
+    return client, ui, store
+
+
+def pend(store, cb):
+    async def act():
+        return "done"
+    store._pending[cb] = PendingAction(act, "delete a thing", "ok", "cancelled")
+
+
+async def tap(ui, cb, mid, action="confirm"):
+    await ui.handle_action(
+        action_id=action, message_id=mid, block_kind="confirmation", callback_id=cb
+    )
+
+
+async def main():
+    fails = []
+
+    def check(name, got, want):
+        ok = got == want
+        print(f"{'PASS' if ok else 'FAIL'}  {name}: {got!r}")
+        if not ok:
+            fails.append(f"{name}: got {got!r}, want {want!r}")
+
+    # 1 — normal confirm, prompt sent by this process
+    c, ui, store = build()
+    await ui.send_prompt("cb1", "delete a thing")
+    pend(store, "cb1")
+    await tap(ui, "cb1", 101)
+    check("normal confirm", c.patches, [(101, "confirmed")])
+
+    # 2 — orphan: this process never sent the prompt (restart), nothing pending
+    c, ui, store = build()
+    await tap(ui, "gone", 777)
+    check("orphan expires (was: no PATCH at all)", c.patches, [(777, "expired")])
+
+    # 3 — re-tap after we already settled it
+    c, ui, store = build()
+    await ui.send_prompt("cb3", "delete a thing")
+    pend(store, "cb3")
+    await tap(ui, "cb3", 101)
+    await tap(ui, "cb3", 101)
+    check("re-tap re-affirms (was: silent no-op)", c.patches,
+          [(101, "confirmed"), (101, "confirmed")])
+
+    # 4 — cancel, then re-tap
+    c, ui, store = build()
+    await ui.send_prompt("cb4", "delete a thing")
+    pend(store, "cb4")
+    await tap(ui, "cb4", 101, action="cancel")
+    await tap(ui, "cb4", 101)
+    check("re-tap after cancel", c.patches, [(101, "cancelled"), (101, "cancelled")])
+
+    # 5 — hub refuses our guess; we learn the truth and re-affirm it next time
+    c, ui, store = build(raise_state="confirmed")
+    await tap(ui, "unknown", 555)            # tries expired, hub says confirmed stands
+    await tap(ui, "unknown", 555)            # now re-affirms confirmed
+    check("learns settled state from hub", c.patches,
+          [(555, "expired"), (555, "confirmed")])
+
+    # 6 — TTL eviction path (no tap, so only the send-time handle exists)
+    c, ui, store = build()
+    await ui.send_prompt("cb6", "delete a thing")
+    pend(store, "cb6")
+    await ui.expire("cb6")
+    check("TTL expire still works", c.patches, [(101, "expired")])
+
+    # 7 — prompt send failed, so no handle from either source
+    c, ui, store = build()
+    await ui.expire("never-sent")
+    check("no handle -> no PATCH", c.patches, [])
+
+    # 8 — memory stays bounded
+    c, ui, store = build()
+    for i in range(200):
+        ui._remember_resolved(f"cb{i}", "confirmed")
+    check("resolved memory capped", len(ui._resolved), 64)
+
+    print("\n" + ("ALL PASS" if not fails else "FAILURES:\n  " + "\n  ".join(fails)))
+    return 1 if fails else 0
+
+
+sys.exit(asyncio.run(main()))

--- a/tools/core/__init__.py
+++ b/tools/core/__init__.py
@@ -27,6 +27,7 @@ from tools.core.scheduling import (
     _remove_event,
 )
 from tools.core.activate_skill import activate_skill, deactivate_skill
+from tools.core.forms import send_form
 from tools.core.heartbeat import heartbeat_respond, manage_heartbeat_task
 
 __all__ = [

--- a/tools/core/forms.py
+++ b/tools/core/forms.py
@@ -1,0 +1,154 @@
+"""The send_form tool — put a small prefilled form in front of the owner.
+
+A thin caller over the gateway's block seam: build a neutral Form from the
+model's arguments (all validation lives in the Form itself), pre-flight the
+origin channel's capability, send through that channel's outbox. The tool
+returns a description of what was asked — the thread is the only store a form
+has, so the return string is what later makes the submission intelligible.
+"""
+
+import concurrent.futures
+import logging
+
+from langchain_core.tools import tool
+
+from gateway import outbox as outbox_mod
+from gateway.blocks import Form, FormRow, NumberField, TextField
+from tools.registry import tool_register
+
+logger = logging.getLogger(__name__)
+
+_SEND_TIMEOUT_S = 20.0
+
+
+_ROW_KEYS = {"label", "fields"}
+_FIELD_KEYS = {"field_id", "type", "unit", "default"}
+
+
+def _parse_rows(rows: list) -> list[FormRow]:
+    """Model-supplied dicts -> block dataclasses. Raises ValueError with a
+    correctable message; the Form's own validation runs after. Unknown keys are
+    refused rather than dropped — a stray "value" for "default" would otherwise
+    silently ship a box without its intended prefill."""
+    parsed: list[FormRow] = []
+    for row in rows or []:
+        unknown = set(row) - _ROW_KEYS
+        if unknown:
+            raise ValueError(
+                f"row {row.get('label')!r}: unknown key(s) {sorted(unknown)} — "
+                f"a row has exactly {sorted(_ROW_KEYS)}"
+            )
+        fields = []
+        for f in row.get("fields") or []:
+            unknown = set(f) - _FIELD_KEYS
+            if unknown:
+                raise ValueError(
+                    f"field {f.get('field_id')!r}: unknown key(s) {sorted(unknown)} — "
+                    f"a field has {sorted(_FIELD_KEYS)}"
+                )
+            ftype = f.get("type", "text")
+            kwargs = {
+                "field_id": f.get("field_id", ""),
+                "default": f.get("default"),
+                "unit": f.get("unit"),
+            }
+            if ftype == "number":
+                fields.append(NumberField(**kwargs))
+            elif ftype == "text":
+                fields.append(TextField(**kwargs))
+            else:
+                raise ValueError(
+                    f"field {f.get('field_id')!r}: type must be 'text' or 'number', "
+                    f"got {ftype!r}"
+                )
+        parsed.append(FormRow(label=row.get("label", ""), fields=tuple(fields)))
+    return parsed
+
+
+@tool_register(namespace="core")
+@tool
+def send_form(
+    message_text: str,
+    slug: str,
+    title: str,
+    summary: str,
+    rows: list[dict],
+    subtitle: str = "",
+    submit_label: str = "",
+) -> str:
+    """Send the user a small form — labelled boxes, prefilled with your best guess,
+    submitted in one tap.
+
+    ONLY use a form when you can prefill every box from real data (their logged
+    history, their stated plan) and expect the user to submit it unchanged or with
+    small corrections. A form is for CORRECTING guesses, not for collecting answers:
+    - asking open questions -> just ask in conversation, never a form
+    - one single value -> just ask in conversation
+    - anything you cannot prefill from evidence -> leave that box empty (no default);
+      NEVER invent a plausible-looking default, since unchanged submission records it
+      as fact
+    Do not announce the form separately; message_text accompanies the card.
+
+    After the user submits, the values arrive in this conversation as a
+    "[Submitted form <id>]" message naming each field_id — handle it then (e.g. log
+    it with the right tool). A value of "(left empty)" means the user saw the box
+    and left it blank: respect that as an explicit "no value", don't substitute one.
+
+    Args:
+        message_text: The sentence shown with the card (e.g. "Push day — fill in
+            what you hit."). Required; without it the form opens cold.
+        slug: Short kebab-case name for this form (e.g. 'push-day'). A unique id
+            is derived from it.
+        title: Card heading (e.g. 'Push day').
+        summary: One-line stand-in shown where the card doesn't render
+            (notification preview).
+        rows: Up to 6 rows. Each: {"label": str, "fields": [{"field_id":
+            snake_case str, "type": "text"|"number", "unit": str (required when a
+            row has 2+ fields), "default": prefill matching the type}]}.
+            Example: [{"label": "Bench press", "fields": [
+                {"field_id": "bench_reps", "type": "number", "unit": "reps", "default": 8},
+                {"field_id": "bench_kg", "type": "number", "unit": "kg", "default": 60}]}]
+        subtitle: Optional line under the title (e.g. '4 exercises').
+        submit_label: Optional label for the submit button (default 'Submit').
+    """
+    from gateway.factory import origin_channel, origin_outbox
+
+    try:
+        form = Form(
+            summary=summary,
+            slug=slug,
+            title=title,
+            rows=tuple(_parse_rows(rows)),
+            subtitle=subtitle or None,
+            submit_label=submit_label or None,
+        )
+    except (ValueError, TypeError) as e:
+        return f"Error: invalid form — {e}"
+
+    channel = origin_channel()
+    if not channel.supports_block("form"):
+        # No fallback is sent for the caller: prose is the model's own output,
+        # not a tool's. Echo the prepared guesses so the recovery is a rewrite.
+        return (
+            f"Forms aren't available on {channel.name} — nothing was sent. "
+            f"Say it conversationally instead. You had prepared: {form.describe()}"
+        )
+
+    try:
+        outcome = outbox_mod.submit(
+            origin_outbox().send_block_to_owner(message_text, form)
+        ).result(timeout=_SEND_TIMEOUT_S)
+    except concurrent.futures.TimeoutError:
+        # The send is still running on the loop — expiry means unknown, not
+        # failed, so the directive must prevent a duplicate card.
+        return (
+            "Error: the form send was not confirmed within "
+            f"{_SEND_TIMEOUT_S:.0f}s — it may still reach the user. Do not "
+            "send it again; ask the user whether the card arrived."
+        )
+    if not outcome.ok:
+        return f"Error: form could not be sent — {outcome.error}"
+    return (
+        f"Sent form {form.callback_id} ({title}): {form.describe()}. "
+        f"The user's submission will arrive as a new message."
+    )

--- a/tools/fitness/SKILL.md
+++ b/tools/fitness/SKILL.md
@@ -4,6 +4,7 @@ description: gym attendance, workout logs, running sessions
 ---
 - Before discussing or logging a running session, check MEMORY.md for your running-program notes (current phase, next session). A running session's description must match the program phase and session number (e.g. 'Phase 0 Session 1: 30-min brisk walk'). pain_level is 0=none, 1=slight, 2=moderate, 3=stop-sign; if ≥ 2, flag it clearly in your response.
 - Log workout stats and WOD results immediately when Roi reports them — never acknowledge without saving.
+- To collect workout or running stats, prefer `send_form` prefilled from history (`query_exercise_history`; your running-program notes) over asking in prose. A `[Submitted form ...]` message is Roi reporting stats — log it per the rule above.
 - If any Arbox tool returns "Error: Arbox session expired", relay that exact message to Roi verbatim (he must update ARBOX_ACCESS_TOKEN in the env file). Do not retry.
 - When `fetch_upcoming_arbox_classes` reports it removed a class Roi is no longer registered for, don't treat it as silent cleanup: tell him the class was dropped, and if it puts him under his weekly quota (`get_weekly_fitness_summary`), say so and offer to look at alternatives (`fetch_weekly_gym_schedule`).
 - `fetch_upcoming_arbox_classes` / `fetch_weekly_gym_schedule` already return only the track Roi follows (WOD, or Saturday Endurance) in full. Reach for `get_daily_programming` only when he explicitly asks about another track (PUMP, weightlifting) or wants to compare them.


### PR DESCRIPTION
## What

The hub's new `form` block kind (contract `509c222e84e2c915`, deployed on the staging hub from jarvis-app's `form-renderer` branch), built as a generic gateway capability rather than a form-specific feature:

- **`gateway/blocks/`** — neutral block layer: `Block`/`Interactive`/`BlockAction` + `Form` dataclasses, all validation at construction, `callback_id` generated (slug + entropy), `values` unconstructible on outbound blocks
- **Channel seam** — kind-generic `supports_block`/`send_block` (defaults decline), `Outbox.send_block_to_owner`, `factory.origin_channel/origin_outbox` (origin routing per `get_confirmation`'s rule, falling back for origin-less turns)
- **jarvis-app** — wire mapping table (validated against the vendored contract schema), inbound dispatch: `confirmation` below the LLM as before, `form` submit → ordinary turn (`null` survives as "left empty"), PATCH `logged` strictly after the turn (a crashed turn leaves the card live — per the hub's ack semantics, the re-tap is the recovery). Contract pin bumped; the version check now re-runs on reconnect
- **`send_form` tool** (`tools/core/`) — docstring-guarded (prefill from evidence only, submit-unchanged precondition), declines with the prepared values on a blockless channel, delivery-unknown directive on timeout
- **Confirmation fixes** (independent, `47812dc`) — an orphaned `callback_id` now PATCHes `expired` using the tap's own `message_id`; a re-tap re-affirms the settled state instead of no-op'ing; a `MessageAlreadyResolved` refusal teaches the settled-state map
- **One fitness skill bullet** — prefer a prefilled form for stat collection

## Design decisions (docs/plans/archive/FORM_BLOCK_PLAN.md has the full record)

A form is **content, not a protocol**: no pending store, no TTL, the thread is the store, the submit runs a model turn — no deterministic DB writes below the model. The cross-thread context gap for heartbeat-sent forms is deliberately deferred to #50 (a drafted notification-log bridge was reverted as extending the mechanism #50 exists to replace).

## Verification

- Offline: `scripts/test_app_blocks.py` (41 checks — validation, wire-vs-schema, dispatch, tool) + `scripts/test_app_confirmation.py` (8); all CI guards green
- Live on staging: confirmation matrix (confirm/cancel/re-tap/TTL/orphan-after-restart + Telegram regression); reactive form end to end (prefill → correct → empty box → submit → logged + card resolved); Telegram decline with conversational recovery
- Pending post-merge: the proactive run-day flow (heartbeat toggle + a real evening tick)

## Deploy order

The prod hub must run the form contract **before** this reaches the prod agent — a `form` sent to an older hub is a 422. Staging already satisfies this.