### PR TITLE
Fitness slice 2: compositional logging tools

### DIFF
--- a/docs/architecture/RUNTIME.md
+++ b/docs/architecture/RUNTIME.md
@@ -55,7 +55,7 @@ Tools grouped by **namespace**. A namespace is a skill — and a namespace may b
 | `media/jellyseerr` | `tools/media/jellyseerr/` | Requests: `search_jellyseerr`, `get_jellyseerr_requests`, `request_media`. |
 | `media/system` | `tools/media/system/` | Stack health / overview: `get_library_overview`, `get_media_system_health`. |
 | `web` | `tools/web/` | `web_search`, `fetch_url`. Grouped deliberately: search bound without fetch is what made a turn search 14 times for a URL it could not look up (#7). |
-| `fitness` | `tools/fitness/` | Arbox + training: `manage_fitness_plan`, `fetch_upcoming_arbox_classes`, `fetch_weekly_gym_schedule`, `sync_arbox_attendance`, `log_workout`, `log_exercise_stats`, `log_cardio_stats`, `log_wod_result`, `log_running_session` (deprecated alias), `query_exercise_history`, `get_today_workout_id`, `get_weekly_fitness_summary`, `get_adherence_report`, `query_fitness_db` (read-only ad-hoc SQL). |
+| `fitness` | `tools/fitness/` | Arbox + training: `manage_fitness_plan`, `fetch_upcoming_arbox_classes`, `fetch_weekly_gym_schedule`, `sync_arbox_attendance`, `log_workout`, `log_exercise_stats`, `log_cardio_stats`, `log_wod_result`, `query_exercise_history`, `get_today_workout_id`, `get_weekly_fitness_summary`, `get_adherence_report`, `query_fitness_db` (read-only ad-hoc SQL). |
 
 ⚠ = `destructive`. **No `home` placeholder** — namespaces are added when their tools exist, not before. The registry is extensible: a new top-level skill is a new directory plus `namespace="<name>"` on its tools; a new sub-skill is a `tools/<parent>/<child>/` subpackage plus `namespace="<parent>/<child>"`. Nothing else.
 

--- a/docs/architecture/RUNTIME.md
+++ b/docs/architecture/RUNTIME.md
@@ -55,7 +55,7 @@ Tools grouped by **namespace**. A namespace is a skill — and a namespace may b
 | `media/jellyseerr` | `tools/media/jellyseerr/` | Requests: `search_jellyseerr`, `get_jellyseerr_requests`, `request_media`. |
 | `media/system` | `tools/media/system/` | Stack health / overview: `get_library_overview`, `get_media_system_health`. |
 | `web` | `tools/web/` | `web_search`, `fetch_url`. Grouped deliberately: search bound without fetch is what made a turn search 14 times for a URL it could not look up (#7). |
-| `fitness` | `tools/fitness/` | Arbox + training: `manage_fitness_plan`, `fetch_upcoming_arbox_classes`, `fetch_weekly_gym_schedule`, `sync_arbox_attendance`, `log_exercise_stats`, `log_running_session`, `log_wod_result`, `query_exercise_history`, `get_today_workout_id`, `get_weekly_fitness_summary`, `get_adherence_report`, `query_fitness_db` (read-only ad-hoc SQL). |
+| `fitness` | `tools/fitness/` | Arbox + training: `manage_fitness_plan`, `fetch_upcoming_arbox_classes`, `fetch_weekly_gym_schedule`, `sync_arbox_attendance`, `log_workout`, `log_exercise_stats`, `log_cardio_stats`, `log_wod_result`, `log_running_session` (deprecated alias), `query_exercise_history`, `get_today_workout_id`, `get_weekly_fitness_summary`, `get_adherence_report`, `query_fitness_db` (read-only ad-hoc SQL). |
 
 ⚠ = `destructive`. **No `home` placeholder** — namespaces are added when their tools exist, not before. The registry is extensible: a new top-level skill is a new directory plus `namespace="<name>"` on its tools; a new sub-skill is a `tools/<parent>/<child>/` subpackage plus `namespace="<parent>/<child>"`. Nothing else.
 

--- a/docs/plans/FITNESS_LOGGING_PLAN.md
+++ b/docs/plans/FITNESS_LOGGING_PLAN.md
@@ -154,9 +154,10 @@ app poll.
   `stat_shape` is strength; keep the explicit `workout_id` escape hatch. Together with manual
   rows' midday sentinel time (vs Arbox rows' real class time), this settles the
   double-session-day tie-break that previously attached stats to the wrong row.
-- **`log_running_session` becomes a deprecation shim**: same signature, internally
-  `log_workout` + `log_cardio_stats`, docstring pointing at the new pair; delete after the
-  cutover has held in prod for a while.
+- **`log_running_session` is deleted outright** (no deprecation shim). A shim was planned
+  to keep recent thread history executable, but the observability log showed the tool was
+  called exactly twice ever in prod, last on 2026-07-29 — far outside any 50-message
+  window — so there is no in-context history to protect.
 - **Provenance gating** (FitTrackee's lesson): tools never edit the identity fields
   (`scheduled_time`, `external_id`, status flips owned by the sync) of `source='arbox'` rows;
   enrichment (`wod_result`, stats, notes) stays allowed. Manual rows stay fully editable.

--- a/tools/fitness/SKILL.md
+++ b/tools/fitness/SKILL.md
@@ -3,8 +3,9 @@ name: fitness
 description: gym attendance, workout logs, running sessions
 ---
 - Before discussing or logging a running session, check MEMORY.md for your running-program notes (current phase, next session). A running session's description must match the program phase and session number (e.g. 'Phase 0 Session 1: 30-min brisk walk'). pain_level is 0=none, 1=slight, 2=moderate, 3=stop-sign; if ≥ 2, flag it clearly in your response.
-- Log workout stats and WOD results immediately when Roi reports them — never acknowledge without saving.
-- To collect workout or running stats, prefer `send_form` prefilled from history (`query_exercise_history`; your running-program notes) over asking in prose. A `[Submitted form ...]` message is Roi reporting stats — log it per the rule above.
+- Log workout stats and WOD results immediately when Roi reports them — never acknowledge without saving. A run in one message is one `log_cardio_stats` call (it records the session too, when needed).
+- Gym classes come from the Arbox sync — their rows already exist. Enrich them (`log_wod_result`, `log_exercise_stats`, `log_cardio_stats` for an endurance class); never `log_workout` a class. `log_workout` is for sessions with no Arbox class behind them: hotel WODs, other gyms, travel, new activities.
+- To collect workout or running stats, prefer `send_form` prefilled from history (`query_exercise_history`; your running-program notes) over asking in prose. A `[Submitted form ...]` message is Roi reporting stats — log it per the rule above (a running form maps to one `log_cardio_stats` call).
 - If any Arbox tool returns "Error: Arbox session expired", relay that exact message to Roi verbatim (he must update ARBOX_ACCESS_TOKEN in the env file). Do not retry.
 - When `fetch_upcoming_arbox_classes` reports it removed a class Roi is no longer registered for, don't treat it as silent cleanup: tell him the class was dropped, and if it puts him under his weekly quota (`get_weekly_fitness_summary`), say so and offer to look at alternatives (`fetch_weekly_gym_schedule`).
 - `fetch_upcoming_arbox_classes` / `fetch_weekly_gym_schedule` already return only the track Roi follows (WOD, or Saturday Endurance) in full. Reach for `get_daily_programming` only when he explicitly asks about another track (PUMP, weightlifting) or wants to compare them.

--- a/tools/fitness/__init__.py
+++ b/tools/fitness/__init__.py
@@ -14,9 +14,10 @@ from tools.fitness.classes import (  # noqa: F401
 )
 from tools.fitness.logs import (  # noqa: F401
     get_today_workout_id,
+    log_cardio_stats,
     log_exercise_stats,
-    log_running_session,
     log_wod_result,
+    log_workout,
     query_exercise_history,
 )
 from tools.fitness.plans import manage_fitness_plan  # noqa: F401
@@ -33,9 +34,10 @@ __all__ = [
     "get_daily_programming",
     "get_today_workout_id",
     "get_weekly_fitness_summary",
+    "log_cardio_stats",
     "log_exercise_stats",
-    "log_running_session",
     "log_wod_result",
+    "log_workout",
     "manage_fitness_plan",
     "query_exercise_history",
     "query_fitness_db",

--- a/tools/fitness/classes.py
+++ b/tools/fitness/classes.py
@@ -83,8 +83,19 @@ def _sync_registered_classes() -> str:
 
     conn = _get_db()
     try:
-        plan = conn.execute("SELECT plan_id FROM plans WHERE status='active' LIMIT 1").fetchone()
-        plan_id = plan["plan_id"] if plan else None
+        # Synced classes attach to the one active arbox-bound plan — declared
+        # via plans.binding, never guessed. Zero or several matches is a
+        # configuration problem the owner has to resolve; erroring beats
+        # attaching a class to the wrong plan's quota.
+        bound = conn.execute(
+            "SELECT plan_id FROM plans WHERE status='active' AND binding='arbox'"
+        ).fetchall()
+        if len(bound) != 1:
+            raise RuntimeError(
+                f"expected exactly one active plan with binding='arbox', found {len(bound)} — "
+                "fix with manage_fitness_plan (set binding / status) and retry"
+            )
+        plan_id = bound[0]["plan_id"]
 
         results = []
         for cls in registered:

--- a/tools/fitness/logs.py
+++ b/tools/fitness/logs.py
@@ -1,11 +1,124 @@
-"""Logging what was actually done — lifts, runs, and WOD results."""
+"""Logging what was actually done — sessions, lifts, cardio stats, and WOD results.
+
+The write model is create-then-enrich: `log_workout` records that a session
+happened (one row in `workouts`), and the per-shape enrichers attach stats to
+it — `log_exercise_stats` (strength), `log_cardio_stats` (cardio),
+`log_wod_result` (WOD score). The cardio enricher can also conjure its parent
+row when none exists yet, so the common one-utterance run report stays one
+call. Which shape auto-routes to which rows comes from the `session_types`
+table, never from the type string alone.
+"""
 
 from datetime import datetime, timedelta
 
 from langchain_core.tools import tool
 
-from tools.fitness._db import ISRAEL_TZ, _fmt_pace, _get_db
+from tools.fitness._db import ISRAEL_TZ, _fmt_pace, _get_db, _valid_date
 from tools.registry import tool_register
+
+# A session type's "natural home": which plan binding receives its manual
+# workouts when the caller names no plan. Types not listed here belong to the
+# generic manual channel.
+_BINDING_HOME = {"running": "running", "crossfit": "arbox"}
+
+# Manual rows carry a midday sentinel time: date-only input has no real clock,
+# and midday keeps these rows distinguishable from (and stably ordered
+# against) Arbox rows, which carry the class's actual start time.
+_MANUAL_TIME = "12:00:00"
+
+
+def _resolve_plan(conn, plan: str | None, session_type: str) -> tuple[int | None, str | None]:
+    """Which plan does a manual workout belong to? Returns (plan_id, error).
+
+    An explicit `plan` (id or name, any status) always wins — the owner's
+    choice. Otherwise the session type's natural-home binding picks among
+    *active* plans, and anything but exactly one match is an error naming the
+    candidates — never a silent NULL, because an unattached row shows up in
+    the year totals but in no plan's quota or streak.
+    """
+    if plan:
+        p = plan.strip()
+        if p.isdigit():
+            row = conn.execute("SELECT plan_id FROM plans WHERE plan_id=?", (int(p),)).fetchone()
+            if row:
+                return row["plan_id"], None
+        rows = conn.execute(
+            "SELECT plan_id, name FROM plans WHERE LOWER(name) LIKE LOWER(?)", (f"%{p}%",)
+        ).fetchall()
+        if len(rows) == 1:
+            return rows[0]["plan_id"], None
+        if rows:
+            names = ", ".join(f"[{r['plan_id']}] {r['name']}" for r in rows)
+            return None, f"Plan {plan!r} is ambiguous: {names}. Pass the plan_id."
+        return None, f"No plan matching {plan!r}. Check manage_fitness_plan(action='list')."
+
+    home = _BINDING_HOME.get(session_type, "manual")
+    rows = conn.execute(
+        "SELECT plan_id FROM plans WHERE status='active' AND binding=?", (home,)
+    ).fetchall()
+    if len(rows) == 1:
+        return rows[0]["plan_id"], None
+    active = conn.execute("SELECT plan_id, name, binding FROM plans WHERE status='active'").fetchall()
+    listing = "; ".join(f"[{r['plan_id']}] {r['name']} (binding: {r['binding'] or '—'})" for r in active) or "none"
+    problem = "no active plan has" if not rows else f"{len(rows)} active plans have"
+    return None, (
+        f"Can't attach this {session_type} session: {problem} binding='{home}'. "
+        f"Active plans: {listing}. Pass plan=<id or name>, or fix bindings via manage_fitness_plan."
+    )
+
+
+def _stat_shape(conn, session_type: str) -> str | None:
+    row = conn.execute("SELECT stat_shape FROM session_types WHERE name=?", (session_type,)).fetchone()
+    return row["stat_shape"] if row else None
+
+
+def _create_workout(conn, description: str, session_date: str, session_type: str, plan_id: int | None) -> int:
+    """Insert one completed manual workout row and return its id."""
+    conn.execute(
+        "INSERT INTO workouts (plan_id, session_type, scheduled_time, status, description, source) "
+        "VALUES (?, ?, ?, 'completed', ?, 'manual')",
+        (plan_id, session_type, f"{session_date} {_MANUAL_TIME}", description.strip()),
+    )
+    conn.commit()
+    return conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+
+def _insert_cardio(
+    conn, workout_id: int, duration_min: float, distance_km, avg_hr,
+    pain_level: int, prehab_done: bool, prehab_notes: str, notes: str,
+) -> int | None:
+    """Insert the cardio row (pace derived), mark the workout completed; returns avg_pace_sec."""
+    avg_pace_sec = None
+    if distance_km and duration_min:
+        avg_pace_sec = int((duration_min * 60) / distance_km)
+    conn.execute(
+        "INSERT INTO cardio_logs (workout_id, duration_min, distance_km, avg_pace_sec, avg_hr, "
+        "pain_level, prehab_done, prehab_notes, notes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (workout_id, duration_min, distance_km, avg_pace_sec, avg_hr,
+         pain_level, int(prehab_done), prehab_notes.strip() or None, notes.strip() or None),
+    )
+    # Stats arriving means the session happened — a still-'scheduled' row
+    # (e.g. a synced endurance class) completes on enrichment, mirroring
+    # log_wod_result's flip.
+    conn.execute("UPDATE workouts SET status='completed' WHERE workout_id=?", (workout_id,))
+    conn.commit()
+    return avg_pace_sec
+
+
+def _cardio_parts(duration_min, distance_km, avg_pace_sec, avg_hr, pain_level, prehab_done, prehab_notes) -> list[str]:
+    parts = [f"  Duration: {duration_min} min"]
+    if distance_km:
+        parts.append(f"  Distance: {distance_km} km")
+    if avg_pace_sec:
+        parts.append(f"  Avg pace: {_fmt_pace(avg_pace_sec)}")
+    if avg_hr:
+        parts.append(f"  Avg HR: {avg_hr} bpm")
+    if pain_level > 0:
+        labels = {1: "slight", 2: "moderate", 3: "STOP"}
+        parts.append(f"  Pain: {labels.get(pain_level, pain_level)}")
+    if prehab_done:
+        parts.append(f"  Pre-hab: done ({prehab_notes})" if prehab_notes else "  Pre-hab: done")
+    return parts
 
 
 @tool_register(namespace="fitness")
@@ -36,8 +149,12 @@ def log_exercise_stats(
 
         if workout_id is None:
             today = datetime.now(ISRAEL_TZ).strftime("%Y-%m-%d")
+            # Strength-shaped sessions only (session_types.stat_shape): on a
+            # double-session day this must never grab the run.
             row = conn.execute(
-                "SELECT workout_id FROM workouts WHERE date(scheduled_time) = ? ORDER BY scheduled_time DESC LIMIT 1",
+                "SELECT w.workout_id FROM workouts w "
+                "JOIN session_types st ON st.name = w.session_type AND st.stat_shape='strength' "
+                "WHERE date(w.scheduled_time) = ? ORDER BY w.scheduled_time DESC LIMIT 1",
                 (today,),
             ).fetchone()
             if row:
@@ -101,6 +218,222 @@ def query_exercise_history(exercise_name: str) -> str:
 
 @tool_register(namespace="fitness")
 @tool
+def log_workout(
+    description: str,
+    date: str | None = None,
+    session_type: str = "crossfit",
+    plan: str | None = None,
+    allow_duplicate: bool = False,
+) -> str:
+    """Record that a workout happened — for sessions with no Arbox class behind them.
+
+    Use for off-gym training: a hotel WOD, a session at another gym, travel
+    workouts, or a new activity type. NEVER for a class the Arbox sync already
+    tracks — that row exists; enrich it with log_wod_result / log_exercise_stats
+    / log_cardio_stats instead. For a run, prefer log_cardio_stats directly —
+    it records the session and the stats in one call.
+
+    Any session_type string is accepted (e.g. 'climbing'); an unlisted type
+    still counts toward its plan, it just gets no automatic stat routing.
+    The reply gives the workout_id — pass it to the stat tools when logging
+    stats for anything but today's session.
+
+    Args:
+        description: What the session was (e.g. 'Hotel WOD: 5 rounds burpees/push-ups/squats')
+        date: Session date as YYYY-MM-DD (defaults to today in Israel time)
+        session_type: 'crossfit', 'running', 'walking', 'hiking', 'mobility', or any other activity name
+        plan: Plan to attach to, by id or name. Omit to attach by the plan's
+            binding (crossfit → the arbox-bound plan, running → the running-bound
+            plan, anything else → the manual-bound plan).
+        allow_duplicate: Pass true only if this really is a second session of the
+            same type on the same day.
+    """
+    try:
+        if not description or not description.strip():
+            return "Error: description is required."
+        if date is not None and not _valid_date(date):
+            return "Error: date must be 'YYYY-MM-DD'."
+        session_type = session_type.strip().lower()
+        session_date = date or datetime.now(ISRAEL_TZ).strftime("%Y-%m-%d")
+
+        conn = _get_db()
+        if not allow_duplicate:
+            existing = conn.execute(
+                "SELECT workout_id, status, description FROM workouts "
+                "WHERE date(scheduled_time)=? AND session_type=?",
+                (session_date, session_type),
+            ).fetchall()
+            if existing:
+                listing = "; ".join(
+                    f"workout {r['workout_id']} ({r['status']}): {(r['description'] or '')[:60]}"
+                    for r in existing
+                )
+                conn.close()
+                return (
+                    f"A {session_type} session already exists on {session_date} — {listing}. "
+                    "If this is that session, enrich it (log_wod_result / log_exercise_stats / "
+                    "log_cardio_stats with its workout_id) instead of creating a duplicate. "
+                    "If it really was a separate second session, call again with allow_duplicate=true."
+                )
+
+        plan_id, err = _resolve_plan(conn, plan, session_type)
+        if err:
+            conn.close()
+            return f"Error: {err}"
+
+        workout_id = _create_workout(conn, description, session_date, session_type, plan_id)
+        shape = _stat_shape(conn, session_type)
+        plan_name = conn.execute("SELECT name FROM plans WHERE plan_id=?", (plan_id,)).fetchone()["name"]
+        conn.close()
+
+        reply = (
+            f"Logged workout {workout_id}: {description.strip()} "
+            f"({session_type}, {session_date}, plan: {plan_name})."
+        )
+        if shape == "cardio":
+            reply += f" Now call log_cardio_stats(workout_id={workout_id}) with the session stats."
+        elif shape == "strength":
+            reply += " Attach lifts with log_exercise_stats and the WOD score with log_wod_result."
+        else:
+            reply += (
+                f" Note: '{session_type}' has no automatic stat routing; to attach stats anyway, "
+                f"pass workout_id={workout_id} explicitly."
+            )
+        return reply
+
+    except Exception as e:
+        return f"Error logging workout: {e}"
+
+
+@tool_register(namespace="fitness")
+@tool
+def log_cardio_stats(
+    duration_min: float,
+    distance_km: float | None = None,
+    avg_hr: int | None = None,
+    pain_level: int = 0,
+    prehab_done: bool = False,
+    prehab_notes: str = "",
+    notes: str = "",
+    workout_id: int | None = None,
+    description: str = "",
+    date: str | None = None,
+) -> str:
+    """Attach cardio stats (run/walk/row/hike) to a workout — creating the session if needed.
+
+    Call this immediately when Roi reports a cardio session's numbers.
+    Always call this tool — never just acknowledge without saving.
+
+    Auto-links to the day's most recent cardio-shaped workout that has no
+    stats yet (e.g. a synced endurance class, or a log_workout row). If none
+    exists, it records the session itself as a running workout — check the
+    running program memory notes first and pass the program-matched
+    description (e.g. 'Phase 0 Session 1: 30-min brisk walk'). For cardio
+    stats on a non-running session (a hike, a row), create it first with
+    log_workout and pass its workout_id.
+
+    Args:
+        duration_min: Total duration in minutes (e.g. 32.0) — required.
+        distance_km: Distance in km (from watch GPS); pace is derived.
+        avg_hr: Average heart rate in bpm
+        pain_level: 0=none, 1=slight, 2=moderate, 3=stop-sign
+        prehab_done: Whether pre-hab exercises were completed after the session
+        prehab_notes: Description of pre-hab done (e.g. 'Tibialis 3×15, Calf raises 3×15')
+        notes: Any additional session notes
+        workout_id: Attach to this specific workout. Omit to auto-link (or create).
+        description: Session description, used only when creating a new running
+            workout (required then; must match the running program phase).
+        date: Session date as YYYY-MM-DD (defaults to today in Israel time)
+    """
+    try:
+        if date is not None and not _valid_date(date):
+            return "Error: date must be 'YYYY-MM-DD'."
+        session_date = date or datetime.now(ISRAEL_TZ).strftime("%Y-%m-%d")
+
+        conn = _get_db()
+        created = False
+        if workout_id is None:
+            row = conn.execute(
+                "SELECT w.workout_id, w.description FROM workouts w "
+                "JOIN session_types st ON st.name = w.session_type AND st.stat_shape='cardio' "
+                "WHERE date(w.scheduled_time)=? AND w.workout_id NOT IN "
+                "(SELECT workout_id FROM cardio_logs WHERE workout_id IS NOT NULL) "
+                "ORDER BY w.scheduled_time DESC LIMIT 1",
+                (session_date,),
+            ).fetchone()
+            if row:
+                workout_id = row["workout_id"]
+                target_desc = row["description"] or ""
+            else:
+                # No stats-less cardio row — but if the day already has cardio
+                # sessions *with* stats, creating another here would silently
+                # double-count the day. A genuine second session goes through
+                # log_workout's explicit allow_duplicate gate instead.
+                enriched = conn.execute(
+                    "SELECT w.workout_id FROM workouts w "
+                    "JOIN session_types st ON st.name = w.session_type AND st.stat_shape='cardio' "
+                    "WHERE date(w.scheduled_time)=?",
+                    (session_date,),
+                ).fetchall()
+                if enriched:
+                    ids = ", ".join(str(r["workout_id"]) for r in enriched)
+                    conn.close()
+                    return (
+                        f"Error: every cardio session on {session_date} (workout {ids}) already has "
+                        "stats — this tool never overwrites. If this really was a separate second "
+                        "session, create it with log_workout(session_type='running', "
+                        "allow_duplicate=true) and pass its workout_id here."
+                    )
+                if not description.strip():
+                    conn.close()
+                    return (
+                        f"Error: no cardio-shaped workout on {session_date} to attach to. "
+                        "Pass description (matched to the running program notes) to record the "
+                        "session, or workout_id to attach to a specific one."
+                    )
+                plan_id, err = _resolve_plan(conn, None, "running")
+                if err:
+                    conn.close()
+                    return f"Error: {err}"
+                workout_id = _create_workout(conn, description, session_date, "running", plan_id)
+                target_desc = description.strip()
+                created = True
+        else:
+            row = conn.execute(
+                "SELECT workout_id, description FROM workouts WHERE workout_id=?", (workout_id,)
+            ).fetchone()
+            if not row:
+                conn.close()
+                return f"Error: no workout {workout_id}."
+            target_desc = row["description"] or ""
+
+        if conn.execute(
+            "SELECT 1 FROM cardio_logs WHERE workout_id=?", (workout_id,)
+        ).fetchone():
+            conn.close()
+            return (
+                f"Error: workout {workout_id} already has cardio stats — this tool never "
+                "overwrites. Use query_fitness_db to inspect them."
+            )
+
+        avg_pace_sec = _insert_cardio(
+            conn, workout_id, duration_min, distance_km, avg_hr,
+            pain_level, prehab_done, prehab_notes, notes,
+        )
+        conn.close()
+
+        verb = "Logged" if created else f"Stats attached to workout {workout_id}:"
+        head = f"{verb} {target_desc}".rstrip() if created or target_desc else f"Stats attached to workout {workout_id}"
+        parts = [head + (f" (workout {workout_id})" if created else "")]
+        parts += _cardio_parts(duration_min, distance_km, avg_pace_sec, avg_hr, pain_level, prehab_done, prehab_notes)
+        return "\n".join(parts)
+
+    except Exception as e:
+        return f"Error logging cardio stats: {e}"
+
+
+@tool_register(namespace="fitness")
+@tool
 def log_running_session(
     duration_min: float,
     description: str,
@@ -112,11 +445,10 @@ def log_running_session(
     notes: str = "",
     date: str | None = None,
 ) -> str:
-    """Log a running or walking session to the fitness database.
+    """Deprecated alias for log_cardio_stats — prefer that tool.
 
-    Call this immediately when Roi reports completing a running/walking session.
-    Always call this tool — never just acknowledge without saving.
-    Check your running program memory notes to determine the correct description before calling.
+    Kept so recent conversation history stays executable; records the session
+    and stats exactly as log_cardio_stats(description=...) does.
 
     Args:
         duration_min: Total session duration in minutes (e.g. 32.0)
@@ -130,54 +462,17 @@ def log_running_session(
         notes: Any additional session notes
         date: Session date as YYYY-MM-DD (defaults to today in Israel time)
     """
-    try:
-        conn = _get_db()
-        session_date = date or datetime.now(ISRAEL_TZ).strftime("%Y-%m-%d")
-        scheduled_time = f"{session_date} 00:00:00"
-
-        plan = conn.execute(
-            "SELECT plan_id FROM plans WHERE name LIKE '%Running%' AND status='active' LIMIT 1"
-        ).fetchone()
-        plan_id = plan["plan_id"] if plan else None
-
-        conn.execute(
-            "INSERT INTO workouts (plan_id, session_type, scheduled_time, status, description, source) "
-            "VALUES (?, 'running', ?, 'completed', ?, 'manual')",
-            (plan_id, scheduled_time, description.strip()),
-        )
-        conn.commit()
-        workout_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
-
-        avg_pace_sec = None
-        if distance_km and duration_min:
-            avg_pace_sec = int((duration_min * 60) / distance_km)
-
-        conn.execute(
-            "INSERT INTO cardio_logs (workout_id, duration_min, distance_km, avg_pace_sec, avg_hr, "
-            "pain_level, prehab_done, prehab_notes, notes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            (workout_id, duration_min, distance_km, avg_pace_sec, avg_hr,
-             pain_level, int(prehab_done), prehab_notes.strip() or None, notes.strip() or None),
-        )
-        conn.commit()
-        conn.close()
-
-        parts = [f"Logged running session: {description}"]
-        parts.append(f"  Duration: {duration_min} min")
-        if distance_km:
-            parts.append(f"  Distance: {distance_km} km")
-        if avg_pace_sec:
-            parts.append(f"  Avg pace: {_fmt_pace(avg_pace_sec)}")
-        if avg_hr:
-            parts.append(f"  Avg HR: {avg_hr} bpm")
-        if pain_level > 0:
-            labels = {1: "slight", 2: "moderate", 3: "STOP"}
-            parts.append(f"  Pain: {labels.get(pain_level, pain_level)}")
-        if prehab_done:
-            parts.append(f"  Pre-hab: done ({prehab_notes})" if prehab_notes else "  Pre-hab: done")
-        return "\n".join(parts)
-
-    except Exception as e:
-        return f"Error logging running session: {e}"
+    return log_cardio_stats.func(
+        duration_min=duration_min,
+        distance_km=distance_km,
+        avg_hr=avg_hr,
+        pain_level=pain_level,
+        prehab_done=prehab_done,
+        prehab_notes=prehab_notes,
+        notes=notes,
+        description=description,
+        date=date,
+    )
 
 
 @tool_register(namespace="fitness")

--- a/tools/fitness/logs.py
+++ b/tools/fitness/logs.py
@@ -434,49 +434,6 @@ def log_cardio_stats(
 
 @tool_register(namespace="fitness")
 @tool
-def log_running_session(
-    duration_min: float,
-    description: str,
-    distance_km: float | None = None,
-    avg_hr: int | None = None,
-    pain_level: int = 0,
-    prehab_done: bool = False,
-    prehab_notes: str = "",
-    notes: str = "",
-    date: str | None = None,
-) -> str:
-    """Deprecated alias for log_cardio_stats — prefer that tool.
-
-    Kept so recent conversation history stays executable; records the session
-    and stats exactly as log_cardio_stats(description=...) does.
-
-    Args:
-        duration_min: Total session duration in minutes (e.g. 32.0)
-        description: Session description from the running program
-            (e.g. 'Phase 0 Session 1: 30-min brisk walk')
-        distance_km: Distance covered in km (from watch GPS)
-        avg_hr: Average heart rate in bpm
-        pain_level: 0=none, 1=slight, 2=moderate, 3=stop-sign
-        prehab_done: Whether pre-hab exercises were completed after the session
-        prehab_notes: Description of pre-hab done (e.g. 'Tibialis 3×15, Calf raises 3×15')
-        notes: Any additional session notes
-        date: Session date as YYYY-MM-DD (defaults to today in Israel time)
-    """
-    return log_cardio_stats.func(
-        duration_min=duration_min,
-        distance_km=distance_km,
-        avg_hr=avg_hr,
-        pain_level=pain_level,
-        prehab_done=prehab_done,
-        prehab_notes=prehab_notes,
-        notes=notes,
-        description=description,
-        date=date,
-    )
-
-
-@tool_register(namespace="fitness")
-@tool
 def log_wod_result(
     result: str,
     workout_id: int | None = None,


### PR DESCRIPTION
Stacked on #119 (which stacks on #118). Merge order: #118 → #119 → this.

## What

The tool slice of `docs/plans/FITNESS_LOGGING_PLAN.md`:

- **`log_workout`** — the manual "session happened" creator. Binding-based plan resolution (explicit `plan=` wins; zero/many matches error with candidates, never silent NULL), soft session-type vocabulary (unknown types accepted, no auto stat routing), same-day dedup guard with `allow_duplicate` escape hatch, id-returning replies with the shape-appropriate next step.
- **`log_cardio_stats`** — the cardio enricher with wger-style find-or-create: auto-links to the day's latest stats-less cardio-shaped row, else records the running session itself. Refuses when the day's cardio rows all carry stats (a genuine second session routes through `log_workout(allow_duplicate=true)`), never overwrites, completes a still-scheduled synced class on enrichment.
- **`log_exercise_stats`** auto-link now filters to strength-shaped rows via `session_types` — lifts can't attach to a run on a double-session day. Manual rows use a midday sentinel time.
- **`log_running_session`** kept as a deprecated alias delegating to `log_cardio_stats` (thread-history compatibility; delete after cutover holds).
- **Arbox sync** resolves the one active `binding='arbox'` plan, errors on zero-or-many (callers already wrap `RuntimeError` as an Error string); `%Running%` heuristic removed with the old creator body.
- **SKILL.md** rewritten around the split; RUNTIME.md tool roster updated.

## Verification (sandbox DB copy)

Exercised end-to-end: hotel-WOD create → lifts auto-link → WOD result; dedup guard + `allow_duplicate`; one-call run (find-or-create) incl. the paused-running-plan error naming candidates; repeated cardio report refused (the double-count bug was caught by this suite and fixed in-branch); explicit second-session chain (`log_workout` → instructed `log_cardio_stats` → auto-link); unknown type (`climbing`) accepted with explicit plan, refused-with-candidates without; deprecated alias delegates correctly. `py_compile` + all four CI guards pass.

## Live staging check (needs a restart)

After merge: restart staging, then via Telegram — report a fake hotel WOD, a one-utterance run, and stats after a synced class; confirm plan attribution and dashboard counts. The staging DB was already migrated by slice 1.

https://claude.ai/code/session_01JKFq2YmiakpnSUdxp1yUUf