### PR TITLE
feat(heartbeat): manual pause/resume for tasks

### DIFF
--- a/docs/architecture/HEARTBEAT.md
+++ b/docs/architecture/HEARTBEAT.md
@@ -74,7 +74,7 @@ only input to the gate).
 ## Task grammar
 
 ```
-- **<task-name>** | every <N><unit> [| due: <window>] | notes: `heartbeat/<file>.md`
+- **<task-name>** | every <N><unit> [| due: <window>] [| paused] | notes: `heartbeat/<file>.md`
   <free-form prose instruction — the model's brief, never parsed by code>
 ```
 
@@ -85,6 +85,10 @@ only input to the gate).
   radius; `+-`/`+/-` accepted), each optionally prefixed by weekdays
   (`Tue,Sat 20:30±3h`). Enforced by the gate — if a task reaches the model,
   its window is open.
+- **`paused`** (optional): a bare field switching the task off. Matched only as
+  a whole field between pipes, so a notes path or window containing the word is
+  not the flag. Owner-declared and manual — nothing in the system sets or clears
+  it on its own.
 - **`notes:`/`state:` pointer**: both words accepted; names the task's notes
   file.
 
@@ -99,7 +103,14 @@ only input to the gate).
 
 ## The gate (`heartbeat_state.any_due`)
 
-A task is due when **cadence elapsed AND window open**, where cadence elapsed
+A task is due when **not paused AND cadence elapsed AND window open**. `paused`
+short-circuits first: no cadence maths, no window check, and the task never
+enters `due_names` — so a tick whose only candidates are paused makes no model
+call at all. Pausing does not touch `state.json`, so a task resumed after a long
+pause is immediately cadence-due and runs on the next tick inside its window.
+That is intended: resuming is when you want the check to happen.
+
+Otherwise, cadence elapsed
 means: never stamped, stamp unreadable, cadence unparseable, or
 `now − last_run ≥ cadence` (less `CADENCE_GRACE`). Empty/unreadable
 `HEARTBEAT.md` → `(True, None)`: run the model with the *full* file rather than
@@ -146,8 +157,12 @@ computes that start internally.
 
 Only due task blocks are injected; the preamble is kept and omitted tasks are
 named in a single line so the model knows they exist and are not due
-(`prompts/heartbeat.md` forbids acting on omitted tasks). Cold start / gate
-failure (`due_names=None`) injects the full file.
+(`prompts/heartbeat.md` forbids acting on omitted tasks). Paused tasks are named
+in a *separate* line: "not due yet" invites the model to reason about a next
+run, which is wrong for a task the owner switched off. Cold start / gate failure
+(`due_names=None`) injects the full file, paused tasks included and carrying no
+note — an accepted, bounded cost of the deliberate fail-open: a gate that cannot
+say what is due cannot vouch for what is paused either.
 
 ## The ack (`heartbeat_respond`)
 
@@ -159,12 +174,21 @@ picked up). Missing ack → warning, no stamp, task re-fires — safe.
 
 ## Authoring (`manage_heartbeat_task`)
 
-`create` / `update` / `delete` / `list` in `tools/core/heartbeat.py`, bound in
-both scopes. Validates the mutated file end-to-end before writing it (the
-changed task must round-trip through the same parser the gate uses; all other
-tasks must survive byte-identical), then writes via the memory module's atomic,
-lock-serialized writer. `update` keeps unspecified fields; `due="none"` clears
-a window.
+`create` / `update` / `delete` / `pause` / `resume` / `list` in
+`tools/core/heartbeat.py`, bound in both scopes. Validates the mutated file
+end-to-end before writing it (the changed task must round-trip through the same
+parser the gate uses; all other tasks must survive byte-identical), then writes
+via the memory module's atomic, lock-serialized writer. `update` keeps
+unspecified fields; `due="none"` clears a window.
+
+`pause` / `resume` take only `name` and run through the same keep-everything
+path as `update`, so cadence, window, instruction and a hand-named notes path
+all survive. They are the *only* way to move the flag — `update` has no `paused`
+argument and preserves whatever the task already was, so an unrelated edit can
+never silently switch a task back on. Both are **rejected in heartbeat scope**
+(like `create`): a tick that could pause a task could silence itself, which is
+the automatic behavior the feature exists to avoid. Re-pausing an already-paused
+task is a no-op with a plain message rather than an error.
 
 Changes land immediately — no confirmation step. HEARTBEAT.md is a
 Jarvis-managed file, and validation (not an owner tap) is what protects it: a

