### PR TITLE
Mirror heartbeat-sent form cards (closes the last form-antecedent gap)

### DIFF
--- a/scripts/test_app_blocks.py
+++ b/scripts/test_app_blocks.py
@@ -298,6 +298,31 @@ check("timeout returns delivery-unknown directive",
 turn_context.CURRENT_CHANNEL.reset(tok)
 factory._registry["jarvis-app"] = factory._Registered(app_channel, Outbox(app_channel))
 
+# ── heartbeat-scope sends are event-tagged into the notification log ──
+logged = []
+
+
+async def sink(event, text, metadata):
+    logged.append((event, text))
+
+
+fc = FakeClient()
+app_channel = JarvisAppChannel(fc, owner_id="owner")
+factory._registry["jarvis-app"] = factory._Registered(app_channel, Outbox(app_channel, sink))
+factory.set_default_channel("jarvis-app")
+
+scope_tok = turn_context.CURRENT_SCOPE.set("heartbeat")
+out = send_form.func(**ARGS)
+turn_context.CURRENT_SCOPE.reset(scope_tok)
+check("heartbeat form send logged for the mirror",
+      logged, [("heartbeat", "Push day — fill in what you hit.")])
+
+logged.clear()
+tok = turn_context.CURRENT_CHANNEL.set("jarvis-app")
+out = send_form.func(**ARGS)
+turn_context.CURRENT_CHANNEL.reset(tok)
+check("user form send stays unlogged", logged, [])
+
 loop.call_soon_threadsafe(loop.stop)
 
 print()

--- a/tools/core/forms.py
+++ b/tools/core/forms.py
@@ -12,8 +12,10 @@ import logging
 
 from langchain_core.tools import tool
 
+import turn_context
 from gateway import outbox as outbox_mod
 from gateway.blocks import Form, FormRow, NumberField, TextField
+from gateway.outbox import EVENT_HEARTBEAT
 from tools.registry import tool_register
 
 logger = logging.getLogger(__name__)
@@ -134,9 +136,14 @@ def send_form(
             f"Say it conversationally instead. You had prepared: {form.describe()}"
         )
 
+    # A heartbeat-sent card and its submission live on different threads; the
+    # event tag routes the card's text through the pending-mirror drain so the
+    # submission's turn has its antecedent. User-turn sends stay untagged —
+    # send and submit already share the thread.
+    event = EVENT_HEARTBEAT if turn_context.current_scope() == "heartbeat" else None
     try:
         outcome = outbox_mod.submit(
-            origin_outbox().send_block_to_owner(message_text, form)
+            origin_outbox().send_block_to_owner(message_text, form, event=event)
         ).result(timeout=_SEND_TIMEOUT_S)
     except concurrent.futures.TimeoutError:
         # The send is still running on the loop — expiry means unknown, not


### PR DESCRIPTION
A heartbeat tick can already call send_form today (core tool, all scopes; the fitness skill rule encourages it for stat collection) — 6d was prompt-content, never a capability gate. This tags the heartbeat-scope send `EVENT_HEARTBEAT` so the card's text mirrors into the owner thread via phase 1's drain, giving the submission its antecedent. User-scope sends stay untagged (same-thread; mirroring would duplicate).

Three lines + two harness cases (heartbeat send logged; user send not). The same edit was drafted-and-reverted in the form work when the only rail was the flat prompt slice — 1c built the right one (record on #50).

https://claude.ai/code/session_016QaaJWiYBVPJGoVDicKJ78