### PR TITLE
Context 1b: one owner conversation across channels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ USER.md            (memory dir — durable user profile; agent-writable, no conf
 compact_skill_list (registry — every skill's SKILL.md description; active skills' rule bodies too)
 ```
 
-**Live cross-scope awareness.** Each scope's prompt now includes a live, log-derived view of what the other side did *today*: the user scope receives today's heartbeat-sent notifications (filtered from `notifications.jsonl` by `event="heartbeat"`); the heartbeat scope receives today's user-thread chat (filtered from `chat_history.jsonl` by `thread_id` starting with `telegram_`). Both are read directly by `build_system_prompt` (no tool call), bounded by start-of-Israel-day and a per-entry length cap. This lets the heartbeat skip a task the user already addressed in chat, and lets the chat assistant reference a briefing the tick just sent without calling `get_notification_history`. The daily log is still injected (richer per-day narrative) but is no longer the **sole** awareness bridge.
+**Live cross-scope awareness.** Each scope's prompt now includes a live, log-derived view of what the other side did *today*: the user scope receives today's heartbeat-sent notifications (filtered from `notifications.jsonl` by `event="heartbeat"`); the heartbeat scope receives today's user-thread chat (every non-heartbeat thread in `chat_history.jsonl`). Both are read directly by `build_system_prompt` (no tool call), bounded by start-of-Israel-day and a per-entry length cap. This lets the heartbeat skip a task the user already addressed in chat, and lets the chat assistant reference a briefing the tick just sent without calling `get_notification_history`. The daily log is still injected (richer per-day narrative) but is no longer the **sole** awareness bridge.
 
 `MEMORY.md` is **not** injected — the agent reads it on demand via the memory tools (AGENTS.md instructs it to consult the index). Per-tool schemas are **not** in the prompt — they come from `llm.bind_tools()` with the scoped tool set. A skill's rules (`SKILL.md` body) appear **only when that skill is active**. `AGENTS.md`/`heartbeat.md` change by code deploy only; `SOUL.md` writes trigger a Telegram confirmation (enforced in `write_memory`). `AGENTS.md` is physically outside the `_get_safe_path` sandbox, so memory tools cannot read or write it.
 
@@ -151,7 +151,7 @@ The heartbeat and user agents share SOUL.md/AGENTS.md/USER.md and the same tool 
 
 | Thread ID | Purpose |
 |-----------|---------|
-| `telegram_{user_id}` | Interactive user chat (50-message window) |
+| `owner` | The one owner conversation — all channels stamp it (50-message window) |
 | `heartbeat` | Scheduled background checks (separate window) |
 
 Both threads write to the same `chat_history.jsonl` (tagged by `thread_id`). Cross-thread awareness flows through two paths: today's chat/notification slices are injected directly into each scope's system prompt by `build_system_prompt` (live, per-turn), and the daily log adds a richer per-day narrative (heartbeat-written, lagging).

--- a/agent.py
+++ b/agent.py
@@ -408,13 +408,11 @@ def build_system_prompt(
         f"[Current time: {now.strftime('%A, %Y-%m-%d %H:%M Israel time')}]",
         f"[Active scope: {scope}]",
     ]
-    # Origin channel, derived from the turn's thread-id prefix (the "<name>_<id>"
-    # convention every channel follows). A runtime value — no channel-name literal
-    # in this module — so it stays inform-only and channel-agnostic. Skipped for
-    # heartbeat, whose thread is not a channel.
-    thread_id = turn_context.current_thread_id()
-    if scope == "user" and thread_id:
-        lines.append(f"[Channel: {thread_id.split('_', 1)[0]}]")
+    # Origin channel — a runtime value (no channel-name literal in this module),
+    # inform-only. None on origin-less turns (heartbeat), where the line is skipped.
+    channel = turn_context.current_channel()
+    if scope == "user" and channel:
+        lines.append(f"[Channel: {channel}]")
     envelope = "\n".join(lines)
     parts = [
         envelope,

--- a/docs/architecture/GATEWAY.md
+++ b/docs/architecture/GATEWAY.md
@@ -621,20 +621,25 @@ Jarvis takes option (2). Each channel's factory reads its owner-config env and p
 
 The factory reads the env value and passes it into the channel constructor; nowhere else in the codebase reads it (`main.py` only calls `load_dotenv` — it never sees channel config).
 
-Domain code reaches channels through factory accessors, never through a channel object. **Proactive** sends use `default_outbox()`, which resolves the configured default channel (`JARVIS_DEFAULT_CHANNEL`, default `telegram`) at call time through a name-keyed registry; `default_owner_thread_id()` addresses the owner's thread on that default channel, for origin-less owner-addressed routing. **Reactive** traffic follows its origin channel instead: a resolved confirmation acks on the thread it came from (the store carries its own channel's thread/outbox), and `get_confirmation()` resolves the origin channel's store from the running turn's `CURRENT_THREAD_ID`. `origin_channel()` / `origin_outbox()` apply the same origin rule to what a turn *produces* — a tool-initiated send (e.g. `send_form`) consults the origin channel's capability and sends on its outbox, falling back to the default entry for origin-less turns. The failure modes differ on purpose: `get_confirmation()` **raises** when the resolved channel has no store (a destructive tool with nowhere to confirm is a wiring bug), while `origin_*` **falls back** to the default (an origin-less turn is a normal case). "Which channel does this target" is a routing decision that lives in `factory.py`, not in callers.
+Domain code reaches channels through factory accessors, never through a channel object. **Proactive** sends use `default_outbox()`, which resolves the configured default channel (`JARVIS_DEFAULT_CHANNEL`, default `telegram`) at call time through a name-keyed registry; `default_owner_thread_id()` addresses the owner's thread on that default channel, for origin-less owner-addressed routing. **Reactive** traffic follows its origin channel instead: a resolved confirmation acks on the thread it came from (the store carries its own channel's thread/outbox), and `get_confirmation()` resolves the origin channel's store from the running turn's `CURRENT_CHANNEL` (router-stamped; the thread id names no channel). `origin_channel()` / `origin_outbox()` apply the same origin rule to what a turn *produces* — a tool-initiated send (e.g. `send_form`) consults the origin channel's capability and sends on its outbox, falling back to the default entry for origin-less turns. The failure modes differ on purpose: `get_confirmation()` **raises** when the resolved channel has no store (a destructive tool with nowhere to confirm is a wiring bug), while `origin_*` **falls back** to the default (an origin-less turn is a normal case). "Which channel does this target" is a routing decision that lives in `factory.py`, not in callers.
 
 ---
 
 ## `thread_id` Namespacing
 
-Each channel produces a `thread_id` of the form `<channel>_<external_id>`. This becomes the LangGraph checkpointer key, the `chat_history.jsonl` filter key, and the lookup key for any per-conversation state.
+Two threads exist. `thread_id` is the LangGraph checkpointer key and the `chat_history.jsonl`
+tag — and nothing else: it does **not** name a channel.
 
-| Channel | Format today | Format planned (Phase 2) |
-|---|---|---|
-| Telegram | `telegram_<user_id>` | `telegram:<user_id>` |
-| Heartbeat | `heartbeat` (singleton) | `heartbeat` |
+| Thread | Holds |
+|---|---|
+| `owner` (`gateway/base.py` OWNER_THREAD_ID) | The one owner conversation — every channel stamps it, so a topic continues across surfaces |
+| `heartbeat` (singleton) | Background ticks |
 
-The format change to `:` separator is a Phase 2 concern paired with the `JarvisState` schema migration; it requires rewriting checkpointer keys and JSONL records. Phase 1 keeps the existing format.
+A channel is a surface onto the conversation, not a conversation of its own. The turn's origin
+channel travels separately (`InboundMessage.channel` → `CURRENT_CHANNEL`), which is what
+confirmation/block routing reads. Historic per-channel ids (`telegram_<user_id>`,
+`jarvis-app_<owner>`) survive only as tags on old `chat_history.jsonl` rows and orphaned
+checkpoints.
 
 ---
 

--- a/gateway/base.py
+++ b/gateway/base.py
@@ -13,16 +13,19 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import AsyncIterator, Awaitable, Callable
 
+# The one conversation. Every channel stamps this on the owner's inbound
+# messages and shares the LangGraph thread behind it; a channel is a surface
+# onto the conversation, not a conversation of its own. The turn's origin
+# channel travels separately (InboundMessage.channel -> CURRENT_CHANNEL).
+OWNER_THREAD_ID = "owner"
+
 
 @dataclass
 class InboundMessage:
     """Channel-agnostic message shape delivered by a channel to the app domain.
 
-    `thread_id` is the only field the agent layer uses to namespace per-conversation
-    state (LangGraph checkpointer key + chat_history.jsonl filter). Channels are
-    responsible for producing a stable, channel-prefixed thread_id. The format is
-    deliberately frozen at `telegram_<user_id>` for Phase 1 — the `:` separator
-    change is a Phase 2 concern coupled to the checkpointer-key migration.
+    `thread_id` namespaces per-conversation state (LangGraph checkpointer key +
+    chat_history.jsonl tag). All owner traffic carries OWNER_THREAD_ID.
     """
 
     user_id: int

--- a/gateway/channels/jarvis_app/channel.py
+++ b/gateway/channels/jarvis_app/channel.py
@@ -23,7 +23,7 @@ except ImportError:
     # without Pillow must still import cleanly — metadata just degrades to none.
     Image = None
 
-from gateway.base import Channel
+from gateway.base import Channel, OWNER_THREAD_ID
 from gateway.blocks import Form
 from gateway.channels.jarvis_app.client import HubClient
 
@@ -33,12 +33,6 @@ logger = logging.getLogger(__name__)
 # outbound encoder (AttachmentBlurEncoder): ~24px, JPEG quality 60.
 _BLUR_EDGE = 24
 _BLUR_QUALITY = 60
-
-
-# thread_id mirrors telegram's "<channel>_<id>", parsed on the first underscore.
-# The channel name contains no underscore, so the prefix stays unambiguous.
-def thread_id_for(owner_id: str) -> str:
-    return f"jarvis-app_{owner_id}"
 
 
 # The kinds this channel can represent, mapped to the (filename, mime_type) the
@@ -183,4 +177,4 @@ class JarvisAppChannel(Channel):
 
     @property
     def owner_thread_id(self) -> str:
-        return thread_id_for(self._owner_id)
+        return OWNER_THREAD_ID

--- a/gateway/channels/telegram/channel.py
+++ b/gateway/channels/telegram/channel.py
@@ -12,7 +12,7 @@ import logging
 from telegram import Bot, BotCommand
 from telegram.error import BadRequest
 
-from gateway.base import Channel
+from gateway.base import Channel, OWNER_THREAD_ID
 from gateway.commands import list_commands as _list_slash_commands
 from gateway.channels.telegram.markdown_to_html import convert as md_to_html
 
@@ -31,13 +31,6 @@ def _truncate_markdown(text: str, limit: int) -> str:
     if len(text) <= limit:
         return text
     return text[:limit].rstrip() + _TRUNCATION_TAIL
-
-
-# thread_id format is frozen at telegram_<user_id> for Phase 1. The ":" separator
-# change is a Phase 2 concern coupled to the checkpointer-key migration; changing
-# it here would orphan every existing LangGraph checkpoint and history record.
-def thread_id_for(user_id: int) -> str:
-    return f"telegram_{user_id}"
 
 
 class TelegramChannel(Channel):
@@ -125,7 +118,7 @@ class TelegramChannel(Channel):
 
     @property
     def owner_thread_id(self) -> str:
-        return thread_id_for(self._owner_id)
+        return OWNER_THREAD_ID
 
     # ------------------------------------------------------------------
     # Telegram-specific helpers used by the router / confirmation UI

--- a/gateway/channels/telegram/router.py
+++ b/gateway/channels/telegram/router.py
@@ -12,7 +12,7 @@ import mimetypes
 from telegram import Update
 
 from gateway.base import InboundMessage, OnMessage
-from gateway.channels.telegram.channel import TelegramChannel, thread_id_for as _thread_id
+from gateway.channels.telegram.channel import TelegramChannel
 from gateway.channels.telegram.media_cache import save as _save_media
 
 logger = logging.getLogger(__name__)
@@ -63,7 +63,7 @@ class TelegramInboundRouter:
         await self._dispatch(InboundMessage(
             user_id=user_id,
             chat_id=update.effective_chat.id,
-            thread_id=_thread_id(user_id),
+            thread_id=self._channel.owner_thread_id,
             user_text=msg.text or "",
         ))
 
@@ -82,7 +82,7 @@ class TelegramInboundRouter:
             await self._dispatch(InboundMessage(
                 user_id=user_id,
                 chat_id=update.effective_chat.id,
-                thread_id=_thread_id(user_id),
+                thread_id=self._channel.owner_thread_id,
                 user_text=msg.caption or "[IMAGE attachment]",
                 attachments=[attachment],
             ))
@@ -125,7 +125,7 @@ class TelegramInboundRouter:
         await self._dispatch(InboundMessage(
             user_id=user_id,
             chat_id=update.effective_chat.id,
-            thread_id=_thread_id(user_id),
+            thread_id=self._channel.owner_thread_id,
             user_text=msg.caption or "[VIDEO attachment]",
             attachments=[attachment],
         ))
@@ -144,7 +144,7 @@ class TelegramInboundRouter:
         await self._dispatch(InboundMessage(
             user_id=user_id,
             chat_id=update.effective_chat.id,
-            thread_id=_thread_id(user_id),
+            thread_id=self._channel.owner_thread_id,
             user_text=msg.caption or "[AUDIO attachment]",
             attachments=[attachment],
         ))
@@ -170,7 +170,7 @@ class TelegramInboundRouter:
         await self._dispatch(InboundMessage(
             user_id=user_id,
             chat_id=update.effective_chat.id,
-            thread_id=_thread_id(user_id),
+            thread_id=self._channel.owner_thread_id,
             user_text=msg.caption or f"[{kind.upper()} attachment]",
             attachments=[attachment],
         ))
@@ -207,7 +207,7 @@ class TelegramInboundRouter:
             await self._dispatch(InboundMessage(
                 user_id=payload["user_id"],
                 chat_id=payload["chat_id"],
-                thread_id=_thread_id(payload["user_id"]),
+                thread_id=self._channel.owner_thread_id,
                 user_text=user_text,
                 attachments=attachments,
             ))

--- a/scripts/test_app_blocks.py
+++ b/scripts/test_app_blocks.py
@@ -170,7 +170,7 @@ router, fc, ui = build_router(ok_turn)
 asyncio.run(router._handle(submit_update({"bench_reps": 8, "core": None})))
 check("submit runs a turn with the rendered text",
       turns[0].user_text, "[Submitted form push-day-a3f1] bench_reps: 8 · core: (left empty)")
-check("submit lands on the owner thread", turns[0].thread_id, "jarvis-app_owner")
+check("submit lands on the owner thread", turns[0].thread_id, "owner")
 check("reply sent, then PATCH logged",
       (fc.sent[0]["text"], fc.patches), ("Logged it.", [(412, "logged")]))
 

--- a/turn_context.py
+++ b/turn_context.py
@@ -18,7 +18,7 @@ from contextvars import ContextVar
 # that restrict what background turns may do.
 CURRENT_SCOPE: ContextVar[str | None] = ContextVar("current_scope", default=None)
 
-# The running turn's conversation thread id (e.g. "telegram_42"); None outside a
+# The running turn's conversation thread id (e.g. "owner"); None outside a
 # turn. Lets tool bodies discover which channel a turn originated on without the
 # model declaring it — e.g. a destructive tool's confirmation resolves to the
 # origin channel's handler. Set by ask_jarvis alongside CURRENT_SCOPE.


### PR DESCRIPTION
The spine — second sub-step of #96, targeting the umbrella (#102), reviewable in isolation.

`OWNER_THREAD_ID = "owner"` in gateway/base.py; both channels stamp it (per-channel `thread_id_for` deleted; Telegram router uses `owner_thread_id` at its six sites). Reply routing unchanged; origin routing already rides `CURRENT_CHANNEL` (1a), and a repo grep confirms nothing derives a channel from a thread id anymore. Fresh checkpoint on first message — no migration; old windows orphan harmlessly, chat_history keeps the record. GATEWAY.md/CLAUDE.md thread tables updated.

Product-visible change: one continuous conversation across the app and Telegram; one-time blank window at the deploy restart.

**Felt test after staging restart:** start a topic in the app, continue it on Telegram, and back — plus one confirmation to re-check origin routing on the shared thread.

https://claude.ai/code/session_016QaaJWiYBVPJGoVDicKJ78