### PR TITLE
Fitness slice 1: plans.binding, external_id, session_types (schema)

### DIFF
--- a/tools/fitness/_db.py
+++ b/tools/fitness/_db.py
@@ -38,13 +38,14 @@ def _init_db():
             tracking_mode       TEXT NOT NULL CHECK(tracking_mode IN ('flexible_quota', 'strict_sequential')),
             weekly_target_count INTEGER,
             status              TEXT DEFAULT 'active' CHECK(status IN ('active', 'paused', 'completed')),
-            start_date          DATE
+            start_date          DATE,
+            binding             TEXT
         );
 
         CREATE TABLE IF NOT EXISTS workouts (
             workout_id      INTEGER PRIMARY KEY AUTOINCREMENT,
             plan_id         INTEGER,
-            arbox_class_id  TEXT UNIQUE,
+            external_id     TEXT UNIQUE,
             scheduled_time  DATETIME NOT NULL,
             status          TEXT DEFAULT 'scheduled'
                                 CHECK(status IN ('scheduled','completed','missed')),
@@ -97,21 +98,62 @@ def _init_db():
             effective_from DATE NOT NULL,
             FOREIGN KEY(plan_id) REFERENCES plans(plan_id)
         );
+
+        CREATE TABLE IF NOT EXISTS session_types (
+            name       TEXT PRIMARY KEY,
+            stat_shape TEXT NOT NULL CHECK(stat_shape IN ('strength', 'cardio', 'none'))
+        );
     """)
     conn.commit()
 
-    # Migrate existing databases: add new columns if missing
+    # session_types is a soft vocabulary, seeded here and only here: it drives
+    # the stat-enrichers' automatic routing (which child table fits a row), it
+    # does not gate workout creation — an unlisted session_type is still a
+    # valid workout, it just gets no automatic stat routing. Adding a type is
+    # a one-line edit to this seed.
+    conn.executemany(
+        "INSERT OR IGNORE INTO session_types (name, stat_shape) VALUES (?, ?)",
+        [
+            ("crossfit", "strength"),
+            ("running", "cardio"),
+            ("walking", "cardio"),
+            ("hiking", "cardio"),
+            ("mobility", "none"),
+        ],
+    )
+    conn.commit()
+
+    # Migrate existing databases: add new columns if missing. The rename
+    # generalizes the Arbox idempotency key: `external_id` is unique per
+    # `source` (index below), so a future non-Arbox sync (e.g. watch sessions)
+    # is just another source value, not another column.
     for sql in [
         "ALTER TABLE workouts ADD COLUMN session_type TEXT DEFAULT 'crossfit'",
         "ALTER TABLE workouts ADD COLUMN wod_result TEXT",
         "ALTER TABLE workouts ADD COLUMN notes TEXT",
         "ALTER TABLE plans ADD COLUMN start_date DATE",
+        "ALTER TABLE plans ADD COLUMN binding TEXT",
+        "ALTER TABLE workouts RENAME COLUMN arbox_class_id TO external_id",
     ]:
         try:
             conn.execute(sql)
             conn.commit()
         except Exception:
-            pass  # column already exists
+            pass  # column already exists (or, for the rename, already renamed)
+
+    # The declared uniqueness contract is per-source. Migrated databases also
+    # keep the stricter single-column UNIQUE the renamed column carried from
+    # its original definition — harmless, since distinct sources' ids don't
+    # collide in practice — so fresh databases declare the same column-level
+    # UNIQUE above to keep the two schema histories equivalent.
+    try:
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_workouts_source_external "
+            "ON workouts(source, external_id) WHERE external_id IS NOT NULL"
+        )
+        conn.commit()
+    except Exception:
+        pass
 
     # One-time, idempotent backfill: a plan with no start_date but with
     # existing workouts gets dated from its earliest workout, so adherence
@@ -126,6 +168,26 @@ def _init_db():
             ") "
             "WHERE start_date IS NULL "
             "  AND EXISTS (SELECT 1 FROM workouts w WHERE w.plan_id = plans.plan_id)"
+        )
+        conn.commit()
+    except Exception:
+        pass
+
+    # One-time, idempotent backfill: stamp each plan's logging channel by
+    # applying the retiring attachment heuristics a final time — the plan
+    # named like Running gets binding='running' (any status: a paused running
+    # plan should still receive runs when reactivated), and the lowest-id
+    # *active* remaining plan gets binding='arbox' (exactly what the old
+    # "first active plan" LIMIT-1 pick resolved to). Other plans stay NULL —
+    # no channel — until set via manage_fitness_plan. The IS NULL guards make
+    # this a no-op on every subsequent boot.
+    try:
+        conn.execute(
+            "UPDATE plans SET binding='running' WHERE binding IS NULL AND name LIKE '%Running%'"
+        )
+        conn.execute(
+            "UPDATE plans SET binding='arbox' WHERE binding IS NULL AND status='active' "
+            "AND plan_id = (SELECT MIN(plan_id) FROM plans WHERE binding IS NULL AND status='active')"
         )
         conn.commit()
     except Exception:

--- a/tools/fitness/classes.py
+++ b/tools/fitness/classes.py
@@ -48,7 +48,7 @@ def _purge_dropped_arbox_classes(conn, registered_ids, now_str, horizon_str):
     params = [now_str, horizon_str]
     if registered_ids:
         placeholders = ",".join("?" * len(registered_ids))
-        where += f" AND arbox_class_id NOT IN ({placeholders})"
+        where += f" AND external_id NOT IN ({placeholders})"
         params += list(registered_ids)
 
     doomed = conn.execute(
@@ -98,7 +98,7 @@ def _sync_registered_classes() -> str:
 
             conn.execute(
                 """INSERT OR IGNORE INTO workouts
