### PR TITLE
feat(timezone): explicit /tz away mode for travel

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -7,7 +7,7 @@ import sqlite3
 import time
 import traceback as _tb
 from uuid import uuid4
-from timeutils import ISRAEL_TZ as _ISRAEL_TZ
+from timeutils import ISRAEL_TZ as _ISRAEL_TZ, owner_tz, owner_tz_name
 from typing import Annotated, Required, NotRequired
 from dotenv import load_dotenv
 from langchain_core.messages import HumanMessage, SystemMessage, ToolMessage
@@ -365,6 +365,15 @@ def build_system_prompt(
         f"[Current time: {now.strftime('%A, %Y-%m-%d %H:%M Israel time')}]",
         f"[Active scope: {scope}]",
     ]
+    # Away mode (/tz): a second clock so the model converts times the owner
+    # speaks. Home has no file and no line — the prompt is byte-identical.
+    away = owner_tz_name()
+    if away:
+        local = now.astimezone(owner_tz())
+        lines.insert(1, (
+            f"[Owner local time: {local.strftime('%A, %Y-%m-%d %H:%M')} ({away}) "
+            "— times the owner speaks are local to them]"
+        ))
     # Origin channel — a runtime value (no channel-name literal in this module),
     # inform-only. None on origin-less turns (heartbeat), where the line is skipped.
     channel = turn_context.current_channel()

--- a/gateway/commands/handlers.py
+++ b/gateway/commands/handlers.py
@@ -374,3 +374,47 @@ async def _usage(inbound: InboundMessage, args: list[str]) -> str:
         group_by=group_by, scope_filter=scope_filter,
     )
     return format_usage_table(rows, title=title)
+
+
+@command("tz", "Show or set the owner's current timezone (travel mode)")
+async def _tz(inbound: InboundMessage, args: list[str]) -> str:
+    """The explicit away-mode switch. No args shows the current mode; an IANA
+    name (`/tz Asia/Tokyo`) marks the owner away; `/tz home` returns. The state
+    is code-owned (jarvis_data/agent/owner_tz.json): the model sees it in its
+    prompt envelope but has no tool to change it."""
+    import datetime as dt
+
+    import timeutils
+
+    if not args:
+        away = timeutils.owner_tz_name()
+        pairs: list[tuple[str, str]] = [("Mode", f"away — {away}" if away else "home")]
+        if away:
+            pairs.append((
+                "Owner local time",
+                dt.datetime.now(timeutils.owner_tz()).strftime("%Y-%m-%d %H:%M"),
+            ))
+        pairs.append((
+            "Israel time",
+            dt.datetime.now(timeutils.ISRAEL_TZ).strftime("%Y-%m-%d %H:%M"),
+        ))
+        pairs.append(("Usage", "`/tz Asia/Tokyo` to go away, `/tz home` to return"))
+        return kv_section("Timezone", pairs)
+
+    name = args[0]
+    if name.lower() == "home":
+        timeutils.clear_owner_tz()
+        return "Away mode off — back on home time (Israel)."
+    try:
+        await asyncio.to_thread(timeutils.set_owner_tz, name)
+    except Exception:
+        return (
+            f"Unknown timezone '{name}'. Use an IANA name like `Europe/Lisbon` "
+            "or `Asia/Tokyo`, or `/tz home` to return."
+        )
+    local = dt.datetime.now(timeutils.owner_tz())
+    israel = dt.datetime.now(timeutils.ISRAEL_TZ)
+    return (
+        f"Away mode on — {name}. Owner local time {local.strftime('%Y-%m-%d %H:%M')}, "
+        f"Israel {israel.strftime('%H:%M')}."
+    )

--- a/scripts/ci/check_command_replies.py
+++ b/scripts/ci/check_command_replies.py
@@ -50,6 +50,9 @@ CASES: list[tuple[str, str]] = [
     ("/usage week", "strict"),
     ("/usage today heartbeat", "strict"),
     ("/usage 32.13", "strict"),    # invalid date → usage help
+    ("/tz", "strict"),
+    ("/tz home", "strict"),
+    ("/tz Nowhere/Nope", "strict"),  # invalid zone → usage help
     ("/nope", "strict"),           # router's unknown-command reply
 ]
 

--- a/timeutils.py
+++ b/timeutils.py
@@ -1,7 +1,9 @@
 """Shared Israel-time helpers — the single home of the local timezone."""
 
+import json
+import os
 from datetime import datetime, timedelta
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 ISRAEL_TZ = ZoneInfo("Asia/Jerusalem")
 
