### PR TITLE
docs: archive the context plan — after-readings recorded, C5 resolved

### DIFF
--- a/docs/plans/archive/CONTEXT_PLAN.md
+++ b/docs/plans/archive/CONTEXT_PLAN.md
@@ -1,11 +1,13 @@
 # Context — one owner conversation, and the cross-scope bridge
 
-**Status:** phases 0–1c COMPLETE and staging-verified; 1d deferred to #106 (2026-08-25).
-Remaining: phase-0 "after" readings, umbrella soak, merge.
+**Status:** COMPLETE and ARCHIVED (2026-08-29). Phases 0–1c shipped via PR #102, in prod since
+deploy-2026-08-25-1; after-readings taken 2026-08-29 (table below). 1d deferred to #106.
+Phases 2–4 and the deferred items below remain tracked by [../context/PROBLEMS.md](../context/PROBLEMS.md)
+via umbrella #18 — deliberately not re-filed as per-phase issues.
 **Date:** 2026-08-25.
-**Problem record:** [context/PROBLEMS.md](context/PROBLEMS.md) — this plan solves C5 (issue #50)
+**Problem record:** [../context/PROBLEMS.md](../context/PROBLEMS.md) — this plan solves C5 (issue #50)
 and touches C1/A-cluster edges; it deliberately does not restate the problems.
-**Evidence:** [context/REFERENCE_ARCHITECTURES.md](context/REFERENCE_ARCHITECTURES.md) (source-level
+**Evidence:** [../context/REFERENCE_ARCHITECTURES.md](../context/REFERENCE_ARCHITECTURES.md) (source-level
 deep dives of OpenClaw and hermes-agent, 2026-08-25). The mechanisms below are the two systems'
 convergence points, not inventions.
 
@@ -58,7 +60,7 @@ unfiled.
 ## Phase 0 — the instrument (preliminary)
 
 One script, `scripts/context_report.py`, printing from data that already exists (recipes in
-[context/RESEARCH.md](context/RESEARCH.md) §2):
+[../context/RESEARCH.md](../context/RESEARCH.md) §2):
 
 - input tokens/turn and turns/day, per scope (`turns.jsonl`)
 - cache-hit ratio per scope (`turns.jsonl` cached-token fields)
@@ -70,13 +72,25 @@ Run once → baseline table below. Re-run at the end of each phase; the deltas a
 Baseline taken 2026-08-25 (`JARVIS_ROOT=/app … --days 7` — **prod data, read-only**; staging's
 traffic is dev noise). One known-unparseable turns.jsonl line reported and skipped.
 
-| Reading | Baseline 2026-08-25 | After 1b | After 1d |
+| Reading | Baseline 2026-08-25 | After 1b+1c (2026-08-29) | After 1d |
 |---|---|---|---|
-| user input/turn | 83,203 (53 turns; 2.55 llm calls/turn) | | |
-| heartbeat input/turn | 67,561 (110 turns; 3.80 llm calls/turn) | | |
-| user cache ratio | 36.7% (heartbeat: 41.8%) | | |
-| checkpoint bytes, owner threads | telegram 48,106 + jarvis-app 67,590 (heartbeat thread: 51,241) | one thread: | |
-| user prompt total (chars) | 7,831 at 05:48 UTC — before any notification slice; the slice varies 0–~5k with time of day, so compare same-time runs | | (slice retired) |
+| user input/turn | 83,203 (53 turns; 2.55 llm calls/turn) | 83,860 (7 turns; 2.71 llm calls/turn) | — |
+| heartbeat input/turn | 67,561 (110 turns; 3.80 llm calls/turn) | 88,582 (42 turns; 3.24 llm calls/turn) | — |
+| user cache ratio | 36.7% (heartbeat: 41.8%) | 33.2% (heartbeat: 44.5%) | — |
+| checkpoint bytes, owner threads | telegram 48,106 + jarvis-app 67,590 (heartbeat thread: 51,241) | one thread: owner 121,055 (heartbeat: 70,947; old per-channel rows frozen in the DB — #12's territory) | — |
+| user prompt total (chars) | 7,831 at 05:48 UTC — before any notification slice; the slice varies 0–~5k with time of day, so compare same-time runs | 8,736 at 13:47 UTC — **no notification slice exists any more**, so time of day no longer matters | (slice retired) |
+
+After-reading notes (2026-08-29, `JARVIS_ROOT=/app … --days 3` — window starts after
+deploy-2026-08-25-1 landed 1a–1c in prod, so it contains no pre-spine traffic):
+
+- **User cost is flat** (83.2k → 83.9k input/turn) where the plan predicted a rise — mirrors in
+  the window replaced the deleted slice at no net cost. Caveat: only 7 user turns in the window.
+- **The 1d column stays empty by design** — 1d was deferred to #106, so "slice retired" landed
+  with 1c and there is no further reading to take.
+- **Heartbeat input/turn rose 31%** (67.6k → 88.6k). Phase 1 barely touched the heartbeat scope
+  (its chat slice is unchanged); the drivers are its own checkpoint growth (51k → 71k bytes) and
+  the window's task mix (6.6 tool calls/turn), and its cache ratio improved. Recorded here so the
+  umbrella (#18) sees it; not attributed to this plan.
 
 Context for the trend: user input/turn was 46.7k at the 07-16 baseline and 78.6k at 08-06
 (PROBLEMS.md §0) — still climbing; the user scope is where window weight lands.

--- a/docs/plans/context/PROBLEMS.md
+++ b/docs/plans/context/PROBLEMS.md
@@ -146,7 +146,7 @@ USER.md and MEMORY.md are injected into every prompt in both scopes, so every li
 permanent per-turn tax, with no pressure to curate between weekly audit passes.
 
 **C5 — A message the heartbeat sent is not part of the conversation the user scope sees, so replies
-to it land without an antecedent.** `MEASURED`
+to it land without an antecedent.** `RESOLVED`
 The owner experiences this as conversations that feel glitchy and out of context. `notify_owner`
 writes the sent text to `notifications.jsonl` only — it never enters the telegram thread's
 checkpoint and is never appended to `chat_history.jsonl` under that thread. The user scope recovers
@@ -166,6 +166,12 @@ it as `_load_recent_heartbeat_notifications()` (`agent.py:343`): flat `[HH:MM] t
 The reverse direction has the same shape but is better served: the heartbeat scope receives today's
 user chat with roles and timestamps (`_load_recent_user_chat`, 60 entries), which is nearer to a
 transcript than to a summary — though still injected as prompt text rather than as history.
+
+Resolved by the context plan's phases 1a–1c (PR #102, prod since 2026-08-25;
+[../archive/CONTEXT_PLAN.md](../archive/CONTEXT_PLAN.md)): delivered notifications are mirrored
+into the one `owner` thread as real history on the next user turn, and the prompt slice is gone.
+Gaps 1–3 are closed outright; of gap 4, yesterday's messages now persist in the window, while a
+tick that acted *without* notifying is still invisible — that remainder is filed as #106.
 
 ---
 
@@ -294,7 +300,7 @@ without anyone testing them:
 | E1, E6 | #36 | instance of, and wider — covers both scopes, and containment as well as legibility |
 | C1 | #81 | complement — C1 is unbounded injection, #81 is unrecoverable truncation |
 | C3 | #61, #60 | complement — content Jarvis saw once and cannot reach again |
-| C5 | #50 | stated here |
+| C5 | #50 | stated here — resolved; #50 closed on phases 1a–1c |
 | B1, B4 | #24 | dependency — the Israel-time duplication any clock work must cross |
 | — | #18 | the umbrella; points at this file rather than restating it |
 

--- a/scripts/context_report.py
+++ b/scripts/context_report.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """The context instrument — one script, ~six numbers, run before and after.
 
-Prints the readings the context plan (docs/plans/CONTEXT_PLAN.md phase 0)
+Prints the readings the context plan (docs/plans/archive/CONTEXT_PLAN.md phase 0)
 brackets every phase with: per-scope turn costs and cache ratio from
 turns.jsonl, checkpoint weight per thread from threads.sqlite, and the
 assembled system prompt's section sizes from build_system_prompt itself.


### PR DESCRIPTION
Closes out the context plan (phases 0–1c shipped via #102, in prod since deploy-2026-08-25-1; 1d deferred to #106).

- Move `docs/plans/CONTEXT_PLAN.md` → `docs/plans/archive/`, status COMPLETE, relative links fixed.
- Fill the phase-0 after-readings (2026-08-29, 3-day post-deploy prod window) into the comparison table: user input/turn flat (83.2k → 83.9k, 7-turn sample), notification slice gone, one `owner` checkpoint replacing the two per-channel threads. Heartbeat's 31% input/turn rise recorded, not attributed to the plan.
- Mark C5 `RESOLVED` in PROBLEMS.md (gaps 1–3 closed by the mirror; gap 4's silent-act remainder is #106) and update its cross-reference row.
- Phases 2–4 and B3 stay tracked by PROBLEMS.md via umbrella #18 — deliberately not re-filed as per-phase issues.
- `context/` evidence dir stays in place (#18 points at it); one docstring path fix in `scripts/context_report.py`.

Readings summary also posted on #18.

https://claude.ai/code/session_01EQRwHdPMo5KMoqaNW5qG6d