--- a/heartbeat_state.py
+++ b/heartbeat_state.py
@@ -56,6 +56,10 @@ _HEADER_RE = re.compile(r"^-\s*\*\*(?P<name>[^*]+?)\*\*(?P<rest>.*)$")
 _CADENCE_RE = re.compile(r"every\s+(?P<n>\d+)\s*(?P<unit>hours?|days?|h|d)\b", re.IGNORECASE)
 # Optional due window field inside the header's "|"-separated segments.
 _DUE_FIELD_RE = re.compile(r"due:\s*(?P<spec>[^|`]+)", re.IGNORECASE)
+# Optional "paused" flag: a bare field of its own between pipes. Anchored to
+# the field boundaries so it cannot be matched out of a word in the notes path
+# or an instruction fragment that shares the line.
+_PAUSED_RE = re.compile(r"(?:^|\|)\s*paused\s*(?=\||$)", re.IGNORECASE)
 # Window spec: "[Day[,Day...] ]HH:MM-HH:MM" or "[Day[,Day...] ]HH:MM±Nh"
 # (± also accepted as "+-" or "+/-" for ASCII-only editing).
 _WINDOW_RE = re.compile(
@@ -136,6 +140,7 @@ class HeartbeatTask:
     raw: str  # the header line as written
     due: str | None = None  # raw due: spec, if present
     window: DueWindow | None = None  # None = no (or unparseable) window → open
+    paused: bool = False  # owner-declared; skipped by the gate without running
 
 
 _parse_cache: tuple[str, float, list[HeartbeatTask]] | None = None  # (path, mtime, tasks)
@@ -233,7 +238,12 @@ def parse_tasks_text(text: str) -> list[HeartbeatTask]:
                 )
         tasks.append(
             HeartbeatTask(
-                name=name, cadence=cadence, raw=line.strip(), due=due_raw, window=window
+                name=name,
+                cadence=cadence,
+                raw=line.strip(),
+                due=due_raw,
+                window=window,
+                paused=bool(_PAUSED_RE.search(rest)),
             )
         )
     return tasks