@@ -16,3 +18,64 @@ def israel_week_bounds(anchor: datetime | None = None) -> tuple[str, str]:
     local = (anchor or now_israel()).astimezone(ISRAEL_TZ)
     start = local - timedelta(days=(local.weekday() + 1) % 7)
     return start.strftime("%Y-%m-%d"), (start + timedelta(days=6)).strftime("%Y-%m-%d")
+
+
+# --- Owner-location awareness (travel mode) --------------------------------
+#
+# The owner's current timezone is code-owned state in DATA_DIR/agent/, set only
+# by the /tz slash command — never by the model. File absent = owner is home,
+# and every consumer takes exactly the same code path it always did; the file
+# existing is the single switch that changes anything.
+
+_OWNER_TZ_PATH = None  # resolved lazily so importing timeutils never needs config
+
+
+def _owner_tz_path() -> str:
+    global _OWNER_TZ_PATH
+    if _OWNER_TZ_PATH is None:
+        import config
+        _OWNER_TZ_PATH = os.path.join(config.DATA_DIR, "agent", "owner_tz.json")
+    return _OWNER_TZ_PATH
+
+
+def owner_tz_name() -> str | None:
+    """The IANA name of the owner's away timezone, or None when home.
+
+    Any unreadable/invalid file reads as home: failing toward Israel keeps the
+    home behavior the default rather than an error state.
+    """
+    try:
+        with open(_owner_tz_path(), encoding="utf-8") as f:
+            name = json.load(f).get("timezone")
+        if not isinstance(name, str):
+            return None
+        ZoneInfo(name)
+        return name
+    except (OSError, ValueError, KeyError, ZoneInfoNotFoundError):
+        return None
+
+
+def owner_tz() -> ZoneInfo:
+    """The owner's current timezone — ISRAEL_TZ unless /tz set an away zone."""
+    name = owner_tz_name()
+    return ZoneInfo(name) if name else ISRAEL_TZ
+
+
+def set_owner_tz(name: str) -> None:
+    """Record the owner's away timezone. Raises ZoneInfoNotFoundError (or
+    ValueError) on a name the tz database doesn't know."""
+    ZoneInfo(name)  # validate before touching disk
+    path = _owner_tz_path()
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump({"timezone": name}, f)
+    os.replace(tmp, path)
+
+
+def clear_owner_tz() -> None:
+    """Back to home: remove the away file (idempotent)."""
+    try:
+        os.remove(_owner_tz_path())
+    except FileNotFoundError:
+        pass

--- a/tools/core/scheduling.py
+++ b/tools/core/scheduling.py
@@ -5,7 +5,7 @@ import tempfile
 import threading
 import uuid
 from datetime import datetime, timezone
-from timeutils import ISRAEL_TZ
+from timeutils import ISRAEL_TZ, owner_tz
 
 from langchain_core.tools import tool
 
@@ -64,6 +64,16 @@ def _remove_event(event_id: str) -> None:
         _save_events(data)
 
 
+def _owner_local_note(fire_at_dt: datetime) -> str:
+    """Away-mode suffix (/tz): the same instant on the owner's own clock, so a
+    wrong model conversion is visible without mental math. Empty at home, so
+    every rendering stays byte-identical there."""
+    tz = owner_tz()
+    if tz is ISRAEL_TZ:
+        return ""
+    return f" ({fire_at_dt.astimezone(tz).strftime('%Y-%m-%d %H:%M')} {tz.key})"
+
+
 # ---------------------------------------------------------------------------
 # LangChain tools
 # ---------------------------------------------------------------------------