-                   (arbox_class_id, plan_id, scheduled_time, description, source)
+                   (external_id, plan_id, scheduled_time, description, source)
                    VALUES (?, ?, ?, ?, 'arbox')""",
                 (schedule_id, plan_id, scheduled_dt, wod or None),
             )

--- a/tools/fitness/plans.py
+++ b/tools/fitness/plans.py
@@ -19,13 +19,15 @@ def manage_fitness_plan(
     weekly_target_count: int | None = None,
     status: str | None = None,
     start_date: str | None = None,
+    binding: str | None = None,
 ) -> str:
     """Create, update, or list fitness plans.
 
     action='create': Create a new plan. Requires name, tracking_mode ('flexible_quota' or
         'strict_sequential'), and weekly_target_count. start_date defaults to today.
     action='update': Update an existing plan. Requires plan_id. Provide any fields to change:
-        name, weekly_target_count, status ('active', 'paused', 'completed'), or start_date.
+        name, weekly_target_count, status ('active', 'paused', 'completed'), start_date,
+        or binding.
     action='list': List all plans with current status, start date, and this-week session counts.
 
     Args:
@@ -36,10 +38,16 @@ def manage_fitness_plan(
         weekly_target_count: How many sessions per week to aim for
         status: 'active', 'paused', or 'completed'
         start_date: 'YYYY-MM-DD' the plan begins. Adherence reports ignore weeks before it. Create defaults to today.
+        binding: Which logging channel feeds this plan — 'arbox' (gym class sync),
+            'running' (running sessions), or 'manual' (manually logged sessions).
+            Create defaults to 'manual'. At most one active plan per binding.
     """
+    _VALID_BINDINGS = ("arbox", "running", "manual")
     try:
         if start_date is not None and not _valid_date(start_date):
             return "Error: start_date must be 'YYYY-MM-DD'."
+        if binding is not None and binding not in _VALID_BINDINGS:
+            return f"Error: binding must be one of {', '.join(_VALID_BINDINGS)}."
         conn = _get_db()
         if action == "create":
             if not all([name, tracking_mode, weekly_target_count is not None]):
@@ -48,8 +56,8 @@ def manage_fitness_plan(
                 return "Error: tracking_mode must be 'flexible_quota' or 'strict_sequential'."
             sd = start_date or datetime.now(ISRAEL_TZ).strftime("%Y-%m-%d")
             conn.execute(
-                "INSERT INTO plans (name, tracking_mode, weekly_target_count, start_date) VALUES (?, ?, ?, ?)",
-                (name, tracking_mode, weekly_target_count, sd),
+                "INSERT INTO plans (name, tracking_mode, weekly_target_count, start_date, binding) VALUES (?, ?, ?, ?, ?)",
+                (name, tracking_mode, weekly_target_count, sd, binding or "manual"),
             )
             conn.commit()
             pid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
@@ -59,7 +67,7 @@ def manage_fitness_plan(
             )
             conn.commit()
             conn.close()
-            return f"Created plan '{name}' (id={pid}, mode={tracking_mode}, target={weekly_target_count}/week, start={sd})."
+            return f"Created plan '{name}' (id={pid}, mode={tracking_mode}, target={weekly_target_count}/week, start={sd}, binding={binding or 'manual'})."
 
         elif action == "update":
             if not plan_id:
@@ -73,8 +81,10 @@ def manage_fitness_plan(
                 fields.append("status = ?"); values.append(status)
             if start_date:
                 fields.append("start_date = ?"); values.append(start_date)
+            if binding:
+                fields.append("binding = ?"); values.append(binding)
             if not fields:
-                return "Error: provide at least one field to update (name, weekly_target_count, status, start_date)."
+                return "Error: provide at least one field to update (name, weekly_target_count, status, start_date, binding)."
 
             # Capture the pre-update target so a real change can be recorded in
             # plan_target_history — past weeks stay judged by the target that
@@ -123,7 +133,8 @@ def manage_fitness_plan(
                 lines.append(
                     f"[{p['plan_id']}] {p['name']} | {p['tracking_mode']} | "
                     f"target: {target}/week | this week: {done}/{target} | "
-                    f"status: {p['status']} | start: {start}"
+                    f"status: {p['status']} | start: {start} | "
+                    f"binding: {p['binding'] or '—'}"
                 )
             conn.close()
             return "\n".join(lines)


### PR DESCRIPTION
Stacked on #118 (merge that first; this PR's base is `feat/fitness-logging-slice0`).

## What

Schema slice of `docs/plans/FITNESS_LOGGING_PLAN.md` — no behavior change; the attachment heuristics stay in place until slice 2 rewires them onto `binding`:

- **`plans.binding`** (`'arbox' | 'running' | 'manual'`, tool-validated) + one-time idempotent backfill that applies the retiring heuristics a final time to stamp existing plans (`%Running%` name → `running`, any status; lowest-id active → `arbox`; rest NULL).
- **`workouts.arbox_class_id` → `external_id`** (`ALTER TABLE ... RENAME COLUMN` in the try/except migration list) with `idx_workouts_source_external` — unique per `(source, external_id)`, the generalized sync-idempotency key (Health Connect `clientRecordId` / HealthKit `syncIdentifier` pattern). `classes.py` references renamed; `INSERT OR IGNORE` sync semantics unchanged.
- **`session_types(name, stat_shape)`** seeded (crossfit→strength; running/walking/hiking→cardio; mobility→none). Soft vocabulary: drives slice 2's enricher auto-routing, never gates creation.
- **`manage_fitness_plan`** grows `binding` (create defaults `'manual'`; update/list support it).

## Verification

- Sandbox DB copy: migration produces expected columns/index/seeds; backfill stamps the three real plans correctly (arbox / NULL / running); re-running the migration is a no-op; duplicate `(source, external_id)` rejected; tool create/update/invalid-binding/list all exercised.
- Real staging DB then migrated (backup kept at `fitness.sqlite.bak-pre-slice1`): 28 workout rows intact, dashboard renders unchanged.
- `py_compile` + all four `scripts/ci` guards pass.

https://claude.ai/code/session_01JKFq2YmiakpnSUdxp1yUUf