@@ -249,8 +259,10 @@ def filter_heartbeat_md(text: str, due_names: list[str]) -> str:
     """
     preamble, blocks = split_blocks(text)
     keep = set(due_names)
+    paused = {t.name for t in parse_tasks_text(text) if t.paused}
     kept = [b for name, b in blocks if name in keep]
-    omitted = [name for name, _ in blocks if name not in keep]
+    omitted = [n for n, _ in blocks if n not in keep and n not in paused]
+    omitted_paused = [n for n, _ in blocks if n not in keep and n in paused]
 
     out: list[str] = []
     if preamble:
@@ -262,6 +274,13 @@ def filter_heartbeat_md(text: str, due_names: list[str]) -> str:
             f"({len(omitted)} other task(s) are not due this tick and are "
             f"omitted here: {', '.join(omitted)}. Do not act on them; the "
             f"full list lives in HEARTBEAT.md.)"
+        )
+    # Named apart from merely-not-due ones: "not due yet" invites the model to
+    # plan around a next run, which is wrong for a task switched off entirely.
+    if omitted_paused:
+        out.append(
+            f"({len(omitted_paused)} task(s) paused by the owner, not scheduled "
+            f"until resumed: {', '.join(omitted_paused)}.)"
         )
     return "\n\n".join(p for p in out if p)
 
@@ -323,6 +342,11 @@ def any_due(
 
     due: list[str] = []
     for t in tasks:
+        # Paused wins over everything: no cadence maths, no window check, and
+        # the task never reaches due_names — so a tick with nothing else due
+        # returns without a model call at all.
+        if t.paused:
+            continue
         if t.window is not None and not t.window.is_open(now):
             continue
         cadence_due = False

--- a/prompts/heartbeat.md
+++ b/prompts/heartbeat.md
@@ -2,7 +2,7 @@ This turn is a scheduled background tick (see `[Active scope: heartbeat]` above)
 
 Heartbeat task management:
 - Your recurring task list lives in HEARTBEAT.md. The copy below shows only the tasks that are DUE this tick: code has already checked every task's interval (`every Xh`/`Xd`) and its optional `due:` window (Israel time) against a code-owned last-run stamp before this turn started. Do not redo that scheduling math — do not skip a shown task because it "ran recently", and do not re-fire a task from memory of earlier ticks.
-- A note names the omitted (not-due) tasks. Never act on them and never read their notes files this tick.
+- A note names the omitted (not-due) tasks and any Roi has paused. Never act on them and never read their notes files this tick.
 - Code enforces only the interval and the window. Any condition written in a task's body (e.g. "run on Thursday evening", a `target_date` check) is still yours to honor.
 
 For each task shown, in order:

--- a/tools/core/heartbeat.py
+++ b/tools/core/heartbeat.py
@@ -57,7 +57,8 @@ def _notes_of(header: str) -> str | None:
 
 
 def _build_block(
-    name: str, cadence: str, due: str, instruction: str, notes: str
+    name: str, cadence: str, due: str, instruction: str, notes: str,
+    paused: bool = False,
 ) -> list[str]:
     """A canonical task block: header line + two-space-indented body.
 
@@ -69,6 +70,8 @@ def _build_block(
     fields = [f"- **{name}**", cadence]
     if due:
         fields.append(f"due: {due}")
+    if paused:
+        fields.append("paused")
     fields.append(f"notes: `{notes}`")
     block = [" | ".join(fields)]
     block += [f"  {line}".rstrip() for line in instruction.strip().splitlines()]
@@ -129,12 +132,19 @@ def manage_heartbeat_task(
     due: str = "",
     instruction: str = "",
 ) -> str:
-    """Create, update, delete or list the recurring heartbeat tasks in
-    HEARTBEAT.md. Use this — never write_memory — to change the task list.
+    """Create, update, delete, pause, resume or list the recurring heartbeat
+    tasks in HEARTBEAT.md. Use this — never write_memory — to change the task
+    list.
 
     Use for RECURRING or CONDITIONAL proactive wishes ("check in after my
     workouts", "every Sunday summarize my week"). For a one-shot ping at a
     fixed moment ("remind me at 15:00 to call") use manage_reminder instead.
+
+    Prefer pause over delete when the owner wants a task to stop only for now
+    ("stop the gym reminders while I'm away"): a paused task keeps its
+    cadence, window, instruction and accumulated notes file, and is skipped
+    entirely until resumed. Delete is for tasks that should not come back.
+    Only pause or resume when the owner asks — never on your own initiative.
 
     Changes land immediately. Invalid input (bad cadence, bad due window,
     duplicate/unknown name) is rejected with the reason and the file stays
@@ -143,7 +153,8 @@ def manage_heartbeat_task(
     update keeps the fields you left empty.
 
     Args:
-        action: "create" | "update" | "delete" | "list".
+        action: "create" | "update" | "delete" | "pause" | "resume" | "list".
+            pause/resume take only `name`; every other field is kept as-is.
         name: kebab-case task name, e.g. "post-class-checkin". Required for
             create/update/delete.
         cadence: how often the task should be considered, e.g. "1h", "24h",
@@ -163,11 +174,15 @@ def manage_heartbeat_task(
         for t in tasks:
             cadence_s = "?" if t.cadence is None else str(t.cadence)
             due_s = f" | due: {t.due}" if t.due else ""
-            lines.append(f"- {t.name} | every {cadence_s}{due_s}")
+            paused_s = " | PAUSED" if t.paused else ""
+            lines.append(f"- {t.name} | every {cadence_s}{due_s}{paused_s}")
         return "Current heartbeat tasks:\n" + "\n".join(lines)
 
-    if action not in ("create", "update", "delete"):
-        return f"Error: unknown action '{action}'. Use create, update, delete or list."
+    if action not in ("create", "update", "delete", "pause", "resume"):
+        return (
+            f"Error: unknown action '{action}'. Use create, update, delete, "
+            "pause, resume or list."
+        )
     if not _NAME_RE.match(name.strip()):
         return (
             f"Error: invalid task name {name!r} — use kebab-case "
@@ -178,6 +193,14 @@ def manage_heartbeat_task(
         return (
             "Error: heartbeat ticks may not create new tasks (update/delete/list "
             "only). Propose the new task to Roi in chat instead."
+        )
+    # Pausing is the owner's call, made in conversation. A tick that could
+    # pause a task could silence itself, which is exactly the automatic
+    # behaviour this feature exists to avoid.
+    if action in ("pause", "resume") and turn_context.current_scope() == "heartbeat":
+        return (
+            f"Error: heartbeat ticks may not {action} tasks — only Roi can, in "
+            "chat. Mention it in your tick summary instead."
         )
 
     try:
@@ -214,7 +237,7 @@ def manage_heartbeat_task(
                 )
             new_due = due.strip()
             notes = _default_notes(name)
-        else:  # update
+        else:  # update / pause / resume — every unset field keeps its value
             if name not in existing:
                 return f"Error: no task named '{name}' in HEARTBEAT.md."
             prior = next(
@@ -253,22 +276,41 @@ def manage_heartbeat_task(
                 ).strip()
                 if not instruction:
                     return f"Error: '{name}' has no body to keep — pass an instruction."
+        # create starts unpaused; update preserves whatever the task already
+        # was (an edit must never silently switch it back on); pause/resume
+        # are the only actions that move it.
+        if action == "create":
+            new_paused = False
+        elif action == "update":
+            new_paused = prior.paused
+        else:
+            new_paused = action == "pause"
+        if action in ("pause", "resume") and prior.paused == new_paused:
+            state = "already paused" if new_paused else "not paused"
+            return f"Heartbeat task '{name}' is {state} — nothing changed."
+
         if new_due and heartbeat_state.parse_window(new_due) is None:
             return (
                 f"Error: unparseable due window {new_due!r}. Use forms like "
                 "'06:00-22:00', 'Tue,Sat 20:30±3h', '09:00±2h' (or 'none' to clear)."
             )
 
-        new_block = _build_block(name, norm_cadence, new_due, instruction, notes)
+        new_block = _build_block(
+            name, norm_cadence, new_due, instruction, notes, paused=new_paused
+        )
         if action == "create":
             new_blocks = blocks + [(name, new_block)]
         else:
             new_blocks = [(n, b if n != name else new_block) for n, b in blocks]
         new_text = _render(preamble, new_blocks)
+        verb = {
+            "create": "created",
+            "update": "updated",
+            "pause": "paused — it will be skipped entirely until resumed",
+            "resume": "resumed — it is due again from the next tick",
+        }[action]
         ok_text = (
-            f"Heartbeat task '{name}' "
-            f"{'created' if action == 'create' else 'updated'}:\n\n"
-            + "\n".join(new_block)
+            f"Heartbeat task '{name}' {verb}:\n\n" + "\n".join(new_block)
         )
 
     # Validate the full candidate exactly as the gate will read it: the
@@ -280,7 +322,12 @@ def manage_heartbeat_task(
     else:
         expected_names = existing | {name}
         t = parsed.get(name)
-        if t is None or t.cadence is None or (new_due and t.window is None):
+        if (
+            t is None
+            or t.cadence is None
+            or (new_due and t.window is None)
+            or t.paused != new_paused
+        ):
             return (
                 "Error: internal validation failed — the resulting task would not "
                 "parse cleanly. HEARTBEAT.md was not modified."


### PR DESCRIPTION
Lets a heartbeat task be switched off without deleting it — the task keeps its cadence, window, instruction and accumulated notes file, and is skipped entirely until resumed.

Motivated by home-anchored proactive work (the CrossFit cluster: `crossfit-sync-and-remind`, `weekly-fitness-scouting`, `weekly-attendance-sync`) being pure noise whenever the owner is away from the gym for a stretch. Today the only options are living with it or hand-editing HEARTBEAT.md, since delete-and-recreate loses the instruction body and risks the notes path.

Deliberately independent of any timezone/travel work (#109 stays file-and-wait).

## Shape

A bare `paused` field in the task header:

```
- **crossfit-sync-and-remind** | every 1h | due: 08:00-22:00 | paused | notes: `heartbeat/crossfit_check.md`
```

Stored in the task definition rather than a separate state file, so it is visible wherever the task list already is, stays hand-editable, and needs no second source of truth. `jarvis_data/heartbeat/state.json` keeps meaning "when did this last run" and is untouched.

## Behaviour

- **Gate** — `paused` short-circuits first in `any_due`: no cadence maths, no window check, never enters `due_names`. A tick whose only candidates are paused makes **no model call at all**.
- **Tool** — `pause`/`resume` are two more values on `manage_heartbeat_task`'s existing `action` argument, not a new tool, so the always-on schema cost is one docstring line. They take only `name` and route through the update path's keep-everything logic, so cadence, window, instruction and hand-named notes paths all survive.
- **`update` preserves the flag** rather than clearing it — an unrelated edit can never silently switch a task back on. The two dedicated actions are the only way to move it.
- **Refused in heartbeat scope**, mirroring the existing `create` guard: a tick that could pause a task could silence itself, which is exactly the automatic behaviour this avoids. Pausing is the owner's call, made in conversation.
- **Resume runs immediately.** Pausing does not touch `state.json`, so a task resumed after a long pause is at once cadence-due. Intended — resuming is when you want the check to happen. Documented so it does not read as a bug.
- Re-pausing an already-paused task is a no-op with a plain message, not an error.
- Paused tasks are named in a *separate* line from merely-not-due ones in the injected prompt: "not due yet" would invite the model to reason about a next run, which is wrong for a task switched off.

## Verification

Exercised end-to-end offline against the real task names: pausing `crossfit-sync-and-remind` drops it from the due list while keeping its `08:00-22:00` window and its hand-named `crossfit_check.md` path; `list` shows `PAUSED`; resume brings it straight back. Also covered: the flag not false-matching a notes path containing the word "paused", multi-line instructions surviving a rebuild, `update` not unpausing, and all-paused returning `(False, [])`.

All three CI guards (`check_paths`, `check_channel_agnostic`, `check_command_replies`) and `scripts/test_context_mirror.py` pass. (`scripts/test_app_blocks.py` fails identically on `main` — pre-existing, unrelated.)

**Not yet verified live** — that needs a service restart. After deploy: ask Jarvis to pause the crossfit reminders, confirm the marker lands in HEARTBEAT.md, then watch a tick in `journalctl` to see it absent from the due list.

## Known limitation

On the fail-open path (unreadable HEARTBEAT.md or a gate exception, `due_names=None`) the full file is injected with paused tasks included and no note. Accepted rather than papered over with prompt text: a gate that cannot say what is due cannot vouch for what is paused either. Documented in `docs/architecture/HEARTBEAT.md`.

https://claude.ai/code/session_01EQRwHdPMo5KMoqaNW5qG6d