@@ -102,6 +112,9 @@ def manage_reminder(
             fire_at_dt = datetime.fromisoformat(fire_at.replace("Z", "+00:00"))
         except ValueError as e:
             return f"Error: invalid fire_at — {e}. Use ISO 8601 UTC, e.g. '2026-05-08T09:00:00Z'."
+        if fire_at_dt.tzinfo is None:
+            return ("Error: fire_at has no timezone offset, so the instant is ambiguous. "
+                    "Use ISO 8601 UTC, e.g. '2026-05-08T09:00:00Z'.")
         if fire_at_dt <= datetime.now(timezone.utc):
             return "Error: fire_at must be in the future."
 
@@ -125,7 +138,8 @@ def manage_reminder(
         now_israel = datetime.now(ISRAEL_TZ)
         fire_israel = fire_at_dt.astimezone(ISRAEL_TZ)
         return (
-            f"Reminder [{event_id}] scheduled for {fire_israel.strftime('%Y-%m-%d %H:%M Israel time')}: \"{text}\". "
+            f"Reminder [{event_id}] scheduled for {fire_israel.strftime('%Y-%m-%d %H:%M Israel time')}"
+            f"{_owner_local_note(fire_at_dt)}: \"{text}\". "
             f"(Current time is {now_israel.strftime('%Y-%m-%d %H:%M Israel time')}. Do not call manage_reminder again for this request.)"
         )
 
@@ -142,7 +156,7 @@ def manage_reminder(
             delta = fire_dt - now
             total_secs = delta.total_seconds()
             due_str = f"in {int(total_secs // 3600)}h {int((total_secs % 3600) // 60)}m" if total_secs > 0 else "overdue"
-            lines.append(f"[{e['id']}] {fire_israel.strftime('%Y-%m-%d %H:%M Israel time')} ({due_str}): \"{e['text']}\"")
+            lines.append(f"[{e['id']}] {fire_israel.strftime('%Y-%m-%d %H:%M Israel time')}{_owner_local_note(fire_dt)} ({due_str}): \"{e['text']}\"")
         return "\n".join(lines)
 
     elif action == "delete":

--- a/tools/travel/itinerary.py
+++ b/tools/travel/itinerary.py
@@ -862,6 +862,16 @@ def _reschedule(
     # before its start — the two ways in must agree or an item means something
     # different depending on how it was made.
     elif st and et and et < st and not finish:
+        # Same cross-zone refusal as schedule: across timezones an end earlier
+        # than its start is not a midnight signal (Tokyo 17:00 to LA 10:00 is
+        # same-day), so the date is asked for, never inferred.
+        dep_tz, arr_tz = entry["departure_timezone"], entry["arrival_timezone"]
+        if dep_tz and arr_tz and dep_tz != arr_tz:
+            raise TravelError(
+                f"This crosses timezones ({dep_tz} to {arr_tz}), so the arrival date "
+                "cannot be guessed from the clock — an arrival earlier than its "
+                "departure may be the same day or two days later. Pass end_date."
+            )
         finish = (date.fromisoformat(start) + timedelta(days=1)).isoformat()
         sets.append("end_date = ?"); args.append(finish)
         said.append(f"ending the next day ({finish})")


### PR DESCRIPTION
## What

The owner is about to travel, and every "local time" in the system is hardwired to Israel — the model's only clock is the prompt envelope, so "remind me at 21:00" said in Tokyo schedules 21:00 Israel (03:00 local), morning phrasing anchors to the wrong wall clock, and near local midnight the model serves the wrong day. This ships the minimal explicit away-mode from the audit of issue #109, plus one travel-skill bug fix:

- **`/tz` slash command** — `/tz Asia/Tokyo` marks the owner away, `/tz home` returns, bare `/tz` shows both clocks. State is code-owned (`jarvis_data/agent/owner_tz.json`); the model has no tool to set it; any unreadable/invalid file fails toward home.
- **`timeutils.owner_tz()` / `owner_tz_name()`** — the seam. File absent → `owner_tz()` *is* `ISRAEL_TZ` and every consumer takes the exact home code path.
- **One away-only envelope line** — `[Owner local time: Saturday, 2026-08-29 19:03 (Asia/Tokyo) — times the owner speaks are local to them]`, both scopes. At home the prompt is byte-identical.
- **Reminder dual echo** — create/list append the owner-local rendering while away (`13:35 Israel time (18:35 Asia/Taipei)`) so a wrong model conversion is visible without mental math. Also: a naive `fire_at` now gets the friendly format error instead of an uncaught `TypeError`.
- **`_reschedule` cross-zone guard** (second commit) — ports `schedule`'s refusal to infer a next-day arrival across timezones; re-timing a cross-zone flight previously moved it a day out silently.

## Deliberately unchanged

Heartbeat `due:` windows (pause is the trip lever — re-windowing trips the elapsed-time gate on revert), fitness/Arbox (the gym is in Israel), daily-log/chat-slice/mirror day boundaries (internal consistency with Israel-dated files), all storage/firing mechanics (already aware-UTC and travel-proof).

## Verification

- All three CI guards pass locally; three `/tz` cases added to `check_command_replies.py`.
- Scratch-root proof that the home prompt is byte-identical after a `/tz` round-trip.
- `_reschedule`: cross-zone refusal, same-zone rollover, and explicit-`end_date` acceptance tested against a real travel DB.
- **Live on staging**: away-mode set to Asia/Taipei, "set a reminder for 18:30" scheduled from local wall-clock speech and fired at the exact instant (10:30 UTC); dual echo rendered; `/tz home` left no state behind; zero errors in the service log.

https://claude.ai/code/session_01EQRwHdPMo5KMoqaNW5qG6d