### PR TITLE
fix(timezone): audit follow-ups — history day boundary, health owner-anchoring, CI anchor guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ name: CI
 #   - channel-agnostic  — the app stays channel-agnostic (check_channel_agnostic.py)
 #   - command-replies   — slash-command replies survive both renderers
 #                         (check_command_replies.py)
+#   - timezone-anchors  — every timezone consumer declares its clock
+#                         (check_timezone_anchors.py)
 # Make each a hard gate with a branch-protection rule on `main` (GitHub → Settings →
 # Branches) requiring its check to pass. (The pre-commit hook is the fast local half
 # and runs the first two — command-replies boots the app, too slow for a hook; see
@@ -56,3 +58,14 @@ jobs:
         # Runs every registered command against a seeded scratch JARVIS_ROOT (same
         # dummy-secret trick as check_paths) and validates the reply markdown.
         run: python scripts/ci/check_command_replies.py
+
+  timezone-anchors:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Timezone-anchoring check
+        # Pure static source scan — no app import and no deps, so no pip install.
+        run: python scripts/ci/check_timezone_anchors.py

--- a/pending_mirrors.py
+++ b/pending_mirrors.py
@@ -5,15 +5,16 @@ cursor file holds the last mirrored row's timestamp. The next user turn on the
 owner thread drains rows past the cursor as ONE user-role block (the reducer
 drops leading assistant-role messages, and one message keeps the Gemini wire
 alternating), and the cursor advances only after that turn completes — a
-failed turn re-delivers, never loses. Rows older than start-of-today never
-drain, which bounds the first run and any backlog.
+failed turn re-delivers, never loses. Rows older than 24 hours never drain,
+which bounds the first run and any backlog. A rolling window, not a calendar
+day: a day boundary in any fixed zone lands mid-evening somewhere the owner
+travels, silently dropping a send between its delivery and the owner's reply.
 """
 
 import datetime as _dt
 import json
 import logging
 import os
-from timeutils import ISRAEL_TZ as _ISRAEL_TZ
 
 import config
 
@@ -35,11 +36,6 @@ MAX_ENTRIES = 20
 ENTRY_CAP = 2000
 
 
-def _today_start_utc() -> _dt.datetime:
-    now = _dt.datetime.now(_dt.timezone.utc).astimezone(_ISRAEL_TZ)
-    return now.replace(hour=0, minute=0, second=0, microsecond=0).astimezone(_dt.timezone.utc)
-
-
 def drain_pending() -> tuple[str | None, str | None]:
     """(user-role block, cursor value to stamp after the turn) or (None, None).
 
@@ -53,7 +49,7 @@ def drain_pending() -> tuple[str | None, str | None]:
             cursor = json.load(f).get("last_ts", "")
     except (OSError, ValueError):
         cursor = ""
-    since = _today_start_utc()
+    since = _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(hours=24)
     entries: list[str] = []
     last_ts: str | None = None
     try:

--- a/scripts/ci/check_timezone_anchors.py
+++ b/scripts/ci/check_timezone_anchors.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""CI guard: every timezone consumer declares which clock it follows.
+
+Since /tz (PR #112) the system has two clocks: ISRAEL_TZ (home) and
+owner_tz() (the owner's current zone — identical to home unless the owner
+set an away zone). A module picks between them by one rule:
+
+    A surface follows owner_tz() only when its underlying data source
+    physically travels with the owner (the watch). Everything anchored to a
+    fixed place or to Israel-dated files stays ISRAEL_TZ.
+
+Timezone mistakes are invisible at home and only fire abroad, so no home
+test catches a wrong pick — review time is the only feedback loop. This
+guard makes the pick explicit, the same way check_command_replies.py makes
+reply layout explicit: a module that starts importing timeutils fails CI
+until it appears in ANCHORS below with a declared anchoring. The guard
+forces the question, not the answer — it cannot know the gym is in Israel.
+
+Two layers:
+  1. Seam integrity — outside timeutils.py, nothing constructs
+     ZoneInfo("Asia/Jerusalem") or opens owner_tz.json directly (quoted
+     literal); every consumer goes through the timeutils seam.
+  2. Declared anchoring — every module importing timeutils appears in
+     ANCHORS as "home", "owner", or "both"; stale entries fail too, so the
+     roster cannot rot.
+
+Scope is app code: venv, caches, and scripts/ (dev tooling and these guards,
+which seed Israel-dated fixtures) are excluded.
+
+Run:  python3 scripts/ci/check_timezone_anchors.py    (exit 0 = clean, 1 = defect)
+"""
+import os
+import re
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# path -> (anchoring, reason). "home" = ISRAEL_TZ only; "owner" = owner_tz()
+# only; "both" = deliberately renders/uses both clocks.
+ANCHORS: dict[str, tuple[str, str]] = {
+    "agent.py": ("both", "Israel prompt envelope + away-only owner-local line"),
+    "gateway/apps/fitness.py": ("home", "Arbox gym is physically in Israel"),
+    "gateway/commands/handlers.py": ("both", "/tz shows both clocks; /logs and /usage cut Israel days"),
+    "heartbeat.py": ("home", "daily-log naming and late-fire annotation are Israel by design"),
+    "heartbeat_state.py": ("home", "due: windows are defined in Israel time"),
+    "observability/usage.py": ("home", "usage buckets report the server's own Israel-dated activity"),
+    "pending_mirrors.py": ("home", "never-drain cutoff is the Israel day boundary"),
+    "tools/core/history.py": ("home", "since= day boundary matches the Israel-dated logs it slices"),
+    "tools/core/scheduling.py": ("both", "Israel rendering + away-mode owner-local echo"),
+    "tools/fitness/_db.py": ("home", "workout dates are Israel-local strings; the gym is in Israel"),
+    "tools/fitness/plans.py": ("home", "Sunday-anchored Israel week quotas"),
+    "tools/fitness/reports.py": ("home", "reports over Israel-dated fitness rows"),
+    "tools/google_health/google_health_tools.py": ("owner", "the watch travels with the owner"),
+}
+
+_VALID = {"home", "owner", "both"}
+SEAM = "timeutils.py"
+_SKIP_DIRS = {"venv", "__pycache__", ".git", "node_modules", "media_cache"}
+_SKIP_TOP = {"scripts"}
+
+_IMPORT_RE = re.compile(r"^\s*(?:from\s+timeutils\s+import|import\s+timeutils)\b", re.M)
+_HARDCODED_ZONE_RE = re.compile(r"ZoneInfo\(\s*[\"']Asia/Jerusalem[\"']")
+_OWNER_FILE_RE = re.compile(r"[\"']owner_tz\.json[\"']")
+
+
+def _py_files() -> list[str]:
+    out = []
+    for dirpath, dirnames, filenames in os.walk(REPO_ROOT):
+        dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS]
+        rel_dir = os.path.relpath(dirpath, REPO_ROOT)
+        if rel_dir != "." and rel_dir.split(os.sep)[0] in _SKIP_TOP:
+            dirnames[:] = []
+            continue
+        for name in filenames:
+            if name.endswith(".py"):
+                out.append(os.path.relpath(os.path.join(dirpath, name), REPO_ROOT))
+    return sorted(out)
+
+
+def main() -> int:
+    failures: list[str] = []
+    for path, (anchoring, _) in ANCHORS.items():
+        if anchoring not in _VALID:
+            failures.append(f"ANCHORS[{path!r}]: invalid anchoring {anchoring!r}")
+
+    importers: set[str] = set()
+    for rel in _py_files():
+        with open(os.path.join(REPO_ROOT, rel), encoding="utf-8") as f:
+            src = f.read()
+        if rel != SEAM:
+            for line_no, line in enumerate(src.splitlines(), 1):
+                if _HARDCODED_ZONE_RE.search(line):
+                    failures.append(
+                        f"{rel}:{line_no}: constructs ZoneInfo('Asia/Jerusalem') directly — "
+                        f"import ISRAEL_TZ (or owner_tz) from timeutils instead"
+                    )
+                if _OWNER_FILE_RE.search(line):
+                    failures.append(
+                        f"{rel}:{line_no}: touches owner_tz.json directly — only timeutils "
+                        f"owns that file; use owner_tz()/set_owner_tz()/clear_owner_tz()"
+                    )
+        if rel != SEAM and _IMPORT_RE.search(src):
+            importers.add(rel)
+
+    for rel in sorted(importers - set(ANCHORS)):
+        failures.append(
+            f"{rel}: imports timeutils but has no ANCHORS entry in "
+            f"scripts/ci/check_timezone_anchors.py — declare 'home', 'owner', or 'both'. "
+            f"Rule: follow owner_tz() only if the data source physically travels with "
+            f"the owner; fixed-place and Israel-dated surfaces stay ISRAEL_TZ."
+        )
+    for rel in sorted(set(ANCHORS) - importers):
+        failures.append(
+            f"ANCHORS lists {rel} but it no longer imports timeutils — remove the stale entry"
+        )
+
+    if failures:
+        print("FAIL: timezone anchoring contract violated:")
+        for f in failures:
+            print("   ", f)
+        return 1
+    print(f"OK: {len(importers)} timezone consumers declared, seam intact (timeutils only)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/check_timezone_anchors.py
+++ b/scripts/ci/check_timezone_anchors.py
@@ -44,7 +44,6 @@ ANCHORS: dict[str, tuple[str, str]] = {
     "heartbeat.py": ("home", "daily-log naming and late-fire annotation are Israel by design"),
     "heartbeat_state.py": ("home", "due: windows are defined in Israel time"),
     "observability/usage.py": ("home", "usage buckets report the server's own Israel-dated activity"),
-    "pending_mirrors.py": ("home", "never-drain cutoff is the Israel day boundary"),
     "tools/core/history.py": ("home", "since= day boundary matches the Israel-dated logs it slices"),
     "tools/core/scheduling.py": ("both", "Israel rendering + away-mode owner-local echo"),
     "tools/fitness/_db.py": ("home", "workout dates are Israel-local strings; the gym is in Israel"),

--- a/tools/core/history.py
+++ b/tools/core/history.py
@@ -3,7 +3,9 @@ import json
 import os
 import tempfile
 import threading
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
+
+from timeutils import ISRAEL_TZ
 from langchain_core.tools import tool
 
 import config
@@ -165,20 +167,30 @@ def get_chat_history(limit: int = 20, since: str | None = None) -> str:
 
     Args:
         limit: max number of entries to return.
-        since: optional ISO 8601 timestamp, offset required. Days are Israel
-               time: '2026-05-08T00:00:00+03:00', not '...Z' (starts at 03:00).
+        since: optional. A plain date '2026-05-08' means the start of that day,
+               Israel time — the day boundary is computed for you. A full
+               ISO 8601 timestamp with a UTC offset makes a precise cut instead.
     """
     if since is not None:
         # Time-filtered path: read all entries and filter, then take last `limit`.
         try:
-            since_dt = datetime.fromisoformat(since.replace("Z", "+00:00"))
+            # Date-only form: the Israel day boundary is computed here, not by
+            # the caller — a fixed offset in the contract was wrong every
+            # winter (+03:00 is summer-only; IST is +02:00).
+            day = date.fromisoformat(since)
+            since_dt = datetime(day.year, day.month, day.day, tzinfo=ISRAEL_TZ)
         except ValueError:
-            return f"Invalid 'since' timestamp: {since!r}. Use ISO 8601 with an offset, e.g. '2026-05-08T00:00:00+03:00'."
-        if since_dt.tzinfo is None:
-            # Log entries are offset-aware; comparing them against a naive
-            # bound raises TypeError mid-scan. Reject with the offset spelled
-            # out rather than guessing which day boundary was meant.
-            return f"Ambiguous 'since' timestamp: {since!r} has no UTC offset. Use e.g. '{since}+03:00' for Israel time."
+            try:
+                since_dt = datetime.fromisoformat(since.replace("Z", "+00:00"))
+            except ValueError:
+                return (f"Invalid 'since': {since!r}. Use 'YYYY-MM-DD' for the start "
+                        "of an Israel day, or a full ISO 8601 timestamp with an offset.")
+            if since_dt.tzinfo is None:
+                # Log entries are offset-aware; comparing them against a naive
+                # bound raises TypeError mid-scan. Reject rather than guess
+                # which day boundary was meant.
+                return (f"Ambiguous 'since': {since!r} has no UTC offset. Pass a plain "
+                        "'YYYY-MM-DD' for an Israel day, or include an offset.")
         if not os.path.exists(CHAT_LOG):
             return "No chat history found."
         records = []

--- a/tools/google_health/google_health_tools.py
+++ b/tools/google_health/google_health_tools.py
@@ -30,7 +30,7 @@ from tools.google_health._auth import get_access_token, GoogleHealthNotConfigure
 
 BASE = "https://health.googleapis.com/v4"
 USER = "users/me"
-from timeutils import ISRAEL_TZ
+from timeutils import owner_tz, owner_tz_name
 
 _UTC = ZoneInfo("UTC")
 
@@ -62,16 +62,26 @@ def _list(data_type: str, filter_expr: str, page_size: int = 50) -> list[dict]:
 
 
 def _since_local(days: int) -> datetime:
-    """Local (Asia/Jerusalem) midnight `days-1` days ago; days=1 → today 00:00."""
+    """Owner-local midnight `days-1` days ago (Israel unless /tz set an away
+    zone); days=1 → today 00:00. The watch travels with the owner, so its
+    data's day boundaries follow the owner — the one surface that must NOT
+    stay home-anchored."""
     days = max(1, int(days))
-    return datetime.now(ISRAEL_TZ).replace(
+    return datetime.now(owner_tz()).replace(
         hour=0, minute=0, second=0, microsecond=0
     ) - timedelta(days=days - 1)
 
 
 def _local(ts: str) -> datetime:
-    """Parse an API RFC-3339 timestamp to Asia/Jerusalem local time."""
-    return datetime.fromisoformat(ts.replace("Z", "+00:00")).astimezone(ISRAEL_TZ)
+    """Parse an API RFC-3339 timestamp to the owner's local time."""
+    return datetime.fromisoformat(ts.replace("Z", "+00:00")).astimezone(owner_tz())
+
+
+def _zone_note() -> str:
+    """' (times in <zone>)' while the owner is away; empty at home, so home
+    output stays byte-identical."""
+    name = owner_tz_name()
+    return f" (times in {name})" if name else ""
 
 
 def _hm(td: timedelta) -> str:
@@ -142,7 +152,7 @@ def check_sleep(nights: int = 1) -> str:
             + (f" — {breakdown}" if breakdown else "")
             + (f". {'; '.join(extras)}." if extras else "")
         )
-    return "Sleep:\n" + "\n".join(lines)
+    return "Sleep" + _zone_note() + ":\n" + "\n".join(lines)
 
 
 def _pace(sec_per_m: float) -> str:
@@ -219,14 +229,15 @@ def _format_workout(p: dict) -> str:
 @tool
 def check_workouts(since_date: str = "", until_date: str = "") -> str:
     """Logged Pixel Watch workout/exercise sessions in a date range
-    (Asia/Jerusalem). `since_date`/`until_date` are inclusive YYYY-MM-DD;
+    (owner-local dates — Israel unless traveling). `since_date`/`until_date`
+    are inclusive YYYY-MM-DD;
     `since_date=""` defaults to today, `until_date=""` means no upper bound.
     For a single day, pass `since_date == until_date`. Reports per session:
     name, time, duration, distance/pace/steps/elevation when available,
     calories, avg HR, HR-zone minutes, and per-km splits for GPS sessions.
     Manually-logged sessions are tagged `(manual)` — their kcal/HR are
     MET-estimated, not measured."""
-    today = datetime.now(ISRAEL_TZ).strftime("%Y-%m-%d")
+    today = datetime.now(owner_tz()).strftime("%Y-%m-%d")
     if since_date:
         try:
             datetime.strptime(since_date, "%Y-%m-%d")
@@ -264,7 +275,7 @@ def check_workouts(since_date: str = "", until_date: str = "") -> str:
 
     if not points:
         return f"No workouts {range_desc}."
-    return f"Workouts {range_desc}:\n\n" + "\n\n".join(_format_workout(p) for p in points)
+    return f"Workouts {range_desc}{_zone_note()}:\n\n" + "\n\n".join(_format_workout(p) for p in points)
 
 
 def _daily(data_type: str, filter_member: str, days: int) -> list[dict]:


### PR DESCRIPTION
Follow-ups from the #109 timezone audit that shipped /tz in #112 — all three fixes plus the CI gate that keeps future clock choices deliberate.

- **`get_chat_history` day boundary in code, not in the contract** — the `since` docstring taught a fixed `+03:00` offset for Israel days, wrong every winter (IST is +02:00). `since` now accepts a plain `YYYY-MM-DD` converted to that day's Israel midnight via ZoneInfo (DST-correct); full offset timestamps unchanged as the precise-cut form. Verified against seeded entries ±1min around Israel midnight in both seasons.
- **Google Health follows the owner** — the Health API already buckets by the watch's local civil dates, but the query side was pinned to Israel (workouts `today` default, sleep cutoff, rendering), so the data clock and query clock disagreed abroad. Swapped to `timeutils.owner_tz()` — the same single /tz switch the envelope and reminder echo read, so all owner-following surfaces flip together. At home `owner_tz()` *is* `ISRAEL_TZ`: byte-identical. While away, sleep/workout replies label their clock once.
- **CI guard: `check_timezone_anchors.py`** — with two clocks in the system, a new time consumer picking one by accident only fails abroad, invisible to home testing. The guard (fourth ci.yml job, pure static scan) enforces seam integrity (no `ZoneInfo("Asia/Jerusalem")` or `owner_tz.json` outside `timeutils`) and a declared-anchoring roster: every `timeutils` importer must be listed as `home`/`owner`/`both`, per the rule *follow the owner only if the data source physically travels with the owner*. Negative-tested on all four failure classes.
- **Pending-mirror rolling 24h window** — the drain's never-mirror floor was start-of-Israel-day: invisible at home (lands mid-sleep) but mid-evening local west of Israel, silently dropping a just-delivered proactive send from thread history right before the owner replies to it. Now `now − 24h`: same at-most-a-day backlog bound, no boundary anywhere, simpler code. Deliberately not `owner_tz()` — a floor coupled to the manual /tz switch would jump on travel days. `pending_mirrors` no longer imports `timeutils`; the anchor guard's stale-entry check forced the roster update — its first real catch.

https://claude.ai/code/session_01EQRwHdPMo5KMoqaNW5qG